### PR TITLE
style: changing token bar symbol/value separator from - to |

### DIFF
--- a/src/components/TokenBar.js
+++ b/src/components/TokenBar.js
@@ -124,7 +124,7 @@ class TokenBar extends React.Component {
       return this.props.registeredTokens.map((token) => {
         return (
           <div key={token.uid} className={`token-wrapper ${token.uid === this.props.selectedToken ? 'selected' : ''}`} onClick={(e) => {this.tokenSelected(token.uid)}}>
-            <span className='ellipsis'>{token.symbol} {this.state.opened && ` - ${this.getTokenBalance(token.uid)}`}</span>
+            <span className='ellipsis'>{token.symbol} {this.state.opened && ` | ${this.getTokenBalance(token.uid)}`}</span>
           </div>
         )
       });


### PR DESCRIPTION
Using - as separator could mislead the user to think that it was a negative value. Changed to | as separator.

Old screen:
![Screen Shot 2020-02-10 at 19 19 00](https://user-images.githubusercontent.com/3298774/74195705-9895f500-4c3a-11ea-9de7-28f0c71c5cfb.png)

New screen:
![image](https://user-images.githubusercontent.com/3298774/74195741-acd9f200-4c3a-11ea-9e4d-f29361833783.png)

Closes #79 