### PR TITLE
feat: displaying correct script data on tx details screen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1135,9 +1135,9 @@
       }
     },
     "@hathor/wallet-lib": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/@hathor/wallet-lib/-/wallet-lib-0.26.0.tgz",
-      "integrity": "sha512-Ug2UVBt55HZlkyoUNjtm/v96IoMDc1drs/Va0msZceuViZFvOqe8hiY1OMu5jPk/4SU1Bn6egpX2veasD/vN1A==",
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/@hathor/wallet-lib/-/wallet-lib-0.29.1.tgz",
+      "integrity": "sha512-unTnbwrziAB5W4taW/UThBkVAY5crDvUeBAx4GSo7Gc8AXKV2RL/JYZ6nyoZlcOQsvSNkR1pn3mz/MHLVuqqAw==",
       "requires": {
         "axios": "0.18.1",
         "bitcore-lib": "8.25.10",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "version": "0.21.1",
   "private": true,
   "dependencies": {
-    "@hathor/wallet-lib": "^0.26.0",
+    "@hathor/wallet-lib": "^0.29.0",
     "@ledgerhq/hw-transport-node-hid": "^4.73.4",
     "@sentry/electron": "^0.17.0",
     "babel-polyfill": "^6.26.0",


### PR DESCRIPTION
### Acceptance Criteria
- On "Transactrion Details" screen, data scripts should be shown correctly and not 'Unable to decode'.
- Specifically NFT creation transactions must show their script output correctly
- Resolves #265 

**Old screen**
![Screenshot from 2022-01-20 21-52-22](https://user-images.githubusercontent.com/1299409/150445815-0ec1b969-cedb-4878-8bd0-eaa3e6a62930.png)

**New screen**
![Screenshot from 2022-01-20 21-43-57](https://user-images.githubusercontent.com/1299409/150445555-3fe85ce9-ca4a-4fe6-8ad0-8c38c01119a0.png)

This feature is similar to the Explorer's PR 141: HathorNetwork/hathor-explorer#141

### Other adjustments
Hathor Wallet Lib dependency updated to 0.29

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.

