### PR TITLE
refactor: storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "eslint-config-airbnb": "^16.1.0",
     "eslint-plugin-react": "^7.5.1",
     "font-awesome": "^4.7.0",
-    "@hathor/wallet-lib": "^0.1.2",
+    "@hathor/wallet-lib": "^0.2.0",
     "jquery": "^3.2.1",
     "node-sass-chokidar": "0.0.3",
     "npm-run-all": "^4.1.2",

--- a/src/App.js
+++ b/src/App.js
@@ -42,7 +42,10 @@ import store from './store/index';
 import createRequestInstance from './api/axiosInstance';
 import hathorLib from '@hathor/wallet-lib';
 import { VERSION } from './constants';
+import { storageFactory }  from './storage.js';
 
+
+hathorLib.storage.setStorage(storageFactory);
 
 const mapDispatchToProps = dispatch => {
   return {
@@ -126,7 +129,7 @@ class Root extends React.Component {
    */
   addressesLoadedUpdate = (data) => {
     // Update the version of the wallet that the data was loaded
-    localStorage.setItem('wallet:version', VERSION);
+    hathorLib.storage.setItem('wallet:version', VERSION);
 
     // Check api version everytime we load address history
     version.checkApiVersion();

--- a/src/App.js
+++ b/src/App.js
@@ -42,10 +42,10 @@ import store from './store/index';
 import createRequestInstance from './api/axiosInstance';
 import hathorLib from '@hathor/wallet-lib';
 import { VERSION } from './constants';
-import { storageFactory }  from './storage.js';
+import LocalStorageStore  from './storage.js';
 
 
-hathorLib.storage.setStorage(storageFactory);
+hathorLib.storage.setStorage(new LocalStorageStore());
 
 const mapDispatchToProps = dispatch => {
   return {

--- a/src/App.js
+++ b/src/App.js
@@ -61,6 +61,7 @@ const mapStateToProps = (state) => {
 
 class Root extends React.Component {
   componentDidMount() {
+    hathorLib.WebSocketHandler.setup();
     hathorLib.WebSocketHandler.on('wallet', this.handleWebsocket);
     hathorLib.WebSocketHandler.on('storage', this.handleWebsocketStorage);
 

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,0 +1,21 @@
+export const storageFactory = {
+  getItem(key) {
+    return JSON.parse(localStorage.getItem(key));
+  },
+
+  setItem(key, value) {
+    localStorage.setItem(key, JSON.stringify(value));
+  },
+
+  removeItem(key) {
+    localStorage.removeItem(key);
+  },
+
+  clear() {
+    localStorage.clear();
+  },
+
+  key(n) {
+    return localStorage.key(n);
+  },
+}

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,21 +1,19 @@
-export const storageFactory = {
+class LocalStorageStore {
   getItem(key) {
     return JSON.parse(localStorage.getItem(key));
-  },
+  }
 
   setItem(key, value) {
     localStorage.setItem(key, JSON.stringify(value));
-  },
+  }
 
   removeItem(key) {
     localStorage.removeItem(key);
-  },
+  }
 
   clear() {
     localStorage.clear();
-  },
-
-  key(n) {
-    return localStorage.key(n);
-  },
+  }
 }
+
+export default LocalStorageStore;

--- a/src/utils/tokens.js
+++ b/src/utils/tokens.js
@@ -69,9 +69,8 @@ const tokens = {
    * @inner
    */
   saveTokenRedux(uid) {
-    const storageTokens = localStorage.getItem('wallet:tokens');
-    const tokens = localStorage.memory ? storageTokens : JSON.parse(storageTokens);
-    store.dispatch(newTokens({tokens, uid: uid}));
+    const storageTokens = hathorLib.storage.getItem('wallet:tokens');
+    store.dispatch(newTokens({tokens: storageTokens, uid: uid}));
   },
 }
 

--- a/src/utils/version.js
+++ b/src/utils/version.js
@@ -50,7 +50,7 @@ const version = {
    * @inner
    */
   checkWalletVersion() {
-    const version = localStorage.getItem('wallet:version');
+    const version = hathorLib.storage.getItem('wallet:version');
     if (version !== null && hathorLib.helpers.isVersionAllowed(version, FIRST_WALLET_COMPATIBLE_VERSION)) {
       return true;
     } else {

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -128,8 +128,8 @@ const wallet = {
     const allTokens = 'allTokens' in data ? data['allTokens'] : [];
     const transactionsFound = Object.keys(historyTransactions).length;
 
-    const address = localStorage.getItem('wallet:address');
-    const lastSharedIndex = localStorage.getItem('wallet:lastSharedIndex');
+    const address = hathorLib.storage.getItem('wallet:address');
+    const lastSharedIndex = hathorLib.storage.getItem('wallet:lastSharedIndex');
     const lastGeneratedIndex = hathorLib.wallet.getLastGeneratedIndex();
 
     store.dispatch(historyUpdate({historyTransactions, allTokens, lastSharedIndex, lastSharedAddress: address, addressesFound: lastGeneratedIndex + 1, transactionsFound}));
@@ -173,7 +173,7 @@ const wallet = {
    */
   updateSharedAddress() {
     const lastSharedIndex = hathorLib.wallet.getLastSharedIndex();
-    const lastSharedAddress = localStorage.getItem('wallet:address');
+    const lastSharedAddress = hathorLib.storage.getItem('wallet:address');
     this.updateSharedAddressRedux(lastSharedAddress, lastSharedIndex);
   },
 
@@ -243,7 +243,7 @@ const wallet = {
 
       // Saving address data
       store.dispatch(sharedAddressUpdate({
-        lastSharedAddress: localStorage.getItem('wallet:address'),
+        lastSharedAddress: hathorLib.storage.getItem('wallet:address'),
         lastSharedIndex: hathorLib.wallet.getLastSharedIndex(),
       }));
       return true;
@@ -331,7 +331,7 @@ const wallet = {
    * @inner
    */
   allowSentry() {
-    localStorage.setItem('wallet:sentry', true);
+    hathorLib.storage.setItem('wallet:sentry', true);
     this.updateSentryState();
   },
 
@@ -342,7 +342,7 @@ const wallet = {
    * @inner
    */
   disallowSentry() {
-    localStorage.setItem('wallet:sentry', false);
+    hathorLib.storage.setItem('wallet:sentry', false);
     this.updateSentryState();
   },
 
@@ -355,8 +355,7 @@ const wallet = {
    * @inner
    */
   getSentryPermission() {
-    const sentry = localStorage.getItem('wallet:sentry');
-    return localStorage.memory ? sentry : JSON.parse(sentry);
+    return hathorLib.storage.getItem('wallet:sentry');
   },
 
   /**
@@ -405,7 +404,7 @@ const wallet = {
         ([key, item]) => scope.setExtra(key, item)
       );
       DEBUG_LOCAL_DATA_KEYS.forEach(
-        (key) => scope.setExtra(key, localStorage.getItem(key))
+        (key) => scope.setExtra(key, hathorLib.storage.getItem(key))
       )
       Sentry.captureException(error);
     });
@@ -436,9 +435,7 @@ const wallet = {
    * @inner
    */
   isNotificationOn() {
-    const notification = localStorage.getItem('wallet:notification');
-    const isNotification = localStorage.memory ? notification : JSON.parse(notification);
-    return isNotification !== false;
+    return hathorLib.storage.getItem('wallet:notification') !== false;
   },
 
   /**
@@ -448,7 +445,7 @@ const wallet = {
    * @inner
    */
   turnNotificationOn() {
-    localStorage.setItem('wallet:notification', true);
+    hathorLib.storage.setItem('wallet:notification', true);
   },
 
   /**
@@ -458,7 +455,7 @@ const wallet = {
    * @inner
    */
   turnNotificationOff() {
-    localStorage.setItem('wallet:notification', false);
+    hathorLib.storage.setItem('wallet:notification', false);
   },
 }
 


### PR DESCRIPTION
hathor-wallet-lib now requires to be given a storage.

Also, the lib used to open the websocket connection when it was imported. This was changed and we need to manually start websocket connection.