### PR TITLE
feat: add support for creating NFT

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,7 @@ import { Switch, Route, Redirect } from 'react-router-dom';
 import Wallet from './screens/Wallet';
 import SendTokens from './screens/SendTokens';
 import CreateToken from './screens/CreateToken';
+import CreateNFT from './screens/CreateNFT';
 import Navigation from './components/Navigation';
 import WaitVersion from './components/WaitVersion';
 import TransactionDetail from './screens/TransactionDetail';
@@ -78,6 +79,7 @@ class Root extends React.Component {
     return (
       <Switch>
         <StartedRoute exact path="/create_token" component={CreateToken} loaded={true} />
+        <StartedRoute exact path="/create_nft" component={CreateNFT} loaded={true} />
         <StartedRoute exact path="/custom_tokens" component={CustomTokens} loaded={true} />
         <StartedRoute exact path="/unknown_tokens" component={UnknownTokens} loaded={true} />
         <StartedRoute exact path="/wallet/send_tokens" component={SendTokens} loaded={true} />

--- a/src/constants.js
+++ b/src/constants.js
@@ -135,3 +135,8 @@ export const IPC_RENDERER = ipcRenderer;
  * Flag to hide/show elements after ledger integration is done
  */
 export const LEDGER_ENABLED = false;
+
+/**
+ * Flag to hide/show create NFT button
+ */
+export const NFT_ENABLED = false;

--- a/src/constants.js
+++ b/src/constants.js
@@ -105,6 +105,11 @@ export const TESTNET_EXPLORER_BASE_URL = "https://explorer.testnet.hathor.networ
  */
 export const TOKEN_DEPOSIT_RFC_URL = "https://gitlab.com/HathorNetwork/rfcs/blob/master/text/0011-token-deposit.md";
 
+/**
+ * URL of NFT standard
+ */
+export const NFT_STANDARD_RFC_URL = "https://github.com/HathorNetwork/rfcs/blob/master/text/0032-nft-standard.md";
+
 export const HATHOR_WEBSITE_URL = "https://hathor.network/";
 
 /**

--- a/src/constants.js
+++ b/src/constants.js
@@ -140,3 +140,8 @@ export const LEDGER_ENABLED = false;
  * Flag to hide/show create NFT button
  */
 export const NFT_ENABLED = false;
+
+/**
+ * Maximum size of NFT data length
+ */
+export const NFT_DATA_MAX_SIZE = 150;

--- a/src/index.scss
+++ b/src/index.scss
@@ -190,6 +190,10 @@ div.new-address-wrapper canvas {
   margin-bottom: 1rem;
 }
 
+#formCreateNFT {
+  padding-bottom: 2rem;
+}
+
 .tx-input-wrapper textarea {
   margin: 1rem 0;
 }
@@ -622,7 +626,8 @@ svg.svg-wrapper {
   width: 13rem;
 }
 
-#formCreateToken .address-checkbox {
+#formCreateToken .address-checkbox, #formCreateNFT .address-checkbox {
+  padding-left: 1rem;
   padding-top: 2rem;
 }
 

--- a/src/screens/CreateNFT.js
+++ b/src/screens/CreateNFT.js
@@ -42,8 +42,15 @@ class CreateNFT extends React.Component {
   constructor(props) {
     super(props);
 
-    this.address = React.createRef();
-    this.inputWrapper = React.createRef();
+    this.addressDivRef = React.createRef();
+    this.formCreateNFTRef = React.createRef();
+    this.addressRef = React.createRef();
+    this.autoselectAddressRef = React.createRef();
+    this.nameRef = React.createRef();
+    this.symbolRef = React.createRef();
+    this.nftDataRef = React.createRef();
+    this.createMintAuthorityRef = React.createRef();
+    this.createMeltAuthorityRef = React.createRef();
 
     /**
      * errorMessage {string} Message to show when error happens on the form
@@ -63,9 +70,9 @@ class CreateNFT extends React.Component {
    * Validates if the create NFT form is valid
    */
   formValid = () => {
-    const isValid = this.refs.formCreateNFT.checkValidity();
+    const isValid = this.formCreateNFTRef.current.checkValidity();
     if (isValid) {
-      if (this.refs.address.value === '' && !this.refs.autoselectAddress.checked) {
+      if (this.addressRef.current.value === '' && !this.autoselectAddressRef.current.checked) {
         this.setState({ errorMessage: t`Must choose an address or auto select` });
         return false;
       }
@@ -77,7 +84,7 @@ class CreateNFT extends React.Component {
       }
       return true;
     } else {
-      this.refs.formCreateNFT.classList.add('was-validated')
+      this.formCreateNFTRef.current.classList.add('was-validated')
     }
   }
 
@@ -103,24 +110,24 @@ class CreateNFT extends React.Component {
   prepareSendTransaction = async (pin) => {
     // Get the address to send the created tokens
     let address = '';
-    if (this.refs.autoselectAddress.checked) {
+    if (this.autoselectAddressRef.current.checked) {
       address = hathorLib.wallet.getAddressToUse();
     } else {
-      address = this.refs.address.value;
+      address = this.addressRef.current.value;
     }
 
-    const name = this.refs.shortName.value;
-    const symbol = this.refs.symbol.value;
-    const nftData = this.refs.nftData.value;
-    const createMint = this.refs.createMintAuthority.checked;
-    const createMelt = this.refs.createMeltAuthority.checked;
+    const name = this.nameRef.current.value;
+    const symbol = this.symbolRef.current.value;
+    const nftData = this.nftDataRef.current.value;
+    const createMint = this.createMintAuthorityRef.current.checked;
+    const createMelt = this.createMeltAuthorityRef.current.checked;
 
     let transaction;
     try {
       transaction = await this.props.wallet.prepareCreateNewToken(
         name,
         symbol,
-        this.state.amount,
+        parseInt(this.state.amount),
         {
           nftData,
           address,
@@ -141,8 +148,8 @@ class CreateNFT extends React.Component {
    * @param {Object} tx Create token transaction data
    */
   onTokenCreateSuccess = (tx) => {
-    const name = this.refs.shortName.value;
-    const symbol = this.refs.symbol.value;
+    const name = this.nameRef.current.value;
+    const symbol = this.symbolRef.current.value;
     const token = {
       uid: tx.hash,
       name,
@@ -186,9 +193,9 @@ class CreateNFT extends React.Component {
   handleCheckboxAddress = (e) => {
     const value = e.target.checked;
     if (value) {
-      $(this.address.current).hide(400);
+      $(this.addressDivRef.current).hide(400);
     } else {
-      $(this.address.current).show(400);
+      $(this.addressDivRef.current).show(400);
     }
   }
 
@@ -261,22 +268,22 @@ class CreateNFT extends React.Component {
           )}
         </p>
         <hr className="mb-5 mt-5"/>
-        <form ref="formCreateNFT" id="formCreateNFT">
+        <form ref={this.formCreateNFTRef} id="formCreateNFT">
           <div className="row">
             <div className="form-group col-9">
               <label>{t`NFT Data`}</label>
-              <input required ref="nftData" placeholder={t`ipfs://...`} type="text" className="form-control" />
-              <small id="nftDataHelp" className="form-text text-muted">This can be the ipfs link to your metadata.json file, the link to your asset or a string that uniquely identify your NFT</small>
+              <input required ref={this.nftDataRef} placeholder={t`ipfs://...`} type="text" className="form-control" />
+              <small id="nftDataHelp" className="form-text text-muted">This can be the IPFS link to your metadata.json file, the link to your asset or a string that uniquely identify your NFT</small>
             </div>
           </div>
           <div className="row">
             <div className="form-group col-6">
               <label>{t`Short name`}</label>
-              <input required ref="shortName" placeholder={t`MyCoin`} type="text" className="form-control" />
+              <input required ref={this.nameRef} placeholder={t`MyCoin`} type="text" className="form-control" />
             </div>
             <div className="form-group col-3">
               <label>{t`Symbol`}</label>
-              <input required ref="symbol" placeholder={t`MYC (2-5 characters)`} type="text" minLength={2} maxLength={5} className="form-control" />
+              <input required ref={this.symbolRef} placeholder={t`MYC (2-5 characters)`} type="text" minLength={2} maxLength={5} className="form-control" />
             </div>
           </div>
           <div className="row">
@@ -286,21 +293,21 @@ class CreateNFT extends React.Component {
             </div>
             <div className="form-group d-flex flex-row align-items-center address-checkbox">
               <div className="form-check">
-                <input className="form-check-input" type="checkbox" ref="autoselectAddress" id="autoselectAddress" defaultChecked={true} onChange={this.handleCheckboxAddress} />
+                <input className="form-check-input" type="checkbox" ref={this.autoselectAddressRef} id="autoselectAddress" defaultChecked={true} onChange={this.handleCheckboxAddress} />
                 <label className="form-check-label" htmlFor="autoselectAddress">
                   {t`Select address automatically`}
                 </label>
               </div>
             </div>
-            <div className="form-group col-5" ref={this.address} style={{display: 'none'}}>
+            <div className="form-group col-5" ref={this.addressDivRef} style={{display: 'none'}}>
               <label>{t`Destination address`}</label>
-              <input ref="address" type="text" placeholder={t`Address`} className="form-control" />
+              <input ref={this.addressRef} type="text" placeholder={t`Address`} className="form-control" />
             </div>
           </div>
           <div className="row mt-3">
             <div className="form-group d-flex flex-row align-items-center create-mint-checkbox col-5">
               <div className="form-check">
-                <input className="form-check-input" type="checkbox" ref="createMintAuthority" id="createMintAuthority" defaultChecked={false} />
+                <input className="form-check-input" type="checkbox" ref={this.createMintAuthorityRef} id="createMintAuthority" defaultChecked={false} />
                 <label className="form-check-label" htmlFor="createMintAuthority">
                   {t`Create a mint authority`}<small id="createMintHelp" className="form-text text-muted">If you want to be able to mint more units of this NFT.</small>
                 </label>
@@ -308,7 +315,7 @@ class CreateNFT extends React.Component {
             </div>
             <div className="form-group d-flex flex-row align-items-center create-melt-checkbox col-4">
               <div className="form-check">
-                <input className="form-check-input" type="checkbox" ref="createMeltAuthority" id="createMeltAuthority" defaultChecked={false} />
+                <input className="form-check-input" type="checkbox" ref={this.createMeltAuthorityRef} id="createMeltAuthority" defaultChecked={false} />
                 <label className="form-check-label" htmlFor="createMeltAuthority">
                   {t`Create a melt authority`}<small id="createMeltHelp" className="form-text text-muted">If you want to be able to melt the units of this NFT.</small>
                 </label>

--- a/src/screens/CreateNFT.js
+++ b/src/screens/CreateNFT.js
@@ -1,0 +1,332 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import $ from 'jquery';
+import { t } from 'ttag'
+import { str2jsx } from '../utils/i18n';
+
+import wallet from '../utils/wallet';
+import tokens from '../utils/tokens';
+import SpanFmt from '../components/SpanFmt';
+import ModalSendTx from '../components/ModalSendTx';
+import ModalAlert from '../components/ModalAlert';
+import { connect } from "react-redux";
+import BackButton from '../components/BackButton';
+import hathorLib from '@hathor/wallet-lib';
+import helpers from '../utils/helpers';
+import { NFT_STANDARD_RFC_URL } from '../constants';
+import InputNumber from '../components/InputNumber';
+
+
+const mapStateToProps = (state) => {
+  const HTR_UID = hathorLib.constants.HATHOR_TOKEN_CONFIG.uid;
+  const htrBalance = HTR_UID in state.tokensBalance ? state.tokensBalance[HTR_UID].available : 0;
+  return {
+    htrBalance,
+    wallet: state.wallet,
+  };
+};
+
+
+/**
+ * Create an NFT
+ *
+ * @memberof Screens
+ */
+class CreateNFT extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.address = React.createRef();
+    this.inputWrapper = React.createRef();
+
+    /**
+     * errorMessage {string} Message to show when error happens on the form
+     * name {string} Name of the created token
+     * configurationString {string} Configuration string of the created token
+     * amount {number} Amount of tokens to create
+     */
+    this.state = {
+      errorMessage: '',
+      name: '',
+      configurationString: '',
+      amount: null,
+    };
+  }
+
+  /**
+   * Validates if the create NFT form is valid
+   */
+  formValid = () => {
+    const isValid = this.refs.formCreateNFT.checkValidity();
+    if (isValid) {
+      if (this.refs.address.value === '' && !this.refs.autoselectAddress.checked) {
+        this.setState({ errorMessage: t`Must choose an address or auto select` });
+        return false;
+      }
+
+      // Validating maximum amount
+      if (this.state.amount > hathorLib.constants.MAX_OUTPUT_VALUE) {
+        this.setState({ errorMessage: t`Maximum NFT units to mint is ${hathorLib.constants.MAX_OUTPUT_VALUE}` });
+        return false;
+      }
+      return true;
+    } else {
+      this.refs.formCreateNFT.classList.add('was-validated')
+    }
+  }
+
+  /**
+   * Opens PIN modal if form is valid
+   */
+  onClickCreate = () => {
+    if (!this.formValid()) {
+      return;
+    }
+
+    this.setState({ errorMessage: '' });
+    $('#pinModal').modal('show');
+  }
+
+  /**
+   * Prepare create NFT transaction data after PIN is validated
+   *
+   * @param {String} pin PIN written by the user
+   *
+   * @return {hathorLib.SendTransaction} SendTransaction object
+   */
+  prepareSendTransaction = async (pin) => {
+    // Get the address to send the created tokens
+    let address = '';
+    if (this.refs.autoselectAddress.checked) {
+      address = hathorLib.wallet.getAddressToUse();
+    } else {
+      address = this.refs.address.value;
+    }
+
+    const name = this.refs.shortName.value;
+    const symbol = this.refs.symbol.value;
+    const nftData = this.refs.nftData.value;
+    const createMint = this.refs.createMintAuthority.checked;
+    const createMelt = this.refs.createMeltAuthority.checked;
+
+    let transaction;
+    try {
+      transaction = await this.props.wallet.prepareCreateNewToken(
+        name,
+        symbol,
+        this.state.amount,
+        {
+          nftData,
+          address,
+          pinCode: pin,
+          createMint,
+          createMelt,
+        }
+      );
+      return new hathorLib.SendTransaction({ transaction, pin });
+    } catch (e) {
+      this.setState({ errorMessage: e.message });
+    }
+  }
+
+  /**
+   * Method executed if token is created with success
+   *
+   * @param {Object} tx Create token transaction data
+   */
+  onTokenCreateSuccess = (tx) => {
+    const name = this.refs.shortName.value;
+    const symbol = this.refs.symbol.value;
+    const token = {
+      uid: tx.hash,
+      name,
+      symbol
+    };
+
+    // Update redux with added token
+    tokens.addToken(token.uid, name, symbol);
+    // Must update the shared address, in case we have used one for the change
+    wallet.updateSharedAddress();
+    this.showAlert(token);
+  }
+
+
+  /**
+   * Method called after creating a token, then show an alert with explanation of the token
+   *
+   * @param {Object} token Object with {uid, name, symbol}
+   */
+  showAlert = (token) => {
+    this.setState({ name: token.name, configurationString: hathorLib.tokens.getConfigurationString(token.uid, token.name, token.symbol) }, () => {
+      $('#alertModal').modal('show');
+    });
+  }
+
+  /**
+   * Method called after clicking the button in the alert modal, then redirects to the wallet screen
+   */
+  alertButtonClick = () => {
+    $('#alertModal').on('hidden.bs.modal', (e) => {
+      this.props.history.push('/wallet/');
+    });
+    $('#alertModal').modal('hide');
+  }
+
+  /**
+   * Shows/hides address field depending on the checkbox click
+   *
+   * @param {Object} e Event for the address checkbox input change
+   */
+  handleCheckboxAddress = (e) => {
+    const value = e.target.checked;
+    if (value) {
+      $(this.address.current).hide(400);
+    } else {
+      $(this.address.current).show(400);
+    }
+  }
+
+  /**
+   * Handles amount input change
+   */
+  onAmountChange = (e) => {
+    this.setState({ amount: e.target.value });
+  }
+
+  /**
+   * Method called when user clicked to see the NFT standard RFC
+   *
+   * @param {Object} e Event for the click
+   */
+  goToRFC = (e) => {
+    e.preventDefault();
+    helpers.openExternalURL(NFT_STANDARD_RFC_URL);
+  }
+
+  /**
+   * Method called when user clicked to see the NFT guide
+   *
+   * @param {Object} e Event for the click
+   */
+  goToNFTGuide = (e) => {
+    e.preventDefault();
+    // TODO create this guide in the website (this will be later used as a medium post)
+    //helpers.openExternalURL(NFT_GUIDE_URL);
+  }
+
+  render = () => {
+    const getAlertBody = () => {
+      return (
+        <div>
+          <p>{t`Your NFT has been successfully created!`}</p>
+          <p>{t`You can share the following configuration string with other people to let them register your brand new NFT in their wallets.`}</p>
+          <p><SpanFmt>{t`Remember to **make a backup** of this configuration string.`}</SpanFmt></p>
+          <p><strong>{this.state.configurationString}</strong></p>
+        </div>
+      )
+    }
+
+    const htrDeposit = hathorLib.tokens.getDepositPercentage() * 100;
+    const depositAmount = hathorLib.tokens.getDepositAmount(this.state.amount); 
+
+    return (
+      <div className="content-wrapper">
+        <BackButton {...this.props} />
+        <h3 className="mt-4">Create NFT</h3>
+        <p className="mt-5">{t`Here you will create a new NFT. After the creation, you will be able to send the units of this NFT to other addresses.`}</p>
+        <p>{t`NFTs share the address space with all other tokens, including HTR. This means that you can send and receive tokens using any valid address.`}</p>
+        <p>{t`Remember to make a backup of your new token's configuration string. You will need to send it to other people to allow them to use your NFT.`}</p>
+        <p>
+          {str2jsx(
+            t`When creating and minting NFTs, a |bold:deposit of ${htrDeposit}%| in HTR is required and an additional |bold:fee of ${hathorLib.helpers.prettyValue(tokens.getNFTFee())} HTR|. If these tokens are later melted, this HTR deposit will be returned (depending on the amount melted) and the fee can never be returned. Read more about the NFT standard |link:here|.`,
+            {
+              bold: (x, i) => <strong key={i}>{x}</strong>,
+              link: (x, i) => <a key={i} href="true" onClick={this.goToRFC}>{x}</a>,
+            }
+          )}
+        </p>
+        <p>
+          {str2jsx(
+            t`The most common usage for an NFT is to represent a digital asset. Please see |link:this guide| that explains how to create an NFT data (including suggestions on how to upload files to the IPFS network) in the Hathor standard in order to be able to show your asset in our explorer.`,
+            {
+              link: (x, i) => <a key={i} href="true" onClick={this.goToNFTGuide}>{x}</a>,
+            }
+          )}
+        </p>
+        <hr className="mb-5 mt-5"/>
+        <form ref="formCreateNFT" id="formCreateNFT">
+          <div className="row">
+            <div className="form-group col-9">
+              <label>{t`NFT Data`}</label>
+              <input required ref="nftData" placeholder={t`ipfs://...`} type="text" className="form-control" />
+              <small id="nftDataHelp" className="form-text text-muted">This can be the ipfs link to your metadata.json file, the link to your asset or a string that uniquely identify your NFT</small>
+            </div>
+          </div>
+          <div className="row">
+            <div className="form-group col-6">
+              <label>{t`Short name`}</label>
+              <input required ref="shortName" placeholder={t`MyCoin`} type="text" className="form-control" />
+            </div>
+            <div className="form-group col-3">
+              <label>{t`Symbol`}</label>
+              <input required ref="symbol" placeholder={t`MYC (2-5 characters)`} type="text" minLength={2} maxLength={5} className="form-control" />
+            </div>
+          </div>
+          <div className="row">
+            <div className="form-group col-4">
+              <label>{t`Amount`}</label>
+              <input required type="number" min="0" step="1" className="form-control" placeholder="How many NFT units to create" onChange={this.onAmountChange} />
+            </div>
+            <div className="form-group d-flex flex-row align-items-center address-checkbox">
+              <div className="form-check">
+                <input className="form-check-input" type="checkbox" ref="autoselectAddress" id="autoselectAddress" defaultChecked={true} onChange={this.handleCheckboxAddress} />
+                <label className="form-check-label" htmlFor="autoselectAddress">
+                  {t`Select address automatically`}
+                </label>
+              </div>
+            </div>
+            <div className="form-group col-5" ref={this.address} style={{display: 'none'}}>
+              <label>{t`Destination address`}</label>
+              <input ref="address" type="text" placeholder={t`Address`} className="form-control" />
+            </div>
+          </div>
+          <div className="row mt-3">
+            <div className="form-group d-flex flex-row align-items-center create-mint-checkbox col-5">
+              <div className="form-check">
+                <input className="form-check-input" type="checkbox" ref="createMintAuthority" id="createMintAuthority" defaultChecked={false} />
+                <label className="form-check-label" htmlFor="createMintAuthority">
+                  {t`Create a mint authority`}<small id="createMintHelp" className="form-text text-muted">If you want to be able to mint more units of this NFT.</small>
+                </label>
+              </div>
+            </div>
+            <div className="form-group d-flex flex-row align-items-center create-melt-checkbox col-4">
+              <div className="form-check">
+                <input className="form-check-input" type="checkbox" ref="createMeltAuthority" id="createMeltAuthority" defaultChecked={false} />
+                <label className="form-check-label" htmlFor="createMeltAuthority">
+                  {t`Create a melt authority`}<small id="createMeltHelp" className="form-text text-muted">If you want to be able to melt the units of this NFT.</small>
+                </label>
+              </div>
+            </div>
+          </div>
+          <hr className="mb-5 mt-5"/>
+          <p><strong>HTR available:</strong> {hathorLib.helpers.prettyValue(this.props.htrBalance)} HTR</p>
+          <p><strong>Deposit:</strong> {hathorLib.helpers.prettyValue(depositAmount)} HTR</p>
+          <p><strong>Fee:</strong> {hathorLib.helpers.prettyValue(tokens.getNFTFee())} HTR</p>
+          <p><strong>Total:</strong> {hathorLib.helpers.prettyValue(tokens.getNFTFee() + depositAmount)} HTR</p>
+          <button type="button" className="mt-3 btn btn-hathor" onClick={this.onClickCreate}>Create</button>
+        </form>
+        <p className="text-danger mt-3">{this.state.errorMessage}</p>
+        <ModalSendTx prepareSendTransaction={this.prepareSendTransaction} onSendSuccess={this.onTokenCreateSuccess} title="Creating NFT" />
+        <ModalAlert title={t`NFT ${this.state.name} created`} body={getAlertBody()} handleButton={this.alertButtonClick} buttonName="Ok" />
+      </div>
+    );
+  }
+}
+
+export default connect(mapStateToProps)(CreateNFT);

--- a/src/screens/CreateNFT.js
+++ b/src/screens/CreateNFT.js
@@ -325,7 +325,7 @@ class CreateNFT extends React.Component {
           <hr className="mb-5 mt-5"/>
           <p><strong>HTR available:</strong> {hathorLib.helpers.prettyValue(this.props.htrBalance)} HTR</p>
           <p><strong>Deposit:</strong> {hathorLib.helpers.prettyValue(depositAmount)} HTR</p>
-          <p><strong>Fee:</strong> {hathorLib.helpers.prettyValue(tokens.getNFTFee())} HTR</p>
+          <p><strong>Fee:</strong> {nftFee} HTR</p>
           <p><strong>Total:</strong> {hathorLib.helpers.prettyValue(tokens.getNFTFee() + depositAmount)} HTR</p>
           <button type="button" className="mt-3 btn btn-hathor" onClick={this.onClickCreate}>Create</button>
         </form>

--- a/src/screens/CreateNFT.js
+++ b/src/screens/CreateNFT.js
@@ -273,7 +273,7 @@ class CreateNFT extends React.Component {
             <div className="form-group col-9">
               <label>{t`NFT Data`}</label>
               <input required ref={this.nftDataRef} placeholder={t`ipfs://...`} type="text" className="form-control" maxLength={NFT_DATA_MAX_SIZE} />
-              <small id="nftDataHelp" className="form-text text-muted">This can be the IPFS link to your metadata.json file, the link to your asset or a string that uniquely identify your NFT. Max size: {NFT_DATA_MAX_SIZE} characters.</small>
+              <small id="nftDataHelp" className="form-text text-muted">String that uniquely identify your NFT. For example, the IPFS link to your metadata file, a URI to your asset or any string. Max size: {NFT_DATA_MAX_SIZE} characters.</small>
             </div>
           </div>
           <div className="row">

--- a/src/screens/CreateNFT.js
+++ b/src/screens/CreateNFT.js
@@ -19,7 +19,7 @@ import { connect } from "react-redux";
 import BackButton from '../components/BackButton';
 import hathorLib from '@hathor/wallet-lib';
 import helpers from '../utils/helpers';
-import { NFT_STANDARD_RFC_URL } from '../constants';
+import { NFT_STANDARD_RFC_URL, NFT_DATA_MAX_SIZE } from '../constants';
 import InputNumber from '../components/InputNumber';
 
 
@@ -272,8 +272,8 @@ class CreateNFT extends React.Component {
           <div className="row">
             <div className="form-group col-9">
               <label>{t`NFT Data`}</label>
-              <input required ref={this.nftDataRef} placeholder={t`ipfs://...`} type="text" className="form-control" />
-              <small id="nftDataHelp" className="form-text text-muted">This can be the IPFS link to your metadata.json file, the link to your asset or a string that uniquely identify your NFT</small>
+              <input required ref={this.nftDataRef} placeholder={t`ipfs://...`} type="text" className="form-control" maxLength={NFT_DATA_MAX_SIZE} />
+              <small id="nftDataHelp" className="form-text text-muted">This can be the IPFS link to your metadata.json file, the link to your asset or a string that uniquely identify your NFT. Max size: 150.</small>
             </div>
           </div>
           <div className="row">

--- a/src/screens/CreateNFT.js
+++ b/src/screens/CreateNFT.js
@@ -224,7 +224,7 @@ class CreateNFT extends React.Component {
   goToNFTGuide = (e) => {
     e.preventDefault();
     // TODO create this guide in the website (this will be later used as a medium post)
-    //helpers.openExternalURL(NFT_GUIDE_URL);
+    // helpers.openExternalURL(NFT_GUIDE_URL);
   }
 
   render = () => {

--- a/src/screens/CreateNFT.js
+++ b/src/screens/CreateNFT.js
@@ -234,6 +234,7 @@ class CreateNFT extends React.Component {
 
     const htrDeposit = hathorLib.tokens.getDepositPercentage() * 100;
     const depositAmount = hathorLib.tokens.getDepositAmount(this.state.amount); 
+    const nftFee = hathorLib.helpers.prettyValue(tokens.getNFTFee());
 
     return (
       <div className="content-wrapper">
@@ -244,7 +245,7 @@ class CreateNFT extends React.Component {
         <p>{t`Remember to make a backup of your new token's configuration string. You will need to send it to other people to allow them to use your NFT.`}</p>
         <p>
           {str2jsx(
-            t`When creating and minting NFTs, a |bold:deposit of ${htrDeposit}%| in HTR is required and an additional |bold:fee of ${hathorLib.helpers.prettyValue(tokens.getNFTFee())} HTR|. If these tokens are later melted, this HTR deposit will be returned (depending on the amount melted) and the fee can never be returned. Read more about the NFT standard |link:here|.`,
+            t`When creating and minting NFTs, a |bold:deposit of ${htrDeposit}%| in HTR is required and an additional |bold:fee of ${nftFee} HTR|. If these tokens are later melted, this HTR deposit will be returned (depending on the amount melted) and the fee can never be returned. Read more about the NFT standard |link:here|.`,
             {
               bold: (x, i) => <strong key={i}>{x}</strong>,
               link: (x, i) => <a key={i} href="true" onClick={this.goToRFC}>{x}</a>,

--- a/src/screens/CreateNFT.js
+++ b/src/screens/CreateNFT.js
@@ -273,7 +273,7 @@ class CreateNFT extends React.Component {
             <div className="form-group col-9">
               <label>{t`NFT Data`}</label>
               <input required ref={this.nftDataRef} placeholder={t`ipfs://...`} type="text" className="form-control" maxLength={NFT_DATA_MAX_SIZE} />
-              <small id="nftDataHelp" className="form-text text-muted">This can be the IPFS link to your metadata.json file, the link to your asset or a string that uniquely identify your NFT. Max size: 150.</small>
+              <small id="nftDataHelp" className="form-text text-muted">This can be the IPFS link to your metadata.json file, the link to your asset or a string that uniquely identify your NFT. Max size: 150 characters.</small>
             </div>
           </div>
           <div className="row">

--- a/src/screens/CreateNFT.js
+++ b/src/screens/CreateNFT.js
@@ -273,7 +273,7 @@ class CreateNFT extends React.Component {
             <div className="form-group col-9">
               <label>{t`NFT Data`}</label>
               <input required ref={this.nftDataRef} placeholder={t`ipfs://...`} type="text" className="form-control" maxLength={NFT_DATA_MAX_SIZE} />
-              <small id="nftDataHelp" className="form-text text-muted">This can be the IPFS link to your metadata.json file, the link to your asset or a string that uniquely identify your NFT. Max size: 150 characters.</small>
+              <small id="nftDataHelp" className="form-text text-muted">This can be the IPFS link to your metadata.json file, the link to your asset or a string that uniquely identify your NFT. Max size: {NFT_DATA_MAX_SIZE} characters.</small>
             </div>
           </div>
           <div className="row">

--- a/src/screens/CreateNFT.js
+++ b/src/screens/CreateNFT.js
@@ -252,7 +252,7 @@ class CreateNFT extends React.Component {
         <p>{t`Remember to make a backup of your new token's configuration string. You will need to send it to other people to allow them to use your NFT.`}</p>
         <p>
           {str2jsx(
-            t`When creating and minting NFTs, a |bold:deposit of ${htrDeposit}%| in HTR is required and an additional |bold:fee of ${nftFee} HTR|. If these tokens are later melted, this HTR deposit will be returned (depending on the amount melted) and the fee can never be returned. Read more about the NFT standard |link:here|.`,
+            t`When creating and minting NFTs, a |bold:deposit of ${htrDeposit}%| in HTR is required and an additional |bold:fee of ${nftFee} HTR|. If these tokens are later melted, this HTR deposit will be returned (depending on the amount melted) and the fee will never be returned. Read more about the NFT standard |link:here|.`,
             {
               bold: (x, i) => <strong key={i}>{x}</strong>,
               link: (x, i) => <a key={i} href="true" onClick={this.goToRFC}>{x}</a>,
@@ -317,7 +317,7 @@ class CreateNFT extends React.Component {
               <div className="form-check">
                 <input className="form-check-input" type="checkbox" ref={this.createMeltAuthorityRef} id="createMeltAuthority" defaultChecked={false} />
                 <label className="form-check-label" htmlFor="createMeltAuthority">
-                  {t`Create a melt authority`}<small id="createMeltHelp" className="form-text text-muted">If you want to be able to melt the units of this NFT.</small>
+                  {t`Create a melt authority`}<small id="createMeltHelp" className="form-text text-muted">If you want to be able to melt units of this NFT.</small>
                 </label>
               </div>
             </div>

--- a/src/screens/CustomTokens.js
+++ b/src/screens/CustomTokens.js
@@ -14,6 +14,7 @@ import HathorAlert from '../components/HathorAlert';
 import $ from 'jquery';
 import BackButton from '../components/BackButton';
 import ModalAlertNotSupported from '../components/ModalAlertNotSupported';
+import { NFT_ENABLED } from '../constants';
 import hathorLib from '@hathor/wallet-lib';
 
 
@@ -70,7 +71,7 @@ class CustomTokens extends React.Component {
         <p>{t`If you want to use a custom token that already exists, you need to register this token in your Hathor Wallet. For this, you will need the custom token's Configuration String, which you can get from the creators of the token.`}</p>
         <div className="d-flex flex-row align-items-center justify-content-center mt-5">
           <button className="btn btn-hathor mr-4" onClick={this.createTokenClicked}>{t`Create a new token`}</button>
-          <button className="btn btn-hathor mr-4" onClick={this.createNFTClicked}>{t`Create an NFT`}</button>
+          { NFT_ENABLED && <button className="btn btn-hathor mr-4" onClick={this.createNFTClicked}>{t`Create an NFT`}</button> }
           <button className="btn btn-hathor" onClick={this.registerTokenClicked}>{t`Register a token`}</button>
         </div>
         <ModalAddToken success={this.newTokenSuccess} />

--- a/src/screens/CustomTokens.js
+++ b/src/screens/CustomTokens.js
@@ -49,6 +49,17 @@ class CustomTokens extends React.Component {
     }
   }
 
+  /**
+   * Triggered when user clicks on the Create NFT button
+   */
+  createNFTClicked = () => {
+    if (hathorLib.wallet.isHardwareWallet()) {
+      $('#notSupported').modal('show');
+    } else {
+      this.props.history.push('/create_nft/');
+    }
+  }
+
   render() {
     return (
       <div className="content-wrapper">
@@ -59,6 +70,7 @@ class CustomTokens extends React.Component {
         <p>{t`If you want to use a custom token that already exists, you need to register this token in your Hathor Wallet. For this, you will need the custom token's Configuration String, which you can get from the creators of the token.`}</p>
         <div className="d-flex flex-row align-items-center justify-content-center mt-5">
           <button className="btn btn-hathor mr-4" onClick={this.createTokenClicked}>{t`Create a new token`}</button>
+          <button className="btn btn-hathor mr-4" onClick={this.createNFTClicked}>{t`Create an NFT`}</button>
           <button className="btn btn-hathor" onClick={this.registerTokenClicked}>{t`Register a token`}</button>
         </div>
         <ModalAddToken success={this.newTokenSuccess} />

--- a/src/utils/tokens.js
+++ b/src/utils/tokens.js
@@ -104,6 +104,16 @@ const tokens = {
       return 0;
     }
   },
+
+  /**
+   * Returns the fee in HTR for creating an NFT
+   *
+   * @memberof Tokens
+   * @inner
+   */
+  getNFTFee() {
+    return 1;
+  },
 }
 
 export default tokens;


### PR DESCRIPTION
### Acceptance criteria

- User must be able to create an NFT using the wallet desktop. He must be able to customize it selecting the data string, the address, name, symbol, amount and if he would like to create mint/melt authorities
- The screen must make it clear for the user the deposit and fee required for minting an NFT