### PR TITLE
fix: set wallet version on storage before running version check

### DIFF
--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -6,6 +6,7 @@
  */
 
 import hathorLib from '@hathor/wallet-lib';
+import { VERSION } from '../constants';
 
 const initialState = {
   tokensHistory: {},
@@ -169,6 +170,8 @@ const isAllAuthority = (tx) => {
  * Got wallet history. Update history and balance for each token.
  */
 const onLoadWalletSuccess = (state, action) => {
+  // Update the version of the wallet that the data was loaded
+  hathorLib.storage.setItem('wallet:version', VERSION);
   const { history } = action.payload;
   const tokensHistory = {};
   const newAddressesTxs = {};


### PR DESCRIPTION
This line was removed by mistake in the last PR: https://github.com/HathorNetwork/hathor-wallet/pull/188/files#diff-3d74dddefb6e35fbffe3c76ec0712d5c416352d9449e2fcc8210a9dee57dff67L157