### PR TITLE
feat(deps): Update version of electron-builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,13 @@
     "@sentry/electron": "^0.17.0",
     "babel-polyfill": "^6.26.0",
     "bootstrap": "^4.0.0",
+    "bufferutil": "^4.0.1",
     "eslint-config-airbnb": "^17.1.0",
     "eslint-plugin-react": "^7.13.0",
+    "fibers": "^5.0.0",
     "font-awesome": "^4.7.0",
     "jquery": "^3.4.1",
+    "node-sass": "^4.14.1",
     "node-sass-chokidar": "^1.3.5",
     "npm-run-all": "^4.1.2",
     "popper.js": "^1.15.0",
@@ -47,7 +50,9 @@
     "react-router-dom": "^5.0.1",
     "react-scripts": "^3.0.1",
     "redux": "^4.0.0",
+    "sass": "^1.26.10",
     "ttag": "^1.7.22",
+    "utf-8-validate": "^5.0.2",
     "viz.js": "^2.1.2"
   },
   "main": "public/electron.js",
@@ -75,12 +80,12 @@
     "@sentry/browser": "^5.0.5",
     "@sentry/cli": "^1.40.0",
     "electron": "^5.0.3",
-    "electron-builder": "^20.43.0",
+    "electron-builder": "^22.8.0",
     "electron-devtools-installer": "^2.2.4",
     "electron-notarize": "^0.1.1",
     "jsdoc": "^3.6.2",
-    "ttag-cli": "^1.7.27",
     "nodemon": "^2.0.0",
+    "ttag-cli": "^1.7.27",
     "typescript": "^3.5.3"
   },
   "build": {
@@ -93,16 +98,13 @@
       "publisherName": "Hathor Labs"
     },
     "mac": {
-      "provisioningProfile": "mac_production.provisionprofile",
+      "provisioningProfile": "keys/mac_production.provisionprofile",
       "hardenedRuntime": true,
       "gatekeeperAssess": false,
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.plist",
       "icon": "build/icon.icns",
-      "target": [
-        "dmg",
-        "pkg"
-      ]
+      "target": "dmg"
     },
     "linux": {
       "target": [


### PR DESCRIPTION
This new version allows us to sign our wallet for Windows from MacOS.