### PR TITLE
fix: select wallet type after selecting "software" and restarting

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -144,7 +144,8 @@ const returnLoadedWalletComponent = (Component, props, rest) => {
 }
 
 /**
- * Decides which screen to open at application start according to current state.
+ * Build the selected route component, validating the wallet state and the route security parameters needed for it.
+ * In case any criteria wasn't met, redirect to the relevant route.
  *
  * @param Component
  * @param props

--- a/src/App.js
+++ b/src/App.js
@@ -12,7 +12,6 @@ import SendTokens from './screens/SendTokens';
 import CreateToken from './screens/CreateToken';
 import CreateNFT from './screens/CreateNFT';
 import Navigation from './components/Navigation';
-import WaitVersion from './components/WaitVersion';
 import TransactionDetail from './screens/TransactionDetail';
 import LoadingAddresses from './screens/LoadingAddresses';
 import Server from './screens/Server';
@@ -38,7 +37,7 @@ import RequestErrorModal from './components/RequestError';
 import store from './store/index';
 import createRequestInstance from './api/axiosInstance';
 import hathorLib from '@hathor/wallet-lib';
-import { DEFAULT_SERVER, IPC_RENDERER, VERSION } from './constants';
+import {IPC_RENDERER, LEDGER_ENABLED} from './constants';
 import STORE from './storageInstance';
 import ModalAlert from './components/ModalAlert';
 import SoftwareWalletWarningMessage from './components/SoftwareWalletWarningMessage';
@@ -144,12 +143,13 @@ const returnLoadedWalletComponent = (Component, props, rest) => {
   }
 }
 
-/*
- * If not started, go to welcome screen. If loaded and locked, go to locked screen. If started, we have some options:
- * - If wallet is already loaded and the component requires it's loaded, we show the component.
- * - If wallet is already loaded and the component requires it's not loaded, we go to the wallet detail screen.
- * - If wallet is not loaded and the component requires it's loaded, we go to the wallet type screen.
- * - If wallet is not loaded and the component requires it's not loaded, we show the component.
+/**
+ * Decides which screen to open at application start according to current state.
+ *
+ * @param Component
+ * @param props
+ * @param rest
+ * @returns {JSX.Element|*}
  */
 const returnStartedRoute = (Component, props, rest) => {
   // On Windows the pathname that is being pushed into history has a prefix of '/C:'
@@ -159,46 +159,54 @@ const returnStartedRoute = (Component, props, rest) => {
   // Besides that, when electron loads initially it needs to load index.html from the filesystem
   // So the first load from electron get from '/C:/' in windows. That's why we need the second 'if'
   const pathname = rest.location.pathname;
-  if (pathname.length > 3 && pathname.slice(0,4).toLowerCase() === '/c:/') {
+  if (pathname.length > 3 && pathname.slice(0, 4).toLowerCase() === '/c:/') {
     if (pathname.length > 11 && pathname.slice(-11).toLowerCase() !== '/index.html') {
       return <Redirect to={{pathname: pathname.slice(3)}} />;
     }
   }
 
-  if (hathorLib.wallet.started()) {
-    if (hathorLib.wallet.loaded()) {
-      if (hathorLib.wallet.isLocked()) {
-        return <Redirect to={{pathname: '/locked/'}} />;
-      } else if (rest.loaded) {
-        return returnLoadedWalletComponent(Component, props, rest);
-      } else {
-        return <Redirect to={{pathname: '/wallet/'}} />;
-      }
-    } else {
-      const reduxState = store.getState();
-      if (reduxState.loadingAddresses) {
-        // If wallet is still loading addresses we redirect to the loading screen
-        return <Redirect to={{
-          pathname: '/loading_addresses/',
-          state: {path: props.match.url}
-        }} />;
-      }
-
-      if (rest.loaded) {
-        // When the wallet is opened, the path that is called is '/', which currenctly redirects to the Wallet component
-        // in that case, if the wallet is not loaded but it's started, it should redirect to the signin/wallet type screen
-        if (hathorLib.wallet.isHardwareWallet()) {
-          return <Redirect to={{pathname: '/wallet_type/'}} />;
-        }
-        return <Redirect to={{pathname: '/signin/'}} />;
-      } else {
-        return <Component {...props} />;
-      }
-    }
-  } else {
-    return <Redirect to={{pathname: '/welcome/'}} />;
+  // The wallet was not yet started, go to Welcome
+  if (!hathorLib.wallet.started()) {
+    return <Redirect to={{pathname: '/welcome/'}}/>;
   }
-}
+
+  // The wallet is already loaded
+  const routeRequiresWalletToBeLoaded = rest.loaded;
+  if (hathorLib.wallet.loaded()) {
+    // Wallet is locked, go to locked screen
+    if (hathorLib.wallet.isLocked()) {
+      return <Redirect to={{pathname: '/locked/'}}/>;
+    }
+
+    // Route requires the wallet to be loaded, render it
+    if (routeRequiresWalletToBeLoaded) {
+      return returnLoadedWalletComponent(Component, props, rest);
+    }
+
+    // Route does not require wallet to be loaded. Redirect to wallet "home" screen
+    return <Redirect to={{pathname: '/wallet/'}}/>;
+  }
+
+  // Wallet is not loaded, but it is still loading addresses. Go to the loading screen
+  const reduxState = store.getState();
+  if (reduxState.loadingAddresses) {
+    return <Redirect to={{
+      pathname: '/loading_addresses/',
+      state: {path: props.match.url}
+    }}/>;
+  }
+
+  // Wallet is not loaded nor loading, but it's started. Go to the first screen after "welcome"
+  if (routeRequiresWalletToBeLoaded) {
+    return LEDGER_ENABLED
+        ? <Redirect to={{pathname: '/wallet_type/'}}/>
+        : <Redirect to={{pathname: '/signin/'}}/>;
+  }
+
+  // Wallet is not loaded nor loading, and the route does not require it.
+  // Do not redirect anywhere, just render the component.
+  return <Component {...props} />;
+};
 
 /*
  * Route for the components that will be shown after the wallet was started (After user clicked in 'Get started' in Welcome screen)


### PR DESCRIPTION
### Acceptance Criteria
- When a software wallet setup was not completed, the app should open on "Wallet Type" screen after restarting
- Fixes #233 

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
