### PR TITLE
chore: use wait-on concurrently with electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,8 +68,9 @@
     "electron-pack-linux": "electron-builder --linux -c.extraMetadata.main=build/electron.js",
     "electron-pack-win": "electron-builder --win -c.extraMetadata.main=build/electron.js",
     "watch-electron": "ELECTRON_START_URL=http://localhost:3000 NODE_ENV=dev nodemon --watch ./public/**/* --watch . --exec 'npm run electron'",
-    "electron-dev": "ELECTRON_START_URL=http://localhost:3000 NODE_ENV=dev electron --inspect=5858 .",
-    "locale-update-pot": "ttag extract -o ./locale/texts.pot ./src/"
+    "electron-dev": "npx concurrently 'npx cross-env BROWSER=none npm run start' 'npx wait-on http://localhost:3000/ && npx cross-env ELECTRON_START_URL=http://localhost:3000 NODE_ENV=dev electron --inspect=5858 .'",
+    "locale-update-pot": "ttag extract -o ./locale/texts.pot ./src/",
+    "postinstall": "npm run electron-deps"
   },
   "devDependencies": {
     "@sentry/browser": "^5.0.5",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "watch-electron": "ELECTRON_START_URL=http://localhost:3000 NODE_ENV=dev nodemon --watch ./public/**/* --watch . --exec 'npm run electron'",
     "electron-dev": "npx concurrently 'npx cross-env BROWSER=none npm run start' 'npx wait-on http://localhost:3000/ && npx cross-env ELECTRON_START_URL=http://localhost:3000 NODE_ENV=dev electron --inspect=5858 .'",
     "locale-update-pot": "ttag extract -o ./locale/texts.pot ./src/",
-    "postinstall": "npm run electron-deps"
+    "postinstall": "npx cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=true npm run electron-deps"
   },
   "devDependencies": {
     "@sentry/browser": "^5.0.5",


### PR DESCRIPTION
* `npm run electron-dev` now runs `npm start` concurrently with `wait-on && electron`. It will automatically open electron after 'http://localhost:3000' is available

* `npm run electron-deps` now runs on `postinstall` hook