### PR TITLE
feat: List of addresses from the wallet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hathor-wallet",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1141,9 +1141,9 @@
       }
     },
     "@hathor/wallet-lib": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@hathor/wallet-lib/-/wallet-lib-0.11.0.tgz",
-      "integrity": "sha512-hlLzpQjp2O3kw7oNZypa1FPZrM4MqpknHQnm9vOz+849a6vWyob1edROdoDF1nCIgBTBAQHkGGFB7i0LKa6+/w==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@hathor/wallet-lib/-/wallet-lib-0.11.1.tgz",
+      "integrity": "sha512-4dK5piZKMhmesfEthpAu4v7wvnc+qybOAitswETF3edXU/K/t0KYMm+2GHaa4fdjOrIrO6MfQPZyqyeZ05QWOQ==",
       "requires": {
         "axios": "0.18.1",
         "bitcore-mnemonic": "1.7.0",
@@ -1151,7 +1151,7 @@
         "isomorphic-ws": "4.0.1",
         "lodash": "4.17.15",
         "long": "4.0.0",
-        "ws": "7.2.1"
+        "ws": "7.2.3"
       }
     },
     "@jest/console": {
@@ -3177,9 +3177,9 @@
       }
     },
     "base-x": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.7.tgz",
-      "integrity": "sha512-zAKJGuQPihXW22fkrfOclUUZXM2g92z5GzlSMHxhO6r6Qj+Nm0ccaGNBzDZojzwOMkpjAv4J0fOv1U4go+a4iw==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+      "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
       "requires": {
         "safe-buffer": "5.2.0"
       }
@@ -3599,7 +3599,7 @@
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
       "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
       "requires": {
-        "base-x": "3.0.7"
+        "base-x": "3.0.8"
       }
     },
     "bser": {
@@ -14620,6 +14620,14 @@
       "resolved": "https://registry.npmjs.org/react-loading/-/react-loading-2.0.3.tgz",
       "integrity": "sha512-Vdqy79zq+bpeWJqC+xjltUjuGApyoItPgL0vgVfcJHhqwU7bAMKzysfGW/ADu6i0z0JiOCRJjo+IkFNkRNbA3A=="
     },
+    "react-paginate": {
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/react-paginate/-/react-paginate-6.3.2.tgz",
+      "integrity": "sha512-Ch++Njfv8UHpLtIMiQouAPeJQA5Ki86kIYfCer6c1B96Rvn3UF27se+goCilCP8oHNXNsA2R2kxvzanY1YIkyg==",
+      "requires": {
+        "prop-types": "15.7.2"
+      }
+    },
     "react-redux": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.0.tgz",
@@ -18698,9 +18706,9 @@
       }
     },
     "ws": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.1.tgz",
-      "integrity": "sha512-sucePNSafamSKoOqoNfBd8V0StlkzJKL2ZAhGQinCfNQ+oacw+Pk7lcdAElecBF2VkLNZRiIb5Oi1Q5lVUVt2A=="
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
+      "integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ=="
     },
     "xdg-basedir": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react-copy-to-clipboard": "^5.0.1",
     "react-dom": "^16.8.6",
     "react-loading": "^2.0.3",
+    "react-paginate": "^6.3.2",
     "react-redux": "^7.1.0",
     "react-router-dom": "^5.0.1",
     "react-scripts": "^3.0.1",

--- a/src/App.js
+++ b/src/App.js
@@ -42,6 +42,7 @@ import { DEFAULT_SERVER, IPC_RENDERER, VERSION } from './constants';
 import { HybridStore } from './storage.js';
 import ModalAlert from './components/ModalAlert';
 import SoftwareWalletWarningMessage from './components/SoftwareWalletWarningMessage';
+import AddressList from './screens/AddressList';
 
 hathorLib.network.setNetwork('mainnet');
 hathorLib.storage.setStore(new HybridStore());
@@ -96,7 +97,9 @@ class Root extends React.Component {
     hathorLib.WebSocketHandler.removeListener('is_online', this.isOnlineUpdate);
     hathorLib.WebSocketHandler.removeListener('reload_data', this.reloadData);
 
-    IPC_RENDERER.removeAllListeners("ledger:closed");
+    if (IPC_RENDERER) {
+      IPC_RENDERER.removeAllListeners("ledger:closed");
+    }
   }
 
   handleWebsocket = (wsData) => {
@@ -192,6 +195,7 @@ class Root extends React.Component {
         <StartedRoute exact path="/wallet/passphrase" component={ChoosePassphrase} loaded={true} />
         <StartedRoute exact path="/server" component={Server} loaded={true} />
         <StartedRoute exact path="/transaction/:id" component={TransactionDetail} loaded={true} />
+        <StartedRoute exact path="/addresses" component={AddressList} loaded={true} />
         <StartedRoute exact path="/new_wallet" component={NewWallet} loaded={false} />
         <StartedRoute exact path="/load_wallet" component={LoadWallet} loaded={false} />
         <StartedRoute exact path="/wallet_type" component={WalletType} loaded={false} />

--- a/src/components/HathorPaginate.js
+++ b/src/components/HathorPaginate.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import ReactPaginate from 'react-paginate';
+
+
+class HathorPaginate extends React.Component {
+  render() {
+    return (
+      <ReactPaginate previousLabel={"Previous"}
+         nextLabel={"Next"}
+         pageCount={this.props.pageCount}
+         marginPagesDisplayed={1}
+         pageRangeDisplayed={2}
+         onPageChange={this.props.onPageChange}
+         containerClassName={"pagination justify-content-center"}
+         subContainerClassName={"pages pagination"}
+         activeClassName={"active"}
+         breakClassName="page-item"
+         breakLabel={<a  href="true" className="page-link">...</a>}
+         pageClassName="page-item"
+         previousClassName="page-item"
+         nextClassName="page-item"
+         pageLinkClassName="page-link"
+         previousLinkClassName="page-link"
+         nextLinkClassName="page-link" />
+    );
+  }
+}
+
+export default HathorPaginate;

--- a/src/components/HathorPaginate.js
+++ b/src/components/HathorPaginate.js
@@ -28,8 +28,8 @@ class HathorPaginate extends React.Component {
          containerClassName={"pagination justify-content-center"}
          subContainerClassName={"pages pagination"}
          activeClassName={"active"}
-         breakClassName="page-item"
-         breakLabel={<a  href="true" className="page-link">...</a>}
+         breakClassName="page-item page-link"
+         breakLabel={"..."}
          pageClassName="page-item"
          previousClassName="page-item"
          nextClassName="page-item"

--- a/src/components/HathorPaginate.js
+++ b/src/components/HathorPaginate.js
@@ -1,7 +1,20 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import React from 'react';
 import ReactPaginate from 'react-paginate';
+import PropTypes from 'prop-types';
 
 
+/**
+ * Component to add pagination buttons of a list
+ *
+ * @memberof Components
+ */
 class HathorPaginate extends React.Component {
   render() {
     return (
@@ -25,5 +38,14 @@ class HathorPaginate extends React.Component {
     );
   }
 }
+
+/*
+ * pageCount: Total number of pages of the list being paginated
+ * onPageChange: Method to be executed when the page changes
+ */
+HathorPaginate.propTypes = {
+  pageCount: PropTypes.number.isRequired,
+  onPageChange: PropTypes.function.isRequired,
+};
 
 export default HathorPaginate;

--- a/src/components/HathorPaginate.js
+++ b/src/components/HathorPaginate.js
@@ -8,6 +8,7 @@
 import React from 'react';
 import ReactPaginate from 'react-paginate';
 import PropTypes from 'prop-types';
+import { t } from 'ttag'
 
 
 /**
@@ -18,8 +19,8 @@ import PropTypes from 'prop-types';
 class HathorPaginate extends React.Component {
   render() {
     return (
-      <ReactPaginate previousLabel={"Previous"}
-         nextLabel={"Next"}
+      <ReactPaginate previousLabel={t`Previous`}
+         nextLabel={t`Next`}
          pageCount={this.props.pageCount}
          marginPagesDisplayed={1}
          pageRangeDisplayed={2}

--- a/src/components/HathorPaginate.js
+++ b/src/components/HathorPaginate.js
@@ -45,7 +45,7 @@ class HathorPaginate extends React.Component {
  */
 HathorPaginate.propTypes = {
   pageCount: PropTypes.number.isRequired,
-  onPageChange: PropTypes.function.isRequired,
+  onPageChange: PropTypes.func.isRequired,
 };
 
 export default HathorPaginate;

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -55,9 +55,6 @@ class Navigation extends React.Component {
                 <NavLink to="/custom_tokens/" exact className="nav-link" activeClassName="active" activeStyle={{ fontWeight: 'bold' }}>{t`Custom tokens`}</NavLink>
               </li>
               <li className="nav-item">
-                <NavLink to="/addresses/" exact className="nav-link" activeClassName="active" activeStyle={{ fontWeight: 'bold' }}>{t`Addresses`}</NavLink>
-              </li>
-              <li className="nav-item">
                 <a className="nav-link" href="true" onClick={this.goToExplorer}>{t`Public Explorer`}</a>
               </li>
             </ul>

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -55,6 +55,9 @@ class Navigation extends React.Component {
                 <NavLink to="/custom_tokens/" exact className="nav-link" activeClassName="active" activeStyle={{ fontWeight: 'bold' }}>{t`Custom tokens`}</NavLink>
               </li>
               <li className="nav-item">
+                <NavLink to="/addresses/" exact className="nav-link" activeClassName="active" activeStyle={{ fontWeight: 'bold' }}>{t`Addresses`}</NavLink>
+              </li>
+              <li className="nav-item">
                 <a className="nav-link" href="true" onClick={this.goToExplorer}>{t`Public Explorer`}</a>
               </li>
             </ul>

--- a/src/components/WalletAddress.js
+++ b/src/components/WalletAddress.js
@@ -119,6 +119,7 @@ class WalletAddress extends React.Component {
               </div>
             }
           </div>
+          <button type="button" className="mt-3 btn btn-hathor">{t`See all addresses`}</button>
         </div>
       );
     }

--- a/src/components/WalletAddress.js
+++ b/src/components/WalletAddress.js
@@ -104,6 +104,17 @@ class WalletAddress extends React.Component {
     }
   }
 
+  /**
+   * Method executed when link to See all addresses is clicked
+   * Redirect to address list screen
+   *
+   * @param {Object} e Event emitted by the link clicked
+   */
+  seeAllAddresses = (e) => {
+    e.preventDefault();
+    this.props.history.push('/addresses/');
+  }
+
   render() {
     const renderAddress = () => {
       return (
@@ -119,7 +130,7 @@ class WalletAddress extends React.Component {
               </div>
             }
           </div>
-          <button type="button" className="mt-3 btn btn-hathor">{t`See all addresses`}</button>
+          <a href="true" onClick={this.seeAllAddresses} className="mt-3 ">{t`See all addresses`}</a>
         </div>
       );
     }

--- a/src/index.scss
+++ b/src/index.scss
@@ -132,7 +132,7 @@ a:hover {
   cursor: pointer;
 }
 
-#peer-table tbody td, #peer-table thead th, #tx-table tbody td, #tx-table thead th, #token-history tbody td, #token-history thead th {
+#peer-table tbody td, #peer-table thead th, #tx-table tbody td, #tx-table thead th, #token-history tbody td, #token-history thead th, #address-list tbody td, #address-list thead th {
   text-align: center;
 }
 
@@ -249,6 +249,10 @@ i.pointer {
   border-radius: 0.75rem;
   color: white;
   margin-left: 1rem;
+}
+
+#address-list .number {
+  text-align: right;
 }
 
 tr.tr-title {

--- a/src/screens/AddressList.js
+++ b/src/screens/AddressList.js
@@ -19,6 +19,13 @@ import hathorLib from '@hathor/wallet-lib';
  * @memberof Screens
  */
 class AddressList extends React.Component {
+  /**
+   * addresses {Array} All wallet addresses data {'address', 'index', 'used'}
+   * filteredAddresses {Array} addresses state after search
+   * page: {Number} Current page of the list
+   * totalPages: {Number} Total number of pages of the list
+   * filtered: {Boolean} If the list is filtered
+   */
   state = {
     addresses: [],
     filteredAddresses: [],
@@ -44,6 +51,13 @@ class AddressList extends React.Component {
     this.setState({ addresses, filteredAddresses: addresses, totalPages: this.getTotalPages(addresses) });
   }
 
+  /**
+   * Return total number of pages of the list
+   *
+   * @param {Array} Array of addresses of the list
+   *
+   * @return {Number} Total number of pages of the list
+   */
   getTotalPages = (array) => {
     return Math.ceil(array.length / WALLET_HISTORY_COUNT);
   }
@@ -59,6 +73,11 @@ class AddressList extends React.Component {
     return false;
   }
 
+  /**
+   * Event received from pagination component after a page button in clicked
+   *
+   * @param data {Object} Data with clicked page {'selected'}
+   */
   handlePageClick = (data) => {
     const page = data.selected + 1;
     this.setState({ page });
@@ -80,14 +99,10 @@ class AddressList extends React.Component {
    */
   search = () => {
     const text = this.refs.txSearch.value;
-    console.log('WAT')
     if (text) {
-      console.log(text)
       if (hathorLib.transaction.isAddressValid(text)) {
-        console.log('Yes')
         for (const addr of this.state.addresses) {
           if (addr.address === text) {
-            console.log('found');
             this.setState({ filtered: true, filteredAddresses: [addr], totalPages: 1, page: 1 });
             return
           }

--- a/src/screens/AddressList.js
+++ b/src/screens/AddressList.js
@@ -185,16 +185,16 @@ class AddressList extends React.Component {
       <div className="content-wrapper">
         <div className="d-flex flex-column">
           <div className="d-flex flex-row justify-content-between">
-            <h2>Addresses</h2>
+            <h2>{t`Addresses`}</h2>
             {renderSearch()}
           </div>
           <div className="table-responsive">
             <table className="mt-3 table table-striped" id="address-list">
               <thead>
                 <tr>
-                  <th>Address</th>
-                  <th>Index</th>
-                  <th>Number of transactions</th>
+                  <th>{t`Address`}</th>
+                  <th>{t`Index`}</th>
+                  <th className="number">{t`Number of transactions`}</th>
                 </tr>
               </thead>
               <tbody>

--- a/src/screens/AddressList.js
+++ b/src/screens/AddressList.js
@@ -72,7 +72,7 @@ class AddressList extends React.Component {
   /**
    * Update number of transactions for each address
    *
-   * @param {Object} addressData Transactions by address object {'address': 0}
+   * @param {Object} addressData Transactions by address object {address1: 0, address2: 0}
    * @param {Object} historyTransactions History of transactions from the wallet data storage
    *
    * @return {Number} Total number of transactions using this address

--- a/src/screens/AddressList.js
+++ b/src/screens/AddressList.js
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { t } from 'ttag'
+import HathorPaginate from '../components/HathorPaginate';
+import { WALLET_HISTORY_COUNT } from '../constants';
+
+import hathorLib from '@hathor/wallet-lib';
+
+/**
+ * Screen that has a list of addresses of the wallet
+ *
+ * @memberof Screens
+ */
+class AddressList extends React.Component {
+  state = {
+    addresses: [],
+    page: 1,
+    totalPages: 0,
+  }
+
+  componentDidMount = () => {
+    const walletData = hathorLib.wallet.getWalletData();
+    const addressKeys = walletData.keys;
+    const addresses = [];
+    for (const key in addressKeys) {
+      const addressData = {
+        address: key,
+        index: addressKeys[key].index,
+        used: this.addressUsed(key, walletData.historyTransactions)
+      };
+
+      addresses.push(addressData);
+    }
+
+    const totalPages = Math.ceil(addresses.length / WALLET_HISTORY_COUNT);
+
+    this.setState({ addresses, totalPages });
+  }
+
+  addressUsed = (address, historyTransactions) => {
+    for (const tx_id in historyTransactions) {
+      for (const output of historyTransactions[tx_id].outputs) {
+        if (output.decoded.address === address) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  handlePageClick = (data) => {
+    const page = data.selected + 1;
+    this.setState({ page });
+  }
+
+  render() {
+    const loadPagination = () => {
+      if (this.state.addresses.length === 0 || this.state.totalPages === 1) {
+        return null;
+      } else {
+        return (
+          <HathorPaginate pageCount={this.state.totalPages}
+            onPageChange={this.handlePageClick} />
+        );
+      }
+    }
+
+    const renderData = () => {
+      const startIndex = (this.state.page - 1) * WALLET_HISTORY_COUNT;
+      const endIndex = startIndex + WALLET_HISTORY_COUNT;
+      return this.state.addresses.slice(startIndex, endIndex).map((data) => {
+        return (
+          <tr key={data.address}>
+            <td>{data.address}</td>
+            <td>{data.index}</td>
+            <td>{data.used ? 'Yes' : ''}</td>
+          </tr>
+        )
+      });
+    }
+
+    return (
+      <div className="content-wrapper">
+        <div className="d-flex flex-column">
+          <h2>Addresses</h2>
+          <div className="table-responsive">
+            <table className="mt-3 table table-striped" id="wallet-history">
+              <thead>
+                <tr>
+                  <th>Address</th>
+                  <th>Index</th>
+                  <th>Used</th>
+                </tr>
+              </thead>
+              <tbody>
+                {renderData()}
+              </tbody>
+            </table>
+          </div>
+          {loadPagination()}
+        </div>
+      </div>
+    )
+  }
+}
+
+export default AddressList;

--- a/src/screens/Wallet.js
+++ b/src/screens/Wallet.js
@@ -174,7 +174,7 @@ class Wallet extends React.Component {
             <div className="d-flex flex-column align-items-start justify-content-between">
               <WalletBalance balance={this.props.balance} />
             </div>
-            <WalletAddress />
+            <WalletAddress history={this.props.history} />
           </div>
           <div className="d-sm-none d-flex flex-column align-items-center justify-content-between">
             <div className="d-flex flex-column align-items-center justify-content-between">
@@ -182,7 +182,7 @@ class Wallet extends React.Component {
               <div className="d-flex flex-row align-items-center">
               </div>
             </div>
-            <WalletAddress />
+            <WalletAddress history={this.props.history} />
           </div>
           <WalletHistory
             historyTransactions={this.props.historyTransactions}


### PR DESCRIPTION
- [x] Remove debug logs;
- [x] Add comments in methods/states/propTypes;
- [x] Add link to explorer address search screen on address row click.

Unresolved questions:

1. Should we have a new item on the menu? At first I tried to add some link/button close to the address box in the main wallet screen but none of my attempts were good, so I just added this new menu.
2. I created a new pagination because we already have all the elements on the list and I always think it's better to have all the pages there (if it's possible). Should we keep the same pagination as in the other screens with 'Previous'/'Next'?
3. Should we show all addresses including the ones from the `GAP_LIMIT`. I think we should because maybe the user has generated new addresses, sent to someone but still haven't received the txs, in that case none of those addresses would appear on the list. However, showing all addresses might be confusing to the user.

![image](https://user-images.githubusercontent.com/3298774/78085753-3764e500-7392-11ea-92f0-9cd7d0cd5910.png)
![image](https://user-images.githubusercontent.com/3298774/78085792-5499b380-7392-11ea-850c-950703a69afd.png)

