### PR TITLE
feat: show local date and time in settings screen

### DIFF
--- a/src/screens/Settings.js
+++ b/src/screens/Settings.js
@@ -126,9 +126,13 @@ class Settings extends React.Component {
 
   render() {
     const serverURL = hathorLib.helpers.getServerURL();
+    const now = new Date();
     return (
       <div className="content-wrapper settings">
         <BackButton {...this.props} />
+        <div>
+          <p><strong>{t`Date and time:`}</strong> {now.toString()}</p>
+        </div>
         <div>
           <p><SpanFmt>{t`**Server:** You are connected to ${serverURL}`}</SpanFmt></p>
           <button className="btn btn-hathor" onClick={this.changeServer}>{t`Change server`}</button>

--- a/src/screens/Settings.js
+++ b/src/screens/Settings.js
@@ -30,11 +30,23 @@ class Settings extends React.Component {
   /**
    * confirmData {Object} data for the notification confirm modal (title, body and handleYes)
    * isNotificationOne {boolean} state to update if notification is turned on or off
+   * now {Date} state to store the date which is updated every second
    */
-  state = { confirmData: {}, isNotificationOn: null }
+  state = { confirmData: {}, isNotificationOn: null, now: new Date() }
+
+  // Stores the setTimeout interval of the date update
+  dateSetTimeoutInterval = null
 
   componentDidMount() {
     this.setState({ isNotificationOn: wallet.isNotificationOn() });
+
+    this.dateSetTimeoutInterval = setInterval(() => {
+      this.setState({ now: new Date() });
+    }, 1000);
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.dateSetTimeoutInterval);
   }
 
   /**
@@ -126,12 +138,11 @@ class Settings extends React.Component {
 
   render() {
     const serverURL = hathorLib.helpers.getServerURL();
-    const now = new Date();
     return (
       <div className="content-wrapper settings">
         <BackButton {...this.props} />
         <div>
-          <p><strong>{t`Date and time:`}</strong> {now.toString()} <span title={`Timestamp: ${hathorLib.dateFormatter.dateToTimestamp(now)}`}> <i class="fa fa-exclamation-circle"></i></span></p>
+          <p><strong>{t`Date and time:`}</strong> {this.state.now.toString()} <span title={`Timestamp: ${hathorLib.dateFormatter.dateToTimestamp(this.state.now)}`}> <i className="fa fa-exclamation-circle"></i></span></p>
         </div>
         <div>
           <p><SpanFmt>{t`**Server:** You are connected to ${serverURL}`}</SpanFmt></p>

--- a/src/screens/Settings.js
+++ b/src/screens/Settings.js
@@ -131,7 +131,7 @@ class Settings extends React.Component {
       <div className="content-wrapper settings">
         <BackButton {...this.props} />
         <div>
-          <p><strong>{t`Date and time:`}</strong> {now.toString()}</p>
+          <p><strong>{t`Date and time:`}</strong> {now.toString()} <span title={`Timestamp: ${hathorLib.dateFormatter.dateToTimestamp(now)}`}> <i class="fa fa-exclamation-circle"></i></span></p>
         </div>
         <div>
           <p><SpanFmt>{t`**Server:** You are connected to ${serverURL}`}</SpanFmt></p>

--- a/src/screens/Settings.js
+++ b/src/screens/Settings.js
@@ -31,8 +31,14 @@ class Settings extends React.Component {
    * confirmData {Object} data for the notification confirm modal (title, body and handleYes)
    * isNotificationOne {boolean} state to update if notification is turned on or off
    * now {Date} state to store the date which is updated every second
+   * showTimestamp {boolean} If should show timestamp or full date in date and time
    */
-  state = { confirmData: {}, isNotificationOn: null, now: new Date() }
+  state = {
+    confirmData: {},
+    isNotificationOn: null,
+    now: new Date(),
+    showTimestamp: false,
+  }
 
   // Stores the setTimeout interval of the date update
   dateSetTimeoutInterval = null
@@ -142,7 +148,7 @@ class Settings extends React.Component {
       <div className="content-wrapper settings">
         <BackButton {...this.props} />
         <div>
-          <p><strong>{t`Date and time:`}</strong> {this.state.now.toString()} <span title={`Timestamp: ${hathorLib.dateFormatter.dateToTimestamp(this.state.now)}`}> <i className="fa fa-exclamation-circle"></i></span></p>
+          <p onDoubleClick={() => this.setState({ showTimestamp: !this.state.showTimestamp })}><strong>{t`Date and time:`}</strong> {this.state.showTimestamp ? hathorLib.dateFormatter.dateToTimestamp(this.state.now) : this.state.now.toString()}</p>
         </div>
         <div>
           <p><SpanFmt>{t`**Server:** You are connected to ${serverURL}`}</SpanFmt></p>


### PR DESCRIPTION
The main purpose of this feature is to help debug some timestamp issues we've been having.

Question: Should we show in this format? I like showing the full date/time and timezone. I could remove the weekday only but I left because it's not worse with it in my opinion.

![image](https://user-images.githubusercontent.com/3298774/114225435-ae8b6c80-9948-11eb-9bb4-5b05123f6382.png)


