### PR TITLE
fix: add vertical scroll for token bar body

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -572,6 +572,7 @@ svg.svg-wrapper {
 .token-bar .body {
   width: 100%;
   overflow-y: auto;
+  flex: 1 1;
 }
 
 .token-bar .token-wrapper {


### PR DESCRIPTION
### Acceptance criteria

When we have more tokens registered than it fits on the screen, then we must have a scroll in the token bar for accessing all the tokens.

Fixes #226 

![image](https://user-images.githubusercontent.com/3298774/134237466-34b46958-e935-4a41-91ea-785ff80270ce.png)
![image](https://user-images.githubusercontent.com/3298774/134237493-777772e5-7950-48a7-a346-268b050e8b30.png)
![image](https://user-images.githubusercontent.com/3298774/134237514-654e524c-636a-4f71-8f2f-52f1506c4eb9.png)
