### PR TITLE
fix: testnet warning css class

### DIFF
--- a/src/components/ServerStatus.js
+++ b/src/components/ServerStatus.js
@@ -26,7 +26,7 @@ const ServerStatus = (props) => {
   return (
     props.isOnline !== undefined && 
     <div className="d-flex flex-column version-wrapper align-items-center">
-      <span className={props.network === "testnet" ? "text-testnet" : ""}>{props.network}</span>
+      <span className={props.network.startsWith("testnet") ? "text-testnet" : ""}>{props.network}</span>
       <span className={props.isOnline ? "" : "text-danger"}>{props.isOnline ? 'Online' : 'Offline'}</span>
     </div>
   );


### PR DESCRIPTION
Starting with `testnet-bravo`, testnet names have a suffix. Now we should check if the name starts with "testnet" to add the warning class.