### PR TITLE
fix: ignoring password when user forgot it on wallet reset

### DIFF
--- a/locale/texts.pot
+++ b/locale/texts.pot
@@ -1085,7 +1085,7 @@ msgid "You must write your password or check that you have forgotten it"
 msgstr ""
 
 #: src/components/ModalResetAllData.js:49
-msgid "Confirm message does not match"
+msgid "Confirmation message does not match"
 msgstr ""
 
 #: src/components/ModalResetAllData.js:57

--- a/src/components/ModalResetAllData.js
+++ b/src/components/ModalResetAllData.js
@@ -20,7 +20,8 @@ import SpanFmt from './SpanFmt';
  */
 class ModalResetAllData extends React.Component {
   /**
-   * errorMessage {string} Message to be shown to the user in case of error in the form
+   * @property {string} errorMessage Message to be shown to the user in case of error in the form
+   * @property {boolean} [forgotPassword] Identifies if the user has forgotten their password
    */
   state = { errorMessage: '', forgotPassword: false };
 
@@ -66,6 +67,11 @@ class ModalResetAllData extends React.Component {
     this.props.success()
   }
 
+  /**
+   * Method to be called when user clicks the "Forgot Password" checkbox
+   * In case the user forgot the password, the "Password" field is disabled and cleared
+   * @param {Object} e Event emitted when checkbox is clicked
+   */
   setForgotPassword = (e) => {
     this.setState(state => ({forgotPassword: !state.forgotPassword}))
 
@@ -75,6 +81,11 @@ class ModalResetAllData extends React.Component {
     }
   }
 
+  /**
+   * Method to be called when user closes the modal with the "No" button
+   * Clears the form validation and fields.
+   * @param {Object} e Event emitted when button is clicked
+   */
   onDismiss = (e) => {
     // Form cleanup
     this.refs.formConfirm.classList.remove('was-validated')


### PR DESCRIPTION
### Acceptance Criteria
- Form should ignore the password field if the "Forgot password" checkbox is selected.
- Fixes #246 

### Other improvements
**When the "Forgot Password" checkbox is selected, the "Password" field is cleared and disabled.**
[Example video](https://user-images.githubusercontent.com/1299409/149586640-4f10fcec-36f9-488b-b958-d309e5ec0987.mp4)

**When the user closes the modal, all its fields are cleared.**
https://user-images.githubusercontent.com/1299409/149586712-ec26344c-677f-4264-8860-e3eff63e6c44.mp4

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
