### PR TITLE
feat: show available balance on send tokens screen

### DIFF
--- a/src/components/SendTokensOne.js
+++ b/src/components/SendTokensOne.js
@@ -16,7 +16,12 @@ import hathorLib from '@hathor/wallet-lib';
 
 
 const mapStateToProps = (state) => {
-  return { historyTransactions: state.historyTransactions };
+  // We need the height on the props so it can update the balance
+  // when the network height updates and the wallet had a reward locked block
+  return {
+    historyTransactions: state.historyTransactions,
+    height: state.height,
+  };
 };
 
 
@@ -199,11 +204,17 @@ class SendTokensOne extends React.Component {
       );
     }
 
+    const renderBalance = () => {
+      const balance = hathorLib.wallet.calculateBalance(Object.values(this.props.historyTransactions), this.state.selected.uid);
+      return <span className="ml-3">({t`Balance available: `}{hathorLib.helpers.prettyValue(balance.available)})</span>;
+    }
+
     return (
       <div className='send-tokens-wrapper card'>
         <div className="mb-3">
-          <label>{t`Token:`}</label>
+          <label><strong>{t`Token:`}</strong></label>
           {this.state.selected && renderSelectToken()}
+          {this.state.selected && renderBalance()}
           {this.state.selectedTokens.length !== 1 ? <button type="button" className="text-danger remove-token-btn ml-3" onClick={(e) => this.props.removeToken(this.props.index)}>{t`Remove`}</button> : null}
         </div>
         <div className="outputs-wrapper">


### PR DESCRIPTION
- Show available balance;
- Update balance when changing token;
- Update balance on real time when new tx arrives.

Old screen:
![image](https://user-images.githubusercontent.com/3298774/74194735-a2b6f400-4c38-11ea-90bc-bac4217adfda.png)

New screen:
![image](https://user-images.githubusercontent.com/3298774/74194759-ae0a1f80-4c38-11ea-9877-986e6e2ff929.png)
![image](https://user-images.githubusercontent.com/3298774/74194770-b5312d80-4c38-11ea-810d-d5554394bc12.png)

Closes #67 