### PR TITLE
feat: SendTransaction class now requires network parameter to validate the address of transaction

### DIFF
--- a/QA.md
+++ b/QA.md
@@ -201,6 +201,7 @@ You can connect your wallet to the testnet (https://node1.foxtrot.testnet.hathor
     1. Confirm the Timelock checkbox is also disabled.
     1. Click on 'Add another token' button. A modal is displayed saying the action is not supported.
     1. Try sending a transaction to an invalid address. An error message should show up on the wallet. Nothing should be displayed on Ledger.
+    1. Try sending a transaction with an amount bigger than the one you have. An error message should show up on the wallet. Nothing should be displayed on Ledger.
     1. Send tokens to both copied addresses in the same transaction (2 outputs). A modal will be displayed asking to confirm operation on Ledger.
     1. On Ledger, it should show 'Output 1/2' on the first step the address on the second and the amount on the third step (steps being from left to right), then an "Approve" and "Reject" steps. After clicking both buttons on the "Approve", it shows 'Output 2/2' and the other output (address and ammount).
     1. Clicking both buttons on the "Approve" step one more time will display the confirmation screen. Reject signing the transaction. The modal will hide and an error message should appear on the wallet.
@@ -212,6 +213,7 @@ You can connect your wallet to the testnet (https://node1.foxtrot.testnet.hathor
     1. Click on change server. The usual Change Server screen should show up, but with no PIN field. Change to a new server.
     1. On the settings screen, click on 'Set a passphrase'. It should show a modal saying the action is not supported and it should be done directly on Ledger.
     1. Go to Custom Tokens on the top navigation bar. Clicking 'Create a new token' should display a modal saying action is not supported.
+    1. Now click on 'Create an NFT' and should display a modal saying action is not supported.
     1. Lock wallet. It should go the screen asking to select the wallet type (software or hardware).
     1. Choose 'Hardware Wallet' and go through the same process again.
     1. When finished loading the wallet, it should show the same balance and transactions as before locking.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1135,9 +1135,9 @@
       }
     },
     "@hathor/wallet-lib": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/@hathor/wallet-lib/-/wallet-lib-0.24.1.tgz",
-      "integrity": "sha512-hbJUl+Yh0Yp0/mn5NxYY5Qvbegz3hRL+sjChektL0gqgw5mA1iSgm8DzQdwmWgLAZBcStei0ysrkcV/Z1qiLzg==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/@hathor/wallet-lib/-/wallet-lib-0.26.0.tgz",
+      "integrity": "sha512-Ug2UVBt55HZlkyoUNjtm/v96IoMDc1drs/Va0msZceuViZFvOqe8hiY1OMu5jPk/4SU1Bn6egpX2veasD/vN1A==",
       "requires": {
         "axios": "0.18.1",
         "bitcore-lib": "8.25.10",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "version": "0.21.0",
   "private": true,
   "dependencies": {
-    "@hathor/wallet-lib": "^0.24.1",
+    "@hathor/wallet-lib": "^0.26.0",
     "@ledgerhq/hw-transport-node-hid": "^4.73.4",
     "@sentry/electron": "^0.17.0",
     "babel-polyfill": "^6.26.0",

--- a/src/components/tokens/TokenDelegate.js
+++ b/src/components/tokens/TokenDelegate.js
@@ -54,7 +54,7 @@ class TokenDelegate extends React.Component {
         pinCode: pin,
       }
     );
-    return new hathorLib.SendTransaction({ transaction, pin });
+    return new hathorLib.SendTransaction({ transaction, pin, network: this.props.wallet.getNetworkObject() });
   }
 
   /**

--- a/src/components/tokens/TokenDestroy.js
+++ b/src/components/tokens/TokenDestroy.js
@@ -50,7 +50,7 @@ class TokenDestroy extends React.Component {
       this.state.destroyQuantity,
       { pinCode: pin },
     );
-    return new hathorLib.SendTransaction({ transaction, pin });
+    return new hathorLib.SendTransaction({ transaction, pin, network: this.props.wallet.getNetworkObject() });
   }
 
   /**

--- a/src/components/tokens/TokenMelt.js
+++ b/src/components/tokens/TokenMelt.js
@@ -62,7 +62,7 @@ class TokenMelt extends React.Component {
         pinCode: pin
       }
     );
-    return new hathorLib.SendTransaction({ transaction, pin });
+    return new hathorLib.SendTransaction({ transaction, pin, network: this.props.wallet.getNetworkObject() });
   }
 
   /**

--- a/src/components/tokens/TokenMint.js
+++ b/src/components/tokens/TokenMint.js
@@ -69,7 +69,7 @@ class TokenMint extends React.Component {
         pinCode: pin
       }
     );
-    return new hathorLib.SendTransaction({ transaction, pin });
+    return new hathorLib.SendTransaction({ transaction, pin, network: this.props.wallet.getNetworkObject() });
   }
 
   /**

--- a/src/screens/CreateNFT.js
+++ b/src/screens/CreateNFT.js
@@ -136,7 +136,7 @@ class CreateNFT extends React.Component {
           createMelt,
         }
       );
-      return new hathorLib.SendTransaction({ transaction, pin });
+      return new hathorLib.SendTransaction({ transaction, pin, network: this.props.wallet.getNetworkObject() });
     } catch (e) {
       this.setState({ errorMessage: e.message });
     }

--- a/src/screens/CreateToken.js
+++ b/src/screens/CreateToken.js
@@ -119,7 +119,7 @@ class CreateToken extends React.Component {
         wallet.decimalToInteger(this.state.amount),
         { address, pinCode: pin }
       );
-      return new hathorLib.SendTransaction({ transaction, pin });
+      return new hathorLib.SendTransaction({ transaction, pin, network: this.props.wallet.getNetworkObject() });
     } catch (e) {
       this.setState({ errorMessage: e.message });
     }

--- a/src/screens/SendTokens.js
+++ b/src/screens/SendTokens.js
@@ -163,8 +163,9 @@ class SendTokens extends React.Component {
     try {
       // Prepare data and submit job to tx mining API
       this.data = hathorLib.transaction.prepareData(data, null, {getSignature: false, completeTx: false});
-      const transaction = hathorLib.helpersUtils.createTxFromData(this.data);
-      this.sendTransaction = new hathorLib.SendTransaction({ transaction });
+      const network = this.props.wallet.getNetworkObject();
+      const transaction = hathorLib.helpersUtils.createTxFromData(this.data, network);
+      this.sendTransaction = new hathorLib.SendTransaction({ transaction, network });
       this.setState({ ledgerStep: 1, ledgerModalTitle: t`Sending transaction` });
     } catch(e) {
       this.handleSendError(e);
@@ -256,7 +257,7 @@ class SendTokens extends React.Component {
    * @return {SendTransaction} SendTransaction object, in case of success, null otherwise
    */
   prepareSendTransaction = async (pin) => {
-    return new hathorLib.SendTransaction({ outputs: this.data.outputs, inputs: this.data.inputs, pin });
+    return new hathorLib.SendTransaction({ outputs: this.data.outputs, inputs: this.data.inputs, pin, network: this.props.wallet.getNetworkObject() });
   }
 
   /**

--- a/src/screens/SendTokens.js
+++ b/src/screens/SendTokens.js
@@ -135,10 +135,11 @@ class SendTokens extends React.Component {
     let data = {'inputs': [], 'outputs': []};
     for (const ref of this.references) {
       const instance = ref.current;
-      const dataOne = instance.getData();
+      let dataOne = instance.getData();
       if (!dataOne) return;
       if (hathorLib.wallet.isHardwareWallet()) {
         dataOne = instance.validateInputsAndOutputs(dataOne);
+        if (!dataOne) return;
         // currently we only support HTR
         data['tokens'] = [];
       }


### PR DESCRIPTION
### Summary

In the wallets we prefer to handle every step of the `SendTransaction` flow to show a better information for the user in the screen. Because of that, we are using this class directly which now requires one more parameter because of https://github.com/HathorNetwork/hathor-wallet-lib/pull/276.

### Acceptance criteria

We must send `network` when creating `SendTransaction` object to validate the addresses.