### PR TITLE
fix: ledger communication on Electron release

### DIFF
--- a/public/entitlements.mac.plist
+++ b/public/entitlements.mac.plist
@@ -2,9 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
-    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-    <true/>
-    <key>com.apple.security.network.client</key>
-    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key><true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key><true/>
+    <key>com.apple.security.cs.disable-library-validation</key><true/>
+    <key>com.apple.security.network.client</key><true/>
   </dict>
 </plist>


### PR DESCRIPTION
Closes #97 

I had to add 2 entitlements to resolve 2 different problems:

(1) After I upgraded macOS to Mojave 10.14.6, I had this issue: https://github.com/electron-userland/electron-builder/issues/3940

(2) Final Electron app could not communicate with Ledger, like here: https://github.com/LedgerHQ/ledgerjs/issues/439. The problem was actually in a dependency: https://github.com/node-hid/node-hid/issues/321