### PR TITLE
chore: bump lib version to v0.16.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1135,9 +1135,9 @@
       }
     },
     "@hathor/wallet-lib": {
-      "version": "0.16.3",
-      "resolved": "https://registry.npmjs.org/@hathor/wallet-lib/-/wallet-lib-0.16.3.tgz",
-      "integrity": "sha512-/q9DuYQHvFZQHuAslLrU3FYrIC4IBJ5lsoXTm2335lQ4eXB6GsxtJVVMHkZwkVJiBhslWWifr6nQhPcRofMnWQ==",
+      "version": "0.16.5",
+      "resolved": "https://registry.npmjs.org/@hathor/wallet-lib/-/wallet-lib-0.16.5.tgz",
+      "integrity": "sha512-dVfz9Nv2Syjn+Kwcjppj8ZlXz4HFTs+EVbUp3Lf1rW+NmicpaZiWI3Yhnl9D8/sa4PuK4rdgkAkuL1EM/QwgwQ==",
       "requires": {
         "axios": "0.18.1",
         "bitcore-mnemonic": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "version": "0.17.2",
   "private": true,
   "dependencies": {
-    "@hathor/wallet-lib": "^0.16.3",
+    "@hathor/wallet-lib": "^0.16.5",
     "@ledgerhq/hw-transport-node-hid": "^4.73.4",
     "@sentry/electron": "^0.17.0",
     "babel-polyfill": "^6.26.0",


### PR DESCRIPTION
Bump `wallet-lib` to solve an issue related to importing wallet.
<table>
  <thead>
    <tr>
      <th>Before bump (can't proceed with the importing):</th>
      <th>After bump:</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img src="https://user-images.githubusercontent.com/5104565/101706838-bbff1b80-3a68-11eb-879e-31cb6308dd91.gif" /></td>
      <td><img src="https://user-images.githubusercontent.com/5104565/101706871-d3d69f80-3a68-11eb-809b-f41ef3047b8f.gif" /></td>
    </tr>
  </tbody>
</table>

