### PR TITLE
feat: add support for showing NFT reading metadata mime type

### DIFF
--- a/src/components/NFTListElement.js
+++ b/src/components/NFTListElement.js
@@ -35,16 +35,23 @@ class NFTListElement extends React.Component {
 
     const file = this.props.nftElement.nft_media.file;
 
-    const ext = helpers.getFileExtension(file);
+    // The metadata may have the media mime type (useful for videos and audios) because many times the file does not have an extension.
+    // In case it's not there, we try to get from the file extension
+    // mimeType will already have image/png, video/mp4, application/pdf, audio/mp3
+    // so we don't need to handle anything if it's already set
+    const mimeType = this.props.nftElement.nft_media.mime_type;
 
-    let fileType;
+    let fileType = mimeType;
+    if (!fileType) {
+      const ext = helpers.getFileExtension(file);
 
-    if (nftType === NFT_MEDIA_TYPES.audio) {
-      fileType = AUDIO_MEDIA_TYPES_BY_EXTENSION[ext];
-    }
+      if (nftType === NFT_MEDIA_TYPES.audio) {
+        fileType = AUDIO_MEDIA_TYPES_BY_EXTENSION[ext];
+      }
 
-    if (nftType === NFT_MEDIA_TYPES.video) {
-      fileType = VIDEO_MEDIA_TYPES_BY_EXTENSION[ext];
+      if (nftType === NFT_MEDIA_TYPES.video) {
+        fileType = VIDEO_MEDIA_TYPES_BY_EXTENSION[ext];
+      }
     }
 
     let media;

--- a/src/components/NFTListElement.js
+++ b/src/components/NFTListElement.js
@@ -39,9 +39,7 @@ class NFTListElement extends React.Component {
     // In case it's not there, we try to get from the file extension
     // mimeType will already have image/png, video/mp4, application/pdf, audio/mp3
     // so we don't need to handle anything if it's already set
-    const mimeType = this.props.nftElement.nft_media.mime_type;
-
-    let fileType = mimeType;
+    let fileType = this.props.nftElement.nft_media.mime_type;
     if (!fileType) {
       const ext = helpers.getFileExtension(file);
 


### PR DESCRIPTION
### Motivation

We've added support in the explorer NFT preview to read `mime_type` data from the metadata file to better show the videos and audios preview (https://github.com/HathorNetwork/hathor-explorer/pull/160). We must add this support in the wallet as well because some of the previews are working on the explorer but not in the wallet

### Acceptance Criteria
- Show NFT preview that rely on the mime type


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
