### PR TITLE
fix: package lock rollback for node v8.9.0 format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1147,64 +1147,6 @@
         "lodash": "4.17.15",
         "long": "4.0.0",
         "ws": "7.2.3"
-      },
-      "dependencies": {
-        "bitcore-lib": {
-          "version": "8.25.10",
-          "resolved": "https://registry.npmjs.org/bitcore-lib/-/bitcore-lib-8.25.10.tgz",
-          "integrity": "sha512-MyHpSg7aFRHe359RA/gdkaQAal3NswYZTLEuu0tGX1RGWXAYN9i/24fsjPqVKj+z0ua+gzAT7aQs0KiKXWCgKA==",
-          "requires": {
-            "bech32": "1.1.3",
-            "bn.js": "4.11.8",
-            "bs58": "4.0.1",
-            "buffer-compare": "1.1.1",
-            "elliptic": "6.5.4",
-            "inherits": "2.0.1",
-            "lodash": "4.17.21"
-          },
-          "dependencies": {
-            "lodash": {
-              "version": "4.17.21",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-              "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-            }
-          }
-        },
-        "bitcore-mnemonic": {
-          "version": "8.25.10",
-          "resolved": "https://registry.npmjs.org/bitcore-mnemonic/-/bitcore-mnemonic-8.25.10.tgz",
-          "integrity": "sha512-FeXxO37BLV5JRvxPmVFB91zRHalavV8H4TdQGt1/hz0AkoPymIV68OkuB+TptpjeYgatcgKPoPvPhglJkTzFQQ==",
-          "requires": {
-            "bitcore-lib": "8.25.10",
-            "unorm": "1.6.0"
-          }
-        },
-        "elliptic": {
-          "version": "6.5.4",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-          "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-          "requires": {
-            "bn.js": "4.12.0",
-            "brorand": "1.1.0",
-            "hash.js": "1.1.7",
-            "hmac-drbg": "1.0.1",
-            "inherits": "2.0.4",
-            "minimalistic-assert": "1.0.1",
-            "minimalistic-crypto-utils": "1.0.1"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.12.0",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-              "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-            },
-            "inherits": {
-              "version": "2.0.4",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-              "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-            }
-          }
-        }
       }
     },
     "@jest/console": {
@@ -3215,6 +3157,35 @@
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
       "requires": {
         "file-uri-to-path": "1.0.0"
+      }
+    },
+    "bitcore-lib": {
+      "version": "8.25.10",
+      "resolved": "https://registry.npmjs.org/bitcore-lib/-/bitcore-lib-8.25.10.tgz",
+      "integrity": "sha512-MyHpSg7aFRHe359RA/gdkaQAal3NswYZTLEuu0tGX1RGWXAYN9i/24fsjPqVKj+z0ua+gzAT7aQs0KiKXWCgKA==",
+      "requires": {
+        "bech32": "1.1.3",
+        "bn.js": "4.11.8",
+        "bs58": "4.0.1",
+        "buffer-compare": "1.1.1",
+        "inherits": "2.0.1",
+        "lodash": "4.17.21"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        }
+      }
+    },
+    "bitcore-mnemonic": {
+      "version": "8.25.10",
+      "resolved": "https://registry.npmjs.org/bitcore-mnemonic/-/bitcore-mnemonic-8.25.10.tgz",
+      "integrity": "sha512-FeXxO37BLV5JRvxPmVFB91zRHalavV8H4TdQGt1/hz0AkoPymIV68OkuB+TptpjeYgatcgKPoPvPhglJkTzFQQ==",
+      "requires": {
+        "bitcore-lib": "8.25.10",
+        "unorm": "1.6.0"
       }
     },
     "bl": {
@@ -7137,6 +7108,7 @@
           "requires": {
             "anymatch": "3.1.1",
             "braces": "3.0.2",
+            "fsevents": "2.1.2",
             "glob-parent": "5.1.0",
             "is-binary-path": "2.1.0",
             "is-glob": "4.0.1",
@@ -7155,7 +7127,8 @@
         "fsevents": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-          "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA=="
+          "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+          "optional": true
         },
         "glob-parent": {
           "version": "5.1.0",
@@ -11343,6 +11316,7 @@
           "requires": {
             "anymatch": "3.1.1",
             "braces": "3.0.2",
+            "fsevents": "2.1.2",
             "glob-parent": "5.1.0",
             "is-binary-path": "2.1.0",
             "is-glob": "4.0.1",
@@ -11406,7 +11380,9 @@
         "fsevents": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-          "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA=="
+          "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+          "dev": true,
+          "optional": true
         },
         "get-stream": {
           "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "electron-pack-linux": "electron-builder --linux -c.extraMetadata.main=build/electron.js",
     "electron-pack-win": "electron-builder --win -c.extraMetadata.main=build/electron.js",
     "watch-electron": "ELECTRON_START_URL=http://localhost:3000 NODE_ENV=dev nodemon --watch ./public/**/* --watch . --exec 'npm run electron'",
-    "electron-dev": "npx concurrently 'npx cross-env BROWSER=none npm run start' 'npx wait-on http://localhost:3000/ && npx cross-env ELECTRON_START_URL=http://localhost:3000 NODE_ENV=dev electron --inspect=5858 .'",
+    "electron-dev": "ELECTRON_START_URL=http://localhost:3000 NODE_ENV=dev electron --inspect=5858 .",
+    "electron-dev-concurrently": "npx concurrently 'npx cross-env BROWSER=none npm run start' 'npx wait-on http://localhost:3000/ && npx cross-env ELECTRON_START_URL=http://localhost:3000 NODE_ENV=dev electron --inspect=5858 .'",
     "locale-update-pot": "ttag extract -o ./locale/texts.pot ./src/",
     "postinstall": "npx cross-env ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES=true npm run electron-deps"
   },


### PR DESCRIPTION
A change on package-lock.json (adding the wallet-lib dependencies inside the wallet-lib object instead of outside) created a bug when signing a transaction. The bitcore lib was not being installed correctly.

### Acceptance criteria

- Fix package-lock.json in order to install bitcore lib correctly and the input signatures continue working.