### PR TITLE
feat: wallet service integration on the desktop wallet

### DIFF
--- a/locale/texts.pot
+++ b/locale/texts.pot
@@ -16,10 +16,10 @@ msgid "Addresses"
 msgstr ""
 
 #: src/components/OutputsWrapper.js:58
-#: src/components/tokens/TokenMint.js:137
+#: src/components/tokens/TokenMint.js:146
 #: src/screens/AddressList.js:180
-#: src/screens/CreateNFT.js:306
-#: src/screens/CreateToken.js:278
+#: src/screens/CreateNFT.js:316
+#: src/screens/CreateToken.js:292
 msgid "Address"
 msgstr ""
 
@@ -40,14 +40,14 @@ msgid "Passphrase and confirm passphrase must be equal"
 msgstr ""
 
 #: src/components/ModalBackupWords.js:108
-#: src/components/ModalResetAllData.js:42
+#: src/components/ModalResetAllData.js:62
 #: src/screens/ChoosePassphrase.js:59
 msgid "Invalid password"
 msgstr ""
 
-#: src/components/ModalSendTx.js:101
+#: src/components/ModalSendTx.js:116
 #: src/screens/ChoosePassphrase.js:64
-#: src/screens/LockedWallet.js:54
+#: src/screens/LockedWallet.js:67
 #: src/screens/Server.js:86
 msgid "Invalid PIN"
 msgstr ""
@@ -74,7 +74,7 @@ msgid "Password"
 msgstr ""
 
 #: src/screens/ChoosePassphrase.js:140
-#: src/screens/LockedWallet.js:96
+#: src/screens/LockedWallet.js:118
 #: src/screens/Server.js:217
 msgid "PIN"
 msgstr ""
@@ -112,54 +112,54 @@ msgid "Confirm"
 msgstr ""
 
 #: src/screens/ChoosePassphrase.js:161
-#: src/screens/Settings.js:163
+#: src/screens/Settings.js:196
 msgid "Set a passphrase"
 msgstr ""
 
-#: src/screens/CreateNFT.js:76
-#: src/screens/CreateToken.js:69
+#: src/screens/CreateNFT.js:77
+#: src/screens/CreateToken.js:70
 msgid "Must choose an address or auto select"
 msgstr ""
 
-#: src/screens/CreateNFT.js:82
+#: src/screens/CreateNFT.js:83
 #, javascript-format
 msgid "Maximum NFT units to mint is ${ hathorLib.constants.MAX_OUTPUT_VALUE }"
 msgstr ""
 
-#: src/screens/CreateNFT.js:233
+#: src/screens/CreateNFT.js:243
 msgid "Your NFT has been successfully created!"
 msgstr ""
 
-#: src/screens/CreateNFT.js:234
+#: src/screens/CreateNFT.js:244
 msgid ""
 "You can share the following configuration string with other people to let "
 "them register your brand new NFT in their wallets."
 msgstr ""
 
-#: src/screens/CreateNFT.js:235
-#: src/screens/CreateToken.js:222
+#: src/screens/CreateNFT.js:245
+#: src/screens/CreateToken.js:236
 msgid "Remember to **make a backup** of this configuration string."
 msgstr ""
 
-#: src/screens/CreateNFT.js:252
+#: src/screens/CreateNFT.js:262
 msgid ""
 "Here you will create a new NFT. After the creation, you will be able to "
 "send the units of this NFT to other addresses."
 msgstr ""
 
-#: src/screens/CreateNFT.js:253
+#: src/screens/CreateNFT.js:263
 msgid ""
 "NFTs share the address space with all other tokens, including HTR. This "
 "means that you can send and receive tokens using any valid address."
 msgstr ""
 
-#: src/screens/CreateNFT.js:254
+#: src/screens/CreateNFT.js:264
 msgid ""
 "Remember to make a backup of your new token's configuration string. You "
 "will need to send it to other people to allow them to use your NFT."
 msgstr ""
 
-#: src/screens/CreateNFT.js:257
+#: src/screens/CreateNFT.js:267
 #, javascript-format
 msgid ""
 "When creating and minting NFTs, a |bold:deposit of ${ htrDeposit }%| in HTR "
@@ -169,7 +169,7 @@ msgid ""
 "NFT standard |link:here|."
 msgstr ""
 
-#: src/screens/CreateNFT.js:266
+#: src/screens/CreateNFT.js:276
 msgid ""
 "The most common usage for an NFT is to represent a digital asset. Please "
 "see |link:this guide| that explains how to create an NFT data (including "
@@ -177,98 +177,98 @@ msgid ""
 "standard in order to be able to show your asset in our explorer."
 msgstr ""
 
-#: src/screens/CreateNFT.js:276
+#: src/screens/CreateNFT.js:286
 msgid "NFT Data"
 msgstr ""
 
-#: src/screens/CreateNFT.js:277
+#: src/screens/CreateNFT.js:287
 msgid "ipfs://..."
 msgstr ""
 
 #: src/components/ModalEditToken.js:87
-#: src/screens/CreateNFT.js:283
-#: src/screens/CreateToken.js:250
+#: src/screens/CreateNFT.js:293
+#: src/screens/CreateToken.js:264
 msgid "Short name"
 msgstr ""
 
-#: src/screens/CreateNFT.js:284
-#: src/screens/CreateToken.js:251
+#: src/screens/CreateNFT.js:294
+#: src/screens/CreateToken.js:265
 msgid "MyCoin"
 msgstr ""
 
 #: src/components/ModalEditToken.js:90
-#: src/screens/CreateNFT.js:287
-#: src/screens/CreateToken.js:254
+#: src/screens/CreateNFT.js:297
+#: src/screens/CreateToken.js:268
 msgid "Symbol"
 msgstr ""
 
-#: src/screens/CreateNFT.js:288
-#: src/screens/CreateToken.js:255
+#: src/screens/CreateNFT.js:298
+#: src/screens/CreateToken.js:269
 msgid "MYC (2-5 characters)"
 msgstr ""
 
-#: src/screens/CreateNFT.js:293
-#: src/screens/CreateToken.js:260
+#: src/screens/CreateNFT.js:303
+#: src/screens/CreateToken.js:274
 msgid "Amount"
 msgstr ""
 
-#: src/screens/CreateNFT.js:300
-#: src/screens/CreateToken.js:272
+#: src/screens/CreateNFT.js:310
+#: src/screens/CreateToken.js:286
 msgid "Select address automatically"
 msgstr ""
 
-#: src/screens/CreateNFT.js:305
-#: src/screens/CreateToken.js:277
+#: src/screens/CreateNFT.js:315
+#: src/screens/CreateToken.js:291
 msgid "Destination address"
 msgstr ""
 
-#: src/screens/CreateNFT.js:314
+#: src/screens/CreateNFT.js:324
 msgid "Create a mint authority"
 msgstr ""
 
-#: src/screens/CreateNFT.js:322
+#: src/screens/CreateNFT.js:332
 msgid "Create a melt authority"
 msgstr ""
 
-#: src/screens/CreateNFT.js:336
+#: src/screens/CreateNFT.js:346
 #, javascript-format
 msgid "NFT ${ _this.state.name } created"
 msgstr ""
 
-#: src/screens/CreateToken.js:77
+#: src/screens/CreateToken.js:78
 #, javascript-format
 msgid "Maximum value to mint token is ${ max_output_value_str }"
 msgstr ""
 
-#: src/screens/CreateToken.js:220
+#: src/screens/CreateToken.js:234
 msgid "Your token has been successfully created!"
 msgstr ""
 
-#: src/screens/CreateToken.js:221
+#: src/screens/CreateToken.js:235
 msgid ""
 "You can share the following configuration string with other people to let "
 "them use your brand new token."
 msgstr ""
 
-#: src/screens/CreateToken.js:234
+#: src/screens/CreateToken.js:248
 msgid ""
 "Here you will create a new customized token. After the creation, you will "
 "be able to send this new token to other addresses."
 msgstr ""
 
-#: src/screens/CreateToken.js:235
+#: src/screens/CreateToken.js:249
 msgid ""
 "Custom tokens share the address space with all other tokens, including HTR. "
 "This means that you can send and receive tokens using any valid address."
 msgstr ""
 
-#: src/screens/CreateToken.js:236
+#: src/screens/CreateToken.js:250
 msgid ""
 "Remember to make a backup of your new token's configuration string. You "
 "will need to send it to other people to allow them to use your new token."
 msgstr ""
 
-#: src/screens/CreateToken.js:239
+#: src/screens/CreateToken.js:253
 #, javascript-format
 msgid ""
 "When creating and minting tokens, a |bold:deposit of ${ htrDeposit }%| in "
@@ -276,16 +276,16 @@ msgid ""
 "returned. Read more about it |link:here|."
 msgstr ""
 
-#: src/screens/CreateToken.js:286
+#: src/screens/CreateToken.js:300
 #, javascript-format
 msgid "Token ${ _this.state.name } created"
 msgstr ""
 
-#: src/screens/CustomTokens.js:67
+#: src/screens/CustomTokens.js:68
 msgid "Custom Tokens"
 msgstr ""
 
-#: src/screens/CustomTokens.js:68
+#: src/screens/CustomTokens.js:69
 msgid ""
 "You can create your own digital token with customized specifications on "
 "Hathor Network with only a few clicks. They will fully work under the same "
@@ -294,13 +294,13 @@ msgid ""
 "price of the native HTR token, and they can serve multiple purposes."
 msgstr ""
 
-#: src/screens/CustomTokens.js:69
+#: src/screens/CustomTokens.js:70
 msgid ""
 "Every custom token has a unique **Configuration String** which must be "
 "shared with all other people that will use the custom token."
 msgstr ""
 
-#: src/screens/CustomTokens.js:70
+#: src/screens/CustomTokens.js:71
 msgid ""
 "If you want to use a custom token that already exists, you need to register "
 "this token in your Hathor Wallet. For this, you will need the custom "
@@ -308,19 +308,19 @@ msgid ""
 "token."
 msgstr ""
 
-#: src/screens/CustomTokens.js:72
+#: src/screens/CustomTokens.js:73
 msgid "Create a new token"
 msgstr ""
 
-#: src/screens/CustomTokens.js:73
+#: src/screens/CustomTokens.js:74
 msgid "Create an NFT"
 msgstr ""
 
-#: src/screens/CustomTokens.js:74
+#: src/screens/CustomTokens.js:75
 msgid "Register a token"
 msgstr ""
 
-#: src/screens/CustomTokens.js:77
+#: src/screens/CustomTokens.js:78
 msgid "Token registered with success!"
 msgstr ""
 
@@ -369,17 +369,17 @@ msgstr ""
 msgid "**Transactions found:** ${ this.props.transactionsFound }"
 msgstr ""
 
-#: src/screens/LockedWallet.js:94
+#: src/screens/LockedWallet.js:116
 msgid "Your wallet is locked. Please write down your PIN to unlock it."
 msgstr ""
 
-#: src/components/ModalResetAllData.js:68
-#: src/screens/LockedWallet.js:100
-#: src/screens/Settings.js:164
+#: src/components/ModalResetAllData.js:113
+#: src/screens/LockedWallet.js:122
+#: src/screens/Settings.js:198
 msgid "Reset all data"
 msgstr ""
 
-#: src/screens/LockedWallet.js:101
+#: src/screens/LockedWallet.js:123
 msgid "Unlock"
 msgstr ""
 
@@ -437,7 +437,7 @@ msgid "Backup now"
 msgstr ""
 
 #: src/screens/NewWallet.js:208
-#: src/screens/Wallet.js:102
+#: src/screens/Wallet.js:113
 msgid "Backup completed!"
 msgstr ""
 
@@ -449,40 +449,77 @@ msgstr ""
 msgid "You tried to access a page that does not exist in Hathor Wallet"
 msgstr ""
 
-#: src/screens/SendTokens.js:168
-#: src/screens/SendTokens.js:399
+#: src/screens/SendTokens.js:136
+msgid "Invalid custom tokens"
+msgstr ""
+
+#: src/screens/SendTokens.js:189
+#: src/screens/SendTokens.js:515
 msgid "Sending transaction"
 msgstr ""
 
-#: src/screens/SendTokens.js:301
+#: src/screens/SendTokens.js:248
+#.  there are tokens without signatures, missingSigs
+#.  set tittle and content
+msgid "Unverified custom tokens"
+msgstr ""
+
+#: src/screens/SendTokens.js:381
+#.  limit is 10 custom tokens per tx
+#, javascript-format
+msgid ""
+"Ledger has a limit of ${ LEDGER_TX_CUSTOM_TOKEN_LIMIT } different tokens "
+"per transaction."
+msgstr ""
+
+#: src/screens/SendTokens.js:383
+msgid "Token limit reached"
+msgstr ""
+
+#: src/screens/SendTokens.js:392
 msgid "All your tokens were already added"
 msgstr ""
 
 #: src/components/tokens/TokenAction.js:137
-#: src/screens/SendTokens.js:359
+#: src/screens/SendTokens.js:455
 msgid "Loading metadata..."
 msgstr ""
 
-#: src/screens/SendTokens.js:367
+#: src/screens/SendTokens.js:463
 msgid "Add another token"
 msgstr ""
 
-#: src/screens/SendTokens.js:368
-#: src/screens/SendTokens.js:397
+#: src/screens/SendTokens.js:464
+#: src/screens/SendTokens.js:513
 msgid "Send Tokens"
 msgstr ""
 
-#: src/screens/SendTokens.js:380
+#: src/screens/SendTokens.js:476
 msgid ""
 "Please go to you Ledger and validate each output of your transaction. Press "
 "both buttons in case the output is correct."
 msgstr ""
 
-#: src/screens/SendTokens.js:381
+#: src/screens/SendTokens.js:477
 msgid "In the end, a final screen will ask you to confirm sending the transaction."
 msgstr ""
 
-#: src/screens/SendTokens.js:66
+#: src/screens/SendTokens.js:496
+msgid ""
+"Unfortunately this feature is not supported with the Hathor app version on "
+"your Ledger device. If you need this feature, you can use it by installing "
+"the most recent Hathor app."
+msgstr ""
+
+#: src/components/ModalAddressQRCode.js:100
+#: src/components/ModalAlertNotSupported.js:34
+#: src/components/ModalLedgerResetTokenSignatures.js:117
+#: src/components/ModalLedgerSignToken.js:218
+#: src/screens/SendTokens.js:505
+msgid "Close"
+msgstr ""
+
+#: src/screens/SendTokens.js:65
 #. *
 #.      * errorMessage {string} Message to be shown in case of error in form
 #.      * txTokens {Array} Array of tokens configs already added by the user (start with only hathor)
@@ -581,75 +618,96 @@ msgstr ""
 msgid "Cancel change"
 msgstr ""
 
-#: src/screens/Settings.js:103
+#: src/screens/Settings.js:106
 msgid "Turn notifications off"
 msgstr ""
 
-#: src/screens/Settings.js:104
+#: src/screens/Settings.js:107
 msgid "Are you sure you don't want to receive wallet notifications?"
 msgstr ""
 
-#: src/screens/Settings.js:111
+#: src/screens/Settings.js:114
 msgid "Turn notifications on"
 msgstr ""
 
-#: src/screens/Settings.js:112
+#: src/screens/Settings.js:115
 msgid "Are you sure you want to receive wallet notifications?"
 msgstr ""
 
-#: src/screens/Settings.js:151
+#: src/screens/Settings.js:178
 msgid "Date and time:"
 msgstr ""
 
-#: src/screens/Settings.js:154
+#: src/screens/Settings.js:181
 #, javascript-format
 msgid "**Server:** You are connected to ${ serverURL }"
 msgstr ""
 
 #: src/components/RequestError.js:184
-#: src/screens/Settings.js:155
+#: src/screens/Settings.js:182
 msgid "Change server"
 msgstr ""
 
-#: src/screens/Settings.js:159
+#: src/screens/Settings.js:187
 msgid "Advanced Settings"
 msgstr ""
 
-#: src/screens/Settings.js:161
+#: src/screens/Settings.js:189
 msgid "Allow notifications:"
 msgstr ""
 
-#: src/components/ModalResetAllData.js:100
-#: src/screens/Settings.js:161
-#: src/screens/Settings.js:162
+#: src/components/ModalResetAllData.js:147
+#: src/screens/Settings.js:189
+#: src/screens/Settings.js:190
 msgid "Yes"
 msgstr ""
 
-#: src/components/ModalResetAllData.js:99
-#: src/screens/Settings.js:161
-#: src/screens/Settings.js:162
+#: src/components/ModalResetAllData.js:146
+#: src/screens/Settings.js:189
+#: src/screens/Settings.js:190
 msgid "No"
 msgstr ""
 
-#: src/screens/Settings.js:161
-#: src/screens/Settings.js:162
+#: src/screens/Settings.js:189
+#: src/screens/Settings.js:190
 msgid "Change"
 msgstr ""
 
-#: src/screens/Settings.js:162
+#: src/screens/Settings.js:190
 msgid "Automatically report bugs to Hathor:"
 msgstr ""
 
-#: src/screens/Settings.js:169
+#: src/screens/Settings.js:193
+msgid "Unique identifier"
+msgstr ""
+
+#: src/components/ModalAddressQRCode.js:93
+#: src/components/TokenGeneralInfo.js:157
+#: src/components/WalletAddress.js:153
+#: src/screens/Settings.js:193
+msgid "Copy to clipboard"
+msgstr ""
+
+#: src/screens/Settings.js:197
+msgid "Untrust all tokens on Ledger"
+msgstr ""
+
+#: src/screens/Settings.js:204
 msgid "Complete action on your hardware wallet"
 msgstr ""
 
-#: src/screens/Settings.js:171
+#: src/screens/Settings.js:206
 msgid "You can set your passphrase directly on your hardware wallet."
 msgstr ""
 
-#: src/screens/Settings.js:173
+#: src/screens/Settings.js:208
 msgid "|fn:More info| about this on Ledger."
+msgstr ""
+
+#: src/components/TxData.js:730
+#: src/components/WalletAddress.js:182
+#: src/screens/Settings.js:213
+msgid "Copied to clipboard!"
 msgstr ""
 
 #: src/screens/Signin.js:41
@@ -673,7 +731,7 @@ msgstr ""
 msgid "Transaction with hash ${ _this3.props.match.params.id } not found"
 msgstr ""
 
-#: src/components/NFTListElement.js:94
+#: src/components/NFTListElement.js:99
 #: src/screens/TransactionDetail.js:130
 msgid "See on explorer"
 msgstr ""
@@ -732,8 +790,9 @@ msgstr ""
 msgid "Please update you API version and try again"
 msgstr ""
 
+#: src/components/ModalLedgerResetTokenSignatures.js:116
 #: src/screens/VersionError.js:56
-#: src/screens/WalletType.js:195
+#: src/screens/WalletType.js:228
 msgid "Try again"
 msgstr ""
 
@@ -741,52 +800,65 @@ msgstr ""
 msgid "Change Server"
 msgstr ""
 
-#: src/screens/Wallet.js:153
+#: src/screens/Wallet.js:177
 msgid ""
 "You haven't done the backup of your wallet yet. You should do it as soon as "
 "possible for your own safety."
 msgstr ""
 
-#: src/screens/Wallet.js:153
+#: src/screens/Wallet.js:177
 msgid "Do it now"
 msgstr ""
 
-#: src/screens/Wallet.js:186
+#: src/screens/Wallet.js:210
 msgid "Administrative Tools"
 msgstr ""
 
-#: src/screens/Wallet.js:214
+#: src/screens/Wallet.js:238
 msgid "Balance & History"
 msgstr ""
 
-#: src/screens/Wallet.js:217
+#: src/screens/Wallet.js:241
 #, javascript-format
 msgid "About ${ token.name }"
 msgstr ""
 
-#: src/screens/Wallet.js:240
+#: src/screens/Wallet.js:264
 #, javascript-format
 msgid ""
 "Are you sure you want to unregister the token **${ token.name } (${ "
 "token.symbol })**?"
 msgstr ""
 
-#: src/screens/Wallet.js:241
+#: src/screens/Wallet.js:265
 msgid ""
 "You won't lose your tokens, you just won't see this token on the side bar "
 "anymore."
 msgstr ""
 
-#: src/screens/Wallet.js:252
 #: src/screens/Wallet.js:276
+msgid "Sign token on Ledger"
+msgstr ""
+
+#: src/screens/Wallet.js:277
+msgid "Token signed with Ledger"
+msgstr ""
+
+#: src/screens/Wallet.js:286
+#: src/screens/Wallet.js:316
 msgid "Unregister token"
 msgstr ""
 
-#: src/screens/WalletType.js:173
+#: src/screens/WalletType.js:82
+#.  unsupported version
+msgid "Unsupported Ledger app version"
+msgstr ""
+
+#: src/screens/WalletType.js:206
 msgid "Hathor Wallet supports two types of wallet: software and hardware."
 msgstr ""
 
-#: src/screens/WalletType.js:175
+#: src/screens/WalletType.js:208
 msgid ""
 "|bold:Hardware wallets| are dedicated external devices that store your "
 "private information. We currently support the Ledger hardware wallet and "
@@ -794,37 +866,37 @@ msgid ""
 "about how to use the ledger app with Hathor Wallet check out |fn:this page|."
 msgstr ""
 
-#: src/screens/WalletType.js:182
+#: src/screens/WalletType.js:215
 msgid ""
 "**Software wallets**, on the other hand, store the information on your "
 "computer."
 msgstr ""
 
-#: src/screens/WalletType.js:184
+#: src/screens/WalletType.js:217
 msgid "Hardware wallet"
 msgstr ""
 
-#: src/screens/WalletType.js:185
+#: src/screens/WalletType.js:218
 msgid "Software wallet"
 msgstr ""
 
-#: src/screens/WalletType.js:202
+#: src/screens/WalletType.js:235
 msgid "You need to authorize the operation on your Ledger."
 msgstr ""
 
-#: src/screens/WalletType.js:204
+#: src/screens/WalletType.js:237
 msgid "Please connect your Ledger device to the computer and open the Hathor app."
 msgstr ""
 
-#: src/screens/WalletType.js:210
+#: src/screens/WalletType.js:243
 msgid "Step 2/2"
 msgstr ""
 
-#: src/screens/WalletType.js:212
+#: src/screens/WalletType.js:245
 msgid "Step 1/2"
 msgstr ""
 
-#: src/screens/WalletType.js:219
+#: src/screens/WalletType.js:252
 msgid "Connecting to Ledger"
 msgstr ""
 
@@ -932,6 +1004,21 @@ msgstr ""
 msgid "Previous"
 msgstr ""
 
+#: src/components/LedgerSignTokenInfo.js:21
+#: src/components/TokenGeneralInfo.js:135
+msgid "UID:"
+msgstr ""
+
+#: src/components/LedgerSignTokenInfo.js:31
+#: src/components/TokenGeneralInfo.js:138
+msgid "Symbol:"
+msgstr ""
+
+#: src/components/LedgerSignTokenInfo.js:32
+#: src/components/TokenGeneralInfo.js:137
+msgid "Name:"
+msgstr ""
+
 #: src/components/ModalAddManyTokens.js:52
 msgid "Must provide configuration string"
 msgstr ""
@@ -954,7 +1041,7 @@ msgstr ""
 #: src/components/ModalAddToken.js:91
 #: src/components/ModalBackupWords.js:201
 #: src/components/ModalEditToken.js:95
-#: src/components/ModalSendTx.js:181
+#: src/components/ModalSendTx.js:196
 #: src/components/ModalUnregisteredTokenInfo.js:113
 #: src/components/tokens/TokenAction.js:145
 msgid "Cancel"
@@ -989,25 +1076,14 @@ msgid "Address copied to clipboard!"
 msgstr ""
 
 #: src/components/ModalAddressQRCode.js:83
-#: src/components/WalletAddress.js:127
+#: src/components/WalletAddress.js:129
 msgid "Address to receive tokens"
-msgstr ""
-
-#: src/components/ModalAddressQRCode.js:93
-#: src/components/TokenGeneralInfo.js:157
-#: src/components/WalletAddress.js:151
-msgid "Copy to clipboard"
 msgstr ""
 
 #: src/components/ModalAddressQRCode.js:96
 #: src/components/ModalAddressQRCode.js:101
 #: src/components/TokenGeneralInfo.js:161
 msgid "Download"
-msgstr ""
-
-#: src/components/ModalAddressQRCode.js:100
-#: src/components/ModalAlertNotSupported.js:34
-msgid "Close"
 msgstr ""
 
 #: src/components/ModalAlertNotSupported.js:24
@@ -1040,14 +1116,14 @@ msgid "We need your password to show the words"
 msgstr ""
 
 #: src/components/ModalBackupWords.js:190
-#: src/components/ModalResetAllData.js:78
+#: src/components/ModalResetAllData.js:123
 msgid "Password*"
 msgstr ""
 
 #: src/components/ModalBackupWords.js:202
-#: src/components/ModalSendTx.js:182
-#: src/components/tokens/TokenMelt.js:158
-#: src/components/tokens/TokenMint.js:206
+#: src/components/ModalSendTx.js:197
+#: src/components/tokens/TokenMelt.js:167
+#: src/components/tokens/TokenMint.js:215
 msgid "Go"
 msgstr ""
 
@@ -1080,47 +1156,112 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: src/components/ModalResetAllData.js:44
-msgid "You must write your password or check that you have forgotten it"
+#: src/components/ModalLedgerResetTokenSignatures.js:110
+#: src/components/ModalLedgerSignToken.js:211
+msgid "Waiting for Ledger..."
+msgstr ""
+
+#: src/components/ModalLedgerResetTokenSignatures.js:116
+msgid "Start"
+msgstr ""
+
+#: src/components/ModalLedgerResetTokenSignatures.js:125
+msgid "Custom tokens on Ledger were reset!"
+msgstr ""
+
+#: src/components/ModalLedgerResetTokenSignatures.js:131
+msgid ""
+"This will only remove the verification that Ledger trusts all tokens from "
+"you wallet but it won't have any effect in your balance or history. You can "
+"only execute this action for all tokens, so if you decide to use any token "
+"after that you will need to verify it again with Ledger."
+msgstr ""
+
+#: src/components/ModalLedgerResetTokenSignatures.js:146
+msgid "User denied on Ledger"
+msgstr ""
+
+#: src/components/ModalLedgerResetTokenSignatures.js:149
+msgid "Unkown error"
+msgstr ""
+
+#: src/components/ModalLedgerResetTokenSignatures.js:163
+msgid "Reset token signatures"
+msgstr ""
+
+#: src/components/ModalLedgerSignToken.js:196
+msgid "Token was signed!"
+msgstr ""
+
+#: src/components/ModalLedgerSignToken.js:203
+msgid "Sign token"
+msgstr ""
+
+#: src/components/ModalLedgerSignToken.js:227
+msgid "Signature failed on Ledger"
+msgstr ""
+
+#: src/components/ModalLedgerSignToken.js:230
+msgid "User denied token on Ledger"
+msgstr ""
+
+#: src/components/ModalLedgerSignToken.js:233
+msgid "Ledger denied token"
+msgstr ""
+
+#: src/components/ModalLedgerSignToken.js:236
+msgid "Invalid token symbol"
+msgstr ""
+
+#: src/components/ModalLedgerSignToken.js:239
+msgid "Invalid token name"
+msgstr ""
+
+#: src/components/ModalLedgerSignToken.js:244
+msgid "Error signing token!"
 msgstr ""
 
 #: src/components/ModalResetAllData.js:49
 msgid "Confirmation message does not match"
 msgstr ""
 
-#: src/components/ModalResetAllData.js:57
+#: src/components/ModalResetAllData.js:55
+msgid "You must write your password or check that you have forgotten it"
+msgstr ""
+
+#: src/components/ModalResetAllData.js:102
 msgid ""
 "If you reset your wallet, all data will be deleted, and you will lose "
 "access to your tokens. To recover access to your tokens, you will need to "
 "import your words again."
 msgstr ""
 
-#: src/components/ModalResetAllData.js:59
+#: src/components/ModalResetAllData.js:104
 #, javascript-format
 msgid "${ firstMessage } You still haven't done the backup of your words."
 msgstr ""
 
-#: src/components/ModalResetAllData.js:75
+#: src/components/ModalResetAllData.js:120
 #, javascript-format
 msgid ""
 "If you still wanna do it, we need your password and for you to write down "
 "**'${ CONFIRM_RESET_MESSAGE }'** to confirm the operation."
 msgstr ""
 
-#: src/components/ModalResetAllData.js:82
+#: src/components/ModalResetAllData.js:128
 msgid "Confirm message*"
 msgstr ""
 
-#: src/components/ModalResetAllData.js:83
+#: src/components/ModalResetAllData.js:129
 #, javascript-format
 msgid "Write '${ CONFIRM_RESET_MESSAGE }'"
 msgstr ""
 
-#: src/components/ModalResetAllData.js:87
+#: src/components/ModalResetAllData.js:134
 msgid "I forgot my password"
 msgstr ""
 
-#: src/components/ModalSendTx.js:189
+#: src/components/ModalSendTx.js:204
 msgid "Ok"
 msgstr ""
 
@@ -1224,7 +1365,6 @@ msgid "Public Explorer"
 msgstr ""
 
 #: src/components/OutputsWrapper.js:63
-#: src/components/SendTokensOne.js:219
 msgid "This feature is disabled for hardware wallet"
 msgstr ""
 
@@ -1296,51 +1436,55 @@ msgstr ""
 msgid "Retry request"
 msgstr ""
 
-#: src/components/SendTokensOne.js:219
+#: src/components/SendTokensOne.js:197
 msgid "Select token"
 msgstr ""
 
-#: src/components/SendTokensOne.js:231
+#: src/components/SendTokensOne.js:197
+msgid "This feature is disabled for the current Ledger app version"
+msgstr ""
+
+#: src/components/SendTokensOne.js:209
 msgid "Balance available: "
 msgstr ""
 
-#: src/components/SendTokensOne.js:245
+#: src/components/SendTokensOne.js:223
 msgid "Token:"
 msgstr ""
 
-#: src/components/SendTokensOne.js:248
+#: src/components/SendTokensOne.js:226
 msgid "Remove"
 msgstr ""
 
-#: src/components/SendTokensOne.js:258
+#: src/components/SendTokensOne.js:236
 msgid "Choose inputs automatically"
 msgstr ""
 
-#: src/components/SendTokensOne.js:262
+#: src/components/SendTokensOne.js:240
 msgid "Inputs"
 msgstr ""
 
-#: src/components/SendTxHandler.js:21
+#: src/components/SendTxHandler.js:25
 msgid "Resolving proof of work of your transaction."
 msgstr ""
 
-#: src/components/SendTxHandler.js:24
+#: src/components/SendTxHandler.js:28
 msgid "Propagating transaction to the network."
 msgstr ""
 
-#: src/components/SendTxHandler.js:27
+#: src/components/SendTxHandler.js:31
 msgid "Your transaction was sent successfully!"
 msgstr ""
 
-#: src/components/SendTxHandler.js:89
+#: src/components/SendTxHandler.js:93
 msgid "There was an unexpected error when pushing the transaction to the network."
 msgstr ""
 
-#: src/components/SendTxHandler.js:90
+#: src/components/SendTxHandler.js:94
 msgid "There are no utxos available to fill the transaction."
 msgstr ""
 
-#: src/components/SendTxHandler.js:91
+#: src/components/SendTxHandler.js:95
 msgid "The selected inputs are invalid."
 msgstr ""
 
@@ -1365,63 +1509,63 @@ msgid ""
 "have support for Ledger."
 msgstr ""
 
-#: src/components/TokenAdministrative.js:153
+#: src/components/TokenAdministrative.js:176
 msgid "This feature is not currently supported for a hardware wallet."
 msgstr ""
 
-#: src/components/TokenAdministrative.js:188
-#: src/components/TokenAdministrative.js:199
+#: src/components/TokenAdministrative.js:211
+#: src/components/TokenAdministrative.js:222
 msgid "Operations"
 msgstr ""
 
-#: src/components/TokenAdministrative.js:189
-#: src/components/tokens/TokenMelt.js:157
+#: src/components/TokenAdministrative.js:212
+#: src/components/tokens/TokenMelt.js:166
 msgid "Melt tokens"
 msgstr ""
 
-#: src/components/TokenAdministrative.js:190
+#: src/components/TokenAdministrative.js:213
 msgid "Delegate melt"
 msgstr ""
 
-#: src/components/TokenAdministrative.js:191
+#: src/components/TokenAdministrative.js:214
 msgid "Destroy melt"
 msgstr ""
 
-#: src/components/TokenAdministrative.js:200
-#: src/components/tokens/TokenMint.js:203
+#: src/components/TokenAdministrative.js:223
+#: src/components/tokens/TokenMint.js:212
 msgid "Mint tokens"
 msgstr ""
 
-#: src/components/TokenAdministrative.js:200
+#: src/components/TokenAdministrative.js:223
 msgid "Mint more tokens"
 msgstr ""
 
-#: src/components/TokenAdministrative.js:201
+#: src/components/TokenAdministrative.js:224
 msgid "Delegate mint"
 msgstr ""
 
-#: src/components/TokenAdministrative.js:202
+#: src/components/TokenAdministrative.js:225
 msgid "Destroy mint"
 msgstr ""
 
-#: src/components/TokenAdministrative.js:209
+#: src/components/TokenAdministrative.js:232
 msgid "You have no more authority outputs for this token"
 msgstr ""
 
-#: src/components/TokenAdministrative.js:215
+#: src/components/TokenAdministrative.js:238
 msgid "Mint authority management"
 msgstr ""
 
-#: src/components/TokenAdministrative.js:220
+#: src/components/TokenAdministrative.js:243
 msgid "Melt authority management"
 msgstr ""
 
-#: src/components/TokenAdministrative.js:232
+#: src/components/TokenAdministrative.js:255
 #: src/components/TokenGeneralInfo.js:139
 msgid "Total supply:"
 msgstr ""
 
-#: src/components/TokenAdministrative.js:233
+#: src/components/TokenAdministrative.js:256
 msgid "Your balance available:"
 msgstr ""
 
@@ -1444,21 +1588,9 @@ msgstr ""
 msgid "Configuration string copied to clipboard!"
 msgstr ""
 
-#: src/components/TokenGeneralInfo.js:135
-msgid "UID:"
-msgstr ""
-
 #: src/components/TokenGeneralInfo.js:136
-#: src/components/TxData.js:649
+#: src/components/TxData.js:666
 msgid "Type:"
-msgstr ""
-
-#: src/components/TokenGeneralInfo.js:137
-msgid "Name:"
-msgstr ""
-
-#: src/components/TokenGeneralInfo.js:138
-msgid "Symbol:"
 msgstr ""
 
 #: src/components/TokenGeneralInfo.js:140
@@ -1559,179 +1691,174 @@ msgstr ""
 msgid "Spent"
 msgstr ""
 
-#: src/components/TxData.js:377
+#: src/components/TxData.js:394
 #, javascript-format
 msgid "${ ret } | Locked until ${ parsedTimestamp }"
 msgstr ""
 
-#: src/components/TxData.js:384
+#: src/components/TxData.js:401
 #, javascript-format
 msgid ""
 "Match values (nano contract), oracle id: ${ decoded.oracle_data_id } hash: "
 "${ decoded.oracle_pubkey_hash }"
 msgstr ""
 
-#: src/components/TxData.js:424
-#: src/components/TxData.js:433
+#: src/components/TxData.js:441
+#: src/components/TxData.js:450
 #.  there are conflicts, but it is not voided
 msgid "This ${ typeStr } is valid."
 msgstr ""
 
-#: src/components/TxData.js:435
+#: src/components/TxData.js:452
 #.  there are conflicts, but it is not voided
 msgid ""
 "Although there is a double-spending transaction, this transaction has the "
 "highest accumulated weight and is valid."
 msgstr ""
 
-#: src/components/TxData.js:440
+#: src/components/TxData.js:457
 #.  there are conflicts, but it is not voided
 msgid "Transactions double spending the same outputs as this transaction:"
 msgstr ""
 
-#: src/components/TxData.js:454
+#: src/components/TxData.js:471
 #.  it is voided, but there is no conflict
 #, javascript-format
 msgid "This ${ typeStr } is voided and **NOT** valid."
 msgstr ""
 
-#: src/components/TxData.js:456
+#: src/components/TxData.js:473
 #.  it is voided, but there is no conflict
 msgid ""
 "This ${ typeStr } is verifying (directly or indirectly) a voided "
 "double-spending transaction, hence it is voided as well."
 msgstr ""
 
-#: src/components/TxData.js:459
+#: src/components/TxData.js:476
 #.  it is voided, but there is no conflict
 #, javascript-format
 msgid "This ${ typeStr } is voided because of these transactions: "
 msgstr ""
 
-#: src/components/TxData.js:469
+#: src/components/TxData.js:486
 #.  it is voided, and there is a conflict
 msgid "This ${ typeStr } is **NOT** valid."
 msgstr ""
 
-#: src/components/TxData.js:471
+#: src/components/TxData.js:488
 #.  it is voided, and there is a conflict
 msgid "It is voided by: "
 msgstr ""
 
-#: src/components/TxData.js:477
+#: src/components/TxData.js:494
 #.  it is voided, and there is a conflict
 msgid "Conflicts with: "
 msgstr ""
 
-#: src/components/TxData.js:497
+#: src/components/TxData.js:514
 #, javascript-format
 msgid "Over ${ acc }"
 msgstr ""
 
-#: src/components/TxData.js:502
+#: src/components/TxData.js:519
 msgid "Retrieving accumulated weight data..."
 msgstr ""
 
-#: src/components/TxData.js:541
+#: src/components/TxData.js:558
 msgid "Tokens:"
 msgstr ""
 
-#: src/components/TxData.js:555
+#: src/components/TxData.js:572
 msgid "Your address"
 msgstr ""
 
-#: src/components/TxData.js:569
+#: src/components/TxData.js:586
 #, javascript-format
 msgid "**${ tokenSymbol }:** Received"
 msgstr ""
 
-#: src/components/TxData.js:575
+#: src/components/TxData.js:592
 msgid "**${ tokenSymbol }:** Sent"
 msgstr ""
 
-#: src/components/TxData.js:599
+#: src/components/TxData.js:616
 msgid "Balance:"
 msgstr ""
 
-#: src/components/TxData.js:608
+#: src/components/TxData.js:625
 msgid "First block:"
 msgstr ""
 
-#: src/components/TxData.js:617
+#: src/components/TxData.js:634
 msgid "Accumulated weight:"
 msgstr ""
 
-#: src/components/TxData.js:626
+#: src/components/TxData.js:643
 msgid "Confirmation level:"
 msgstr ""
 
-#: src/components/TxData.js:645
+#: src/components/TxData.js:662
 msgid "Block"
 msgstr ""
 
-#: src/components/TxData.js:645
+#: src/components/TxData.js:662
 msgid "Transaction"
 msgstr ""
 
-#: src/components/TxData.js:650
+#: src/components/TxData.js:667
 msgid "Time:"
 msgstr ""
 
-#: src/components/TxData.js:651
+#: src/components/TxData.js:668
 msgid "Nonce:"
 msgstr ""
 
-#: src/components/TxData.js:652
+#: src/components/TxData.js:669
 msgid "Weight:"
 msgstr ""
 
-#: src/components/TxData.js:664
+#: src/components/TxData.js:681
 msgid "Inputs:"
 msgstr ""
 
-#: src/components/TxData.js:668
+#: src/components/TxData.js:685
 msgid "Outputs:"
 msgstr ""
 
-#: src/components/TxData.js:675
+#: src/components/TxData.js:692
 msgid "Parents:"
 msgstr ""
 
-#: src/components/TxData.js:679
+#: src/components/TxData.js:696
 msgid "Children:"
 msgstr ""
 
-#: src/components/TxData.js:679
+#: src/components/TxData.js:696
 msgid "Click to hide"
 msgstr ""
 
-#: src/components/TxData.js:679
+#: src/components/TxData.js:696
 msgid "Click to show"
 msgstr ""
 
-#: src/components/TxData.js:684
+#: src/components/TxData.js:701
 msgid "Verification neighbors"
 msgstr ""
 
-#: src/components/TxData.js:687
+#: src/components/TxData.js:704
 msgid "Funds neighbors"
 msgstr ""
 
-#: src/components/TxData.js:699
+#: src/components/TxData.js:716
 msgid "Hide raw transaction"
 msgstr ""
 
-#: src/components/TxData.js:699
+#: src/components/TxData.js:716
 msgid "Show raw transaction"
 msgstr ""
 
-#: src/components/TxData.js:702
+#: src/components/TxData.js:719
 msgid "Copy raw tx to clipboard"
-msgstr ""
-
-#: src/components/TxData.js:713
-#: src/components/WalletAddress.js:180
-msgid "Copied to clipboard!"
 msgstr ""
 
 #: src/components/TxTextInput.js:25
@@ -1747,46 +1874,46 @@ msgstr ""
 msgid "Hardware Wallet"
 msgstr ""
 
-#: src/components/WalletAddress.js:130
+#: src/components/WalletAddress.js:132
 msgid "Generate new address"
 msgstr ""
 
-#: src/components/WalletAddress.js:130
+#: src/components/WalletAddress.js:132
 msgid "Get new address"
 msgstr ""
 
-#: src/components/WalletAddress.js:134
+#: src/components/WalletAddress.js:136
 #.  hide the QR code for hardware wallet 
 msgid "QR Code"
 msgstr ""
 
-#: src/components/WalletAddress.js:134
+#: src/components/WalletAddress.js:136
 #.  hide the QR code for hardware wallet 
 msgid "Get qrcode"
 msgstr ""
 
-#: src/components/WalletAddress.js:139
+#: src/components/WalletAddress.js:141
 #.  hide all addresses for hardware wallet
 msgid "See all addresses"
 msgstr ""
 
-#: src/components/WalletAddress.js:161
+#: src/components/WalletAddress.js:163
 msgid "Show full address"
 msgstr ""
 
-#: src/components/WalletAddress.js:170
+#: src/components/WalletAddress.js:172
 msgid "Validate that the address below is the same presented on the Ledger screen."
 msgstr ""
 
-#: src/components/WalletAddress.js:171
+#: src/components/WalletAddress.js:173
 msgid "Press both buttons on your Ledger in case the address is valid."
 msgstr ""
 
-#: src/components/WalletAddress.js:181
+#: src/components/WalletAddress.js:183
 msgid "You must use an old address before generating new ones"
 msgstr ""
 
-#: src/components/WalletAddress.js:183
+#: src/components/WalletAddress.js:185
 msgid "Validate address on Ledger"
 msgstr ""
 
@@ -1794,129 +1921,129 @@ msgstr ""
 msgid "Transaction history"
 msgstr ""
 
-#: src/components/tokens/TokenDelegate.js:46
-#: src/components/tokens/TokenDelegate.js:64
-#: src/components/tokens/TokenDelegate.js:92
-#: src/components/tokens/TokenDestroy.js:60
-#: src/components/tokens/TokenDestroy.js:101
+#: src/components/tokens/TokenDelegate.js:47
+#: src/components/tokens/TokenDelegate.js:73
+#: src/components/tokens/TokenDelegate.js:101
+#: src/components/tokens/TokenDestroy.js:69
+#: src/components/tokens/TokenDestroy.js:110
 msgid "Mint"
 msgstr ""
 
-#: src/components/tokens/TokenDelegate.js:46
-#: src/components/tokens/TokenDelegate.js:64
-#: src/components/tokens/TokenDelegate.js:92
-#: src/components/tokens/TokenDestroy.js:60
-#: src/components/tokens/TokenDestroy.js:101
+#: src/components/tokens/TokenDelegate.js:47
+#: src/components/tokens/TokenDelegate.js:73
+#: src/components/tokens/TokenDelegate.js:101
+#: src/components/tokens/TokenDestroy.js:69
+#: src/components/tokens/TokenDestroy.js:110
 msgid "Melt"
 msgstr ""
 
-#: src/components/tokens/TokenDelegate.js:65
+#: src/components/tokens/TokenDelegate.js:74
 #, javascript-format
 msgid "${ type } output delegated!"
 msgstr ""
 
-#: src/components/tokens/TokenDelegate.js:70
-#: src/components/tokens/TokenDestroy.js:73
+#: src/components/tokens/TokenDelegate.js:79
 #: src/components/tokens/TokenDestroy.js:82
+#: src/components/tokens/TokenDestroy.js:91
 msgid "mint"
 msgstr ""
 
-#: src/components/tokens/TokenDelegate.js:70
-#: src/components/tokens/TokenDestroy.js:73
+#: src/components/tokens/TokenDelegate.js:79
 #: src/components/tokens/TokenDestroy.js:82
+#: src/components/tokens/TokenDestroy.js:91
 msgid "melt"
 msgstr ""
 
-#: src/components/tokens/TokenDelegate.js:75
+#: src/components/tokens/TokenDelegate.js:84
 #, javascript-format
 msgid "Address of the new ${ type } authority"
 msgstr ""
 
-#: src/components/tokens/TokenDelegate.js:83
+#: src/components/tokens/TokenDelegate.js:92
 msgid "Create another ${ type } output for you?"
 msgstr ""
 
-#: src/components/tokens/TokenDelegate.js:85
-#: src/components/tokens/TokenMelt.js:147
-#: src/components/tokens/TokenMint.js:183
+#: src/components/tokens/TokenDelegate.js:94
+#: src/components/tokens/TokenMelt.js:156
+#: src/components/tokens/TokenMint.js:192
 msgid "Leave it checked unless you know what you are doing"
 msgstr ""
 
-#: src/components/tokens/TokenDelegate.js:98
+#: src/components/tokens/TokenDelegate.js:107
 msgid "Delegate"
 msgstr ""
 
-#: src/components/tokens/TokenDelegate.js:101
+#: src/components/tokens/TokenDelegate.js:110
 msgid "Delegating authority"
 msgstr ""
 
-#: src/components/tokens/TokenDestroy.js:61
+#: src/components/tokens/TokenDestroy.js:70
 #, javascript-format
 msgid "${ label } outputs destroyed!"
 msgstr ""
 
-#: src/components/tokens/TokenDestroy.js:75
+#: src/components/tokens/TokenDestroy.js:84
 #, javascript-format
 msgid "You only have ${ authoritiesLength } ${ type } ${ plural } to destroy."
 msgstr ""
 
-#: src/components/tokens/TokenDestroy.js:86
+#: src/components/tokens/TokenDestroy.js:95
 #, javascript-format
 msgid ""
 "Are you sure you want to destroy **${ quantity } ${ type }** authority ${ "
 "plural }?"
 msgstr ""
 
-#: src/components/tokens/TokenDestroy.js:108
+#: src/components/tokens/TokenDestroy.js:117
 msgid "Destroy"
 msgstr ""
 
-#: src/components/tokens/TokenDestroy.js:112
+#: src/components/tokens/TokenDestroy.js:121
 msgid "Destroying authorities"
 msgstr ""
 
-#: src/components/tokens/TokenMelt.js:81
+#: src/components/tokens/TokenMelt.js:90
 #, javascript-format
 msgid "${ prettyAmountValue } ${ _this.props.token.symbol } melted!"
 msgstr ""
 
-#: src/components/tokens/TokenMelt.js:94
+#: src/components/tokens/TokenMelt.js:103
 #, javascript-format
 msgid "The total amount you have is only ${ prettyWalletAmount }."
 msgstr ""
 
-#: src/components/tokens/TokenMelt.js:138
-#: src/components/tokens/TokenMint.js:173
+#: src/components/tokens/TokenMelt.js:147
+#: src/components/tokens/TokenMint.js:182
 msgid ""
 "This is an NFT token. The amount will be an integer number, without decimal "
 "places."
 msgstr ""
 
-#: src/components/tokens/TokenMelt.js:145
+#: src/components/tokens/TokenMelt.js:154
 msgid "Create another melt output for you?"
 msgstr ""
 
-#: src/components/tokens/TokenMelt.js:162
+#: src/components/tokens/TokenMelt.js:171
 msgid "Melting tokens"
 msgstr ""
 
-#: src/components/tokens/TokenMint.js:88
+#: src/components/tokens/TokenMint.js:97
 #, javascript-format
 msgid "${ prettyAmountValue } ${ _this.props.token.symbol } minted!"
 msgstr ""
 
-#: src/components/tokens/TokenMint.js:98
+#: src/components/tokens/TokenMint.js:107
 msgid "Address is required when not selected automatically"
 msgstr ""
 
-#: src/components/tokens/TokenMint.js:131
+#: src/components/tokens/TokenMint.js:140
 msgid "Automatically select address to receive new tokens"
 msgstr ""
 
-#: src/components/tokens/TokenMint.js:181
+#: src/components/tokens/TokenMint.js:190
 msgid "Create another mint output for you?"
 msgstr ""
 
-#: src/components/tokens/TokenMint.js:210
+#: src/components/tokens/TokenMint.js:219
 msgid "Minting tokens"
 msgstr ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1135,9 +1135,9 @@
       }
     },
     "@hathor/wallet-lib": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@hathor/wallet-lib/-/wallet-lib-0.33.1.tgz",
-      "integrity": "sha512-sth0sb18pb2MY6o7TEtiliG6Lx0zLbDvoXIja85XxtHoCvZdzd/j38JuepNB05xEwrEalPfCYfM1Aq/2ub8cTQ==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@hathor/wallet-lib/-/wallet-lib-0.35.0.tgz",
+      "integrity": "sha512-nk+OtfG0gTgZNokIrmIpWuj1JsQ7nRREkoPRva2Y92l3uUbGhqP6sjBcxe3saFSaq/f2Ojid8P70/A1aqpqPhQ==",
       "requires": {
         "axios": "0.18.1",
         "bitcore-lib": "8.25.10",
@@ -3838,6 +3838,7 @@
         "anymatch": "2.0.0",
         "async-each": "1.0.3",
         "braces": "2.3.2",
+        "fsevents": "1.2.13",
         "glob-parent": "3.1.0",
         "inherits": "2.0.4",
         "is-binary-path": "1.0.1",
@@ -7275,6 +7276,16 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
+    "fsevents": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "optional": true,
+      "requires": {
+        "bindings": "1.5.0",
+        "nan": "2.14.0"
+      }
+    },
     "fstream": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
@@ -9145,6 +9156,7 @@
         "@jest/types": "24.9.0",
         "anymatch": "2.0.0",
         "fb-watchman": "2.0.1",
+        "fsevents": "1.2.13",
         "graceful-fs": "4.2.3",
         "invariant": "2.2.4",
         "jest-serializer": "24.9.0",
@@ -14189,6 +14201,7 @@
         "eslint-plugin-react-hooks": "1.7.0",
         "file-loader": "4.3.0",
         "fs-extra": "8.1.0",
+        "fsevents": "2.1.2",
         "html-webpack-plugin": "4.0.0-beta.11",
         "identity-obj-proxy": "3.0.0",
         "jest": "24.9.0",
@@ -14239,6 +14252,12 @@
             "prop-types": "15.7.2",
             "resolve": "1.15.0"
           }
+        },
+        "fsevents": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+          "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+          "optional": true
         },
         "resolve": {
           "version": "1.15.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "version": "0.22.1",
   "private": true,
   "dependencies": {
-    "@hathor/wallet-lib": "^0.33.1",
+    "@hathor/wallet-lib": "^0.35.0",
     "@ledgerhq/hw-transport-node-hid": "^4.73.4",
     "@sentry/electron": "^0.17.0",
     "babel-polyfill": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "react-scripts": "^3.0.1",
     "redux": "^4.0.0",
     "ttag": "^1.7.22",
+    "unleash-proxy-client": "^1.11.0",
     "viz.js": "^2.1.2"
   },
   "main": "public/electron.js",

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -148,3 +148,8 @@ export const metadataLoaded = data => ({ type: "metadata_loaded", payload: data 
  * Remove token metadata after unregister token
  */
 export const removeTokenMetadata = data => ({ type: "remove_token_metadata", payload: data });
+
+/**
+ * Partially update history and balance
+ */
+export const partiallyUpdateHistoryAndBalance = (data) => ({ type: "partially_update_history_and_balance", payload: data });

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -158,3 +158,13 @@ export const partiallyUpdateHistoryAndBalance = (data) => ({ type: "partially_up
  * Flag indicating if we are using the wallet service facade
  */
 export const setUseWalletService = (useWalletService) => ({ type: "set_use_wallet_service", payload: useWalletService });
+
+/**
+ * Action to display the locked wallet screen and resolve the passed promise after the user typed his PIN
+ */
+export const lockWalletForResult = (promise) => ({ type: "lock_wallet_for_result", payload: promise });
+
+/**
+ * This will resolve the promise and reset the lockWalletPromise state
+ */
+export const resolveLockWalletPromise = (pin) => ({ type: "resolve_lock_wallet_promise", payload: pin });

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -119,13 +119,6 @@ export const loadWalletSuccess = (tokensHistory, tokensBalance, tokens) => ({ ty
  * updatedBalanceMap {Object} balance updated of each token in this tx
  * balances {Object} balance of each token in this tx for this wallet including authorities
  */
-export const newTx = (tx, updatedBalanceMap, balances) => ({ type: "new_tx", payload: { tx, updatedBalanceMap, balances } });
-
-/**
- * tx {Object} the new transaction
- * updatedBalanceMap {Object} balance updated of each token in this tx
- * balances {Object} balance of each token in this tx for this wallet including authorities
- */
 export const updateTx = (tx, updatedBalanceMap, balances) => ({ type: "update_tx", payload: { tx, updatedBalanceMap, balances } });
 
 /**

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -153,3 +153,8 @@ export const removeTokenMetadata = data => ({ type: "remove_token_metadata", pay
  * Partially update history and balance
  */
 export const partiallyUpdateHistoryAndBalance = (data) => ({ type: "partially_update_history_and_balance", payload: data });
+
+/**
+ * Flag indicating if we are using the wallet service facade
+ */
+export const setUseWalletService = (useWalletService) => ({ type: "set_use_wallet_service", payload: useWalletService });

--- a/src/components/ModalSendTx.js
+++ b/src/components/ModalSendTx.js
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { t } from 'ttag';
+import { connect } from "react-redux";
 import $ from 'jquery';
 import PinInput from './PinInput';
 import hathorLib from '@hathor/wallet-lib';
@@ -14,6 +15,13 @@ import SendTxHandler from '../components/SendTxHandler';
 import ReactLoading from 'react-loading';
 import colors from '../index.scss';
 
+
+const mapStateToProps = (state) => {
+  return {
+    wallet: state.wallet,
+    useWalletService: state.useWalletService,
+  };
+};
 
 /**
  * Component that shows a modal with a form to ask for the user PIN
@@ -89,6 +97,13 @@ class ModalSendTx extends React.Component {
       if (hathorLib.wallet.isPinCorrect(pin)) {
         $('#pinModal').data('bs.modal')._config.backdrop = 'static';
         $('#pinModal').data('bs.modal')._config.keyboard = false;
+
+        // If we are using the wallet service facade, we should avail of the validated PIN
+        // to renew the auth token.
+        if (this.props.useWalletService) {
+          await this.props.wallet.validateAndRenewAuthToken(pin);
+        }
+
         this.sendTransaction = await this.props.prepareSendTransaction(pin);
         if (this.sendTransaction) {
           // Show send tx handler component and start sending
@@ -215,4 +230,4 @@ class ModalSendTx extends React.Component {
   }
 }
 
-export default ModalSendTx;
+export default connect(mapStateToProps)(ModalSendTx);

--- a/src/components/SendTxHandler.js
+++ b/src/components/SendTxHandler.js
@@ -7,7 +7,11 @@
 
 import React from 'react';
 import { t } from 'ttag';
-import { SendTransaction, ErrorMessages as errorMessagesEnum } from '@hathor/wallet-lib';
+import {
+  SendTransactionWalletService,
+  SendTransaction,
+  ErrorMessages as errorMessagesEnum,
+} from '@hathor/wallet-lib';
 import PropTypes from 'prop-types';
 
 
@@ -142,7 +146,10 @@ class SendTxHandler extends React.Component {
  * onSendError: optional method to be executed when an error happens while sending the tx
  */
 SendTxHandler.propTypes = {
-  sendTransaction: PropTypes.instanceOf(SendTransaction).isRequired,
+  sendTransaction: PropTypes.oneOfType([
+    SendTransaction,
+    SendTransactionWalletService,
+  ]).isRequired,
   onSendSuccess: PropTypes.func,
   onSendError: PropTypes.func,
 };

--- a/src/components/TokenAdministrative.js
+++ b/src/components/TokenAdministrative.js
@@ -98,34 +98,16 @@ class TokenAdministrative extends React.Component {
   /**
    * Update token state after didmount or props update
    */
-  updateWalletInfo = () => {
-    if (!this.props.token || !this.props.token.uid) {
+  updateWalletInfo = async () => {
+    if (!this.props.token && !this.props.token.uid) {
       return;
     }
 
-    const { uid } = this.props.token;
+    const mintUtxos = await this.props.wallet.getMintAuthority(this.props.token.uid, { many: true });
+    const meltUtxos = await this.props.wallet.getMeltAuthority(this.props.token.uid, { many: true });
 
-    let mintCount = 0;
-    let meltCount = 0;
-
-    const tokenBalance = this.props.tokensBalance[uid];
-
-    if (this.props.useWalletService) {
-      // Wallet Service
-      // TODO: This should come from the wallet service and display the count properly
-      const canMintUtxos = tokenBalance.mint;
-      const canMeltUtxos = tokenBalance.melt;
-
-      mintCount = canMintUtxos ? 1 : 0;
-      meltCount = canMeltUtxos ? 1 : 0;
-    } else {
-      // Old Facade
-      const mintUtxos = this.props.wallet.getMintAuthority(this.props.token.uid, { many: true });
-      const meltUtxos = this.props.wallet.getMeltAuthority(this.props.token.uid, { many: true });
-
-      mintCount = mintUtxos ? mintUtxos.length : 0;
-      meltCount = meltUtxos ? meltUtxos.length : 0;
-    }
+    const mintCount = mintUtxos.length;
+    const meltCount = meltUtxos.length;
 
     const balance = this.props.token.uid in this.props.tokensBalance ? this.props.tokensBalance[this.props.token.uid].available : 0;
 

--- a/src/components/TokenAdministrative.js
+++ b/src/components/TokenAdministrative.js
@@ -98,15 +98,36 @@ class TokenAdministrative extends React.Component {
    * Update token state after didmount or props update
    */
   updateWalletInfo = () => {
-    const mintUtxos = this.props.wallet.getMintAuthority(this.props.token.uid, { many: true });
-    const mintCount = mintUtxos ? mintUtxos.length : 0;
+    if (!this.props.token && !this.props.token.uid) {
+      return;
+    }
 
-    const meltUtxos = this.props.wallet.getMeltAuthority(this.props.token.uid, { many: true });
-    const meltCount = meltUtxos ? meltUtxos.length : 0;
+    const { uid } = this.props.token;
 
-    const tokenBalance = this.props.token.uid in this.props.tokensBalance ? this.props.tokensBalance[this.props.token.uid].available : 0;
+    let canMintUtxos = false;
+    let canMeltUtxos = false;
+    let mintCount = 0;
+    let meltCount = 0;
 
-    this.setState({ mintCount, meltCount, balance: tokenBalance });
+    const tokenBalance = this.props.tokensBalance[uid];
+
+    if (tokenBalance.hasOwnProperty('mint') || tokenBalance.hasOwnProperty('melt')) {
+      // Wallet Service
+      canMintUtxos = tokenBalance.mint;
+      canMeltUtxos = tokenBalance.melt;
+      mintCount = 1;
+      meltCount = 1;
+    } else {
+      // Old Facade
+      canMintUtxos = this.props.wallet.getMintAuthority(this.props.token.uid, { many: true });
+      canMeltUtxos = this.props.wallet.getMeltAuthority(this.props.token.uid, { many: true });
+      mintCount = mintUtxos ? mintUtxos.length : 0;
+      meltCount = meltUtxos ? meltUtxos.length : 0;
+    }
+
+    const balance = this.props.token.uid in this.props.tokensBalance ? this.props.tokensBalance[this.props.token.uid].available : 0;
+
+    this.setState({ mintCount, meltCount, balance: balance });
   }
 
   /**

--- a/src/components/TokenAdministrative.js
+++ b/src/components/TokenAdministrative.js
@@ -105,8 +105,6 @@ class TokenAdministrative extends React.Component {
 
     const { uid } = this.props.token;
 
-    let canMintUtxos = false;
-    let canMeltUtxos = false;
     let mintCount = 0;
     let meltCount = 0;
 
@@ -115,15 +113,16 @@ class TokenAdministrative extends React.Component {
     if (this.props.useWalletService) {
       // Wallet Service
       // TODO: This should come from the wallet service and display the count properly
-      canMintUtxos = tokenBalance.mint;
-      canMeltUtxos = tokenBalance.melt;
+      const canMintUtxos = tokenBalance.mint;
+      const canMeltUtxos = tokenBalance.melt;
 
       mintCount = canMintUtxos ? 1 : 0;
       meltCount = canMeltUtxos ? 1 : 0;
     } else {
       // Old Facade
-      canMintUtxos = this.props.wallet.getMintAuthority(this.props.token.uid, { many: true });
-      canMeltUtxos = this.props.wallet.getMeltAuthority(this.props.token.uid, { many: true });
+      const mintUtxos = this.props.wallet.getMintAuthority(this.props.token.uid, { many: true });
+      const meltUtxos = this.props.wallet.getMeltAuthority(this.props.token.uid, { many: true });
+
       mintCount = mintUtxos ? mintUtxos.length : 0;
       meltCount = meltUtxos ? meltUtxos.length : 0;
     }

--- a/src/components/TokenAdministrative.js
+++ b/src/components/TokenAdministrative.js
@@ -35,6 +35,7 @@ const mapStateToProps = (state, props) => {
     tokensBalance: state.tokensBalance,
     wallet: state.wallet,
     tokenMetadata: state.tokenMetadata,
+    useWalletService: state.useWalletService,
   };
 };
 
@@ -111,12 +112,14 @@ class TokenAdministrative extends React.Component {
 
     const tokenBalance = this.props.tokensBalance[uid];
 
-    if (tokenBalance.hasOwnProperty('mint') || tokenBalance.hasOwnProperty('melt')) {
+    if (this.props.useWalletService) {
       // Wallet Service
+      // TODO: This should come from the wallet service and display the count properly
       canMintUtxos = tokenBalance.mint;
       canMeltUtxos = tokenBalance.melt;
-      mintCount = 1;
-      meltCount = 1;
+
+      mintCount = canMintUtxos ? 1 : 0;
+      meltCount = canMeltUtxos ? 1 : 0;
     } else {
       // Old Facade
       canMintUtxos = this.props.wallet.getMintAuthority(this.props.token.uid, { many: true });

--- a/src/components/TokenAdministrative.js
+++ b/src/components/TokenAdministrative.js
@@ -99,7 +99,7 @@ class TokenAdministrative extends React.Component {
    * Update token state after didmount or props update
    */
   updateWalletInfo = () => {
-    if (!this.props.token && !this.props.token.uid) {
+    if (!this.props.token || !this.props.token.uid) {
       return;
     }
 

--- a/src/components/TokenAdministrative.js
+++ b/src/components/TokenAdministrative.js
@@ -80,19 +80,24 @@ class TokenAdministrative extends React.Component {
   }
 
   /**
-   * Upadte token info getting data from the full node (can mint, can melt, total supply)
+   * Update token info getting data from the facade (can mint, can melt, total supply, total transactions)
    */
-  updateTokenInfo = () => {
+  updateTokenInfo = async () => {
     this.setState({ errorMessage: '' });
-    hathorLib.walletApi.getGeneralTokenInfo(this.props.token.uid, (response) => {
-      if (response.success) {
-        this.setState({
-          totalSupply: response.total,
-        });
-      } else {
-        this.setState({ errorMessage: response.message });
-      }
-    });
+
+    try {
+      const tokenDetails = await this.props.wallet.getTokenDetails(this.props.token.uid);
+      const { totalSupply, totalTransactions, authorities } = tokenDetails;
+
+      this.setState({
+        totalSupply,
+        canMint: authorities.mint,
+        canMelt: authorities.melt,
+        transactionsCount: totalTransactions,
+      });
+    } catch (e) {
+      this.setState({ errorMessage: e.message });
+    }
   }
 
   /**

--- a/src/components/TokenGeneralInfo.js
+++ b/src/components/TokenGeneralInfo.js
@@ -20,6 +20,7 @@ import { get } from 'lodash';
 const mapStateToProps = (state) => {
   return {
     tokenMetadata: state.tokenMetadata,
+    wallet: state.wallet,
   };
 };
 
@@ -56,22 +57,24 @@ class TokenGeneralInfo extends React.Component {
   }
 
   /**
-   * Upadte token info getting data from the full node (can mint, can melt, total supply)
+   * Update token info getting data from the facade (can mint, can melt, total supply and total transactions)
    */
-  updateTokenInfo = () => {
+  updateTokenInfo = async () => {
     this.setState({ errorMessage: '' });
-    hathorLib.walletApi.getGeneralTokenInfo(this.props.token.uid, (response) => {
-      if (response.success) {
-        this.setState({
-          totalSupply: response.total,
-          canMint: response.mint.length > 0,
-          canMelt: response.melt.length > 0,
-          transactionsCount: response.transactions_count,
-        });
-      } else {
-        this.setState({ errorMessage: response.message });
-      }
-    });
+
+    try {
+      const tokenDetails = await this.props.wallet.getTokenDetails(this.props.token.uid);
+      const { totalSupply, totalTransactions, authorities } = tokenDetails;
+
+      this.setState({
+        totalSupply,
+        canMint: authorities.mint,
+        canMelt: authorities.melt,
+        transactionsCount: totalTransactions,
+      });
+    } catch (e) {
+      this.setState({ errorMessage: e.message });
+    }
   }
 
   /**

--- a/src/components/TokenHistory.js
+++ b/src/components/TokenHistory.js
@@ -234,8 +234,8 @@ class TokenHistory extends React.Component {
     }
 
     const renderHistoryData = () => {
-      const keys = hathorLib.wallet.getWalletData().keys;
       const isNFT = helpers.isTokenNFT(get(this.props, 'selectedToken'), this.props.tokenMetadata);
+
       return this.state.transactions.map((tx, idx) => {
         let statusElement = '';
         let trClass = '';

--- a/src/components/WalletAddress.js
+++ b/src/components/WalletAddress.js
@@ -71,16 +71,9 @@ class WalletAddress extends React.Component {
     if (address.address === this.props.lastSharedAddress) {
       this.refs.alertError.show(3000);
     } else {
-      let addressIndex;
-
-      if (address.index) {
-        addressIndex = address.index;
-      } else {
-        addressIndex = this.props.wallet.getAddressIndex(address);
-      }
       this.props.sharedAddressUpdate({
         lastSharedAddress: address.address,
-        lastSharedIndex: addressIndex,
+        lastSharedIndex: address.index,
       });
     }
   }

--- a/src/components/WalletAddress.js
+++ b/src/components/WalletAddress.js
@@ -66,13 +66,23 @@ class WalletAddress extends React.Component {
    */
   generateNewAddress = (e) => {
     e.preventDefault();
-    const { address } = this.props.wallet.getNextAddress();
+    const address = this.props.wallet.getNextAddress();
 
-    if (address === this.props.lastSharedAddress) {
+    if (address.address === this.props.lastSharedAddress) {
       this.refs.alertError.show(3000);
     } else {
-      const addressIndex = this.props.wallet.getAddressIndex(address);
-      this.props.sharedAddressUpdate({ lastSharedAddress: address, lastSharedIndex: addressIndex});
+      let addressIndex;
+
+      // TODO: This should be removed once `getAddressIndex` is implemented on the wallet-service facade
+      if (address.index) {
+        addressIndex = address.index;
+      } else {
+        addressIndex = this.props.wallet.getAddressIndex(address);
+      }
+      this.props.sharedAddressUpdate({
+        lastSharedAddress: address.address,
+        lastSharedIndex: addressIndex,
+      });
     }
   }
 

--- a/src/components/WalletAddress.js
+++ b/src/components/WalletAddress.js
@@ -73,7 +73,6 @@ class WalletAddress extends React.Component {
     } else {
       let addressIndex;
 
-      // TODO: This should be removed once `getAddressIndex` is implemented on the wallet-service facade
       if (address.index) {
         addressIndex = address.index;
       } else {

--- a/src/components/tokens/TokenDelegate.js
+++ b/src/components/tokens/TokenDelegate.js
@@ -14,6 +14,7 @@ import hathorLib from '@hathor/wallet-lib';
 const mapStateToProps = (state) => {
   return {
     wallet: state.wallet,
+    useWalletService: state.useWalletService,
   };
 };
 
@@ -54,6 +55,14 @@ class TokenDelegate extends React.Component {
         pinCode: pin,
       }
     );
+
+    if (this.props.useWalletService) {
+      return new hathorLib.SendTransactionWalletService(this.props.wallet, {
+        transaction,
+        pin,
+      });
+    }
+
     return new hathorLib.SendTransaction({ transaction, pin, network: this.props.wallet.getNetworkObject() });
   }
 

--- a/src/components/tokens/TokenDestroy.js
+++ b/src/components/tokens/TokenDestroy.js
@@ -15,6 +15,7 @@ import { connect } from "react-redux";
 const mapStateToProps = (state) => {
   return {
     wallet: state.wallet,
+    useWalletService: state.useWalletService,
   };
 };
 
@@ -50,6 +51,14 @@ class TokenDestroy extends React.Component {
       this.state.destroyQuantity,
       { pinCode: pin },
     );
+
+    if (this.props.useWalletService) {
+      return new hathorLib.SendTransactionWalletService(this.props.wallet, {
+        transaction,
+        pin,
+      });
+    }
+
     return new hathorLib.SendTransaction({ transaction, pin, network: this.props.wallet.getNetworkObject() });
   }
 

--- a/src/components/tokens/TokenMelt.js
+++ b/src/components/tokens/TokenMelt.js
@@ -19,6 +19,7 @@ const mapStateToProps = (state) => {
   return {
     wallet: state.wallet,
     tokenMetadata: state.tokenMetadata,
+    useWalletService: state.useWalletService,
   };
 };
 
@@ -62,6 +63,14 @@ class TokenMelt extends React.Component {
         pinCode: pin
       }
     );
+
+    if (this.props.useWalletService) {
+      return new hathorLib.SendTransactionWalletService(this.props.wallet, {
+        transaction,
+        pin,
+      });
+    }
+
     return new hathorLib.SendTransaction({ transaction, pin, network: this.props.wallet.getNetworkObject() });
   }
 

--- a/src/components/tokens/TokenMint.js
+++ b/src/components/tokens/TokenMint.js
@@ -21,6 +21,7 @@ const mapStateToProps = (state) => {
   return {
     wallet: state.wallet,
     tokenMetadata: state.tokenMetadata,
+    useWalletService: state.useWalletService,
   };
 };
 
@@ -69,6 +70,14 @@ class TokenMint extends React.Component {
         pinCode: pin
       }
     );
+
+    if (this.props.useWalletService) {
+      return new hathorLib.SendTransactionWalletService(this.props.wallet, {
+        transaction,
+        pin,
+      });
+    }
+
     return new hathorLib.SendTransaction({ transaction, pin, network: this.props.wallet.getNetworkObject() });
   }
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -232,4 +232,4 @@ export const WALLET_SERVICE_MAINNET_BASE_WS_URL = 'wss://ws.wallet-service.hatho
  */
 export const UNLEASH_URL = 'https://unleash-proxy.b7e6a7f52ee9fefaf0c53e300cfcb014.hathor.network/proxy';
 export const UNLEASH_CLIENT_KEY = 'wKNhpEXKa39aTRgIjcNsO4Im618bRGTq';
-export const UNLEASH_POLLING_INTERVAL = 15; // seconds
+export const UNLEASH_POLLING_INTERVAL = 120; // seconds

--- a/src/constants.js
+++ b/src/constants.js
@@ -226,3 +226,10 @@ export const LEDGER_FIRST_CUSTOM_TOKEN_COMPATIBLE_VERSION = '1.1.0'
  */
 export const WALLET_SERVICE_MAINNET_BASE_URL = 'https://wallet-service.hathor.network/';
 export const WALLET_SERVICE_MAINNET_BASE_WS_URL = 'wss://ws.wallet-service.hathor.network/';
+
+/**
+ * Unleash constants
+ */
+export const UNLEASH_URL = 'https://unleash-proxy.b7e6a7f52ee9fefaf0c53e300cfcb014.hathor.network/proxy';
+export const UNLEASH_CLIENT_KEY = 'wKNhpEXKa39aTRgIjcNsO4Im618bRGTq';
+export const UNLEASH_POLLING_INTERVAL = 15; // seconds

--- a/src/constants.js
+++ b/src/constants.js
@@ -219,3 +219,10 @@ export const LEDGER_MAX_VERSION = '2.0.0';
  * First Ledger version with support for custom tokens
  */
 export const LEDGER_FIRST_CUSTOM_TOKEN_COMPATIBLE_VERSION = '1.1.0'
+
+
+/**
+ * Wallet service URLs
+ */
+export const WALLET_SERVICE_MAINNET_BASE_URL = 'https://wallet-service.hathor.network/';
+export const WALLET_SERVICE_MAINNET_BASE_WS_URL = 'wss://ws.wallet-service.hathor.network/';

--- a/src/featureFlags.js
+++ b/src/featureFlags.js
@@ -1,0 +1,88 @@
+import events from 'events';
+import { UnleashClient } from 'unleash-proxy-client';
+import {
+  UNLEASH_URL,
+  UNLEASH_CLIENT_KEY,
+  UNLEASH_POLLING_INTERVAL,
+} from './constants';
+
+export class FeatureFlags extends events.EventEmitter {
+  constructor(userId, network) {
+    super();
+
+    this.userId = userId;
+    this.network = network;
+    this.walletServiceFlag = `wallet-service-wallet-desktop-${this.network}.rollout`;
+    this.walletServiceEnabled = null;
+    this.client = new UnleashClient({
+      url: UNLEASH_URL,
+      clientKey: UNLEASH_CLIENT_KEY,
+      refreshInterval: UNLEASH_POLLING_INTERVAL,
+      appName: `wallet-service-wallet-desktop`,
+    });
+
+    this.client.on('update', () => {
+      // Get current flag
+      const walletServiceEnabled = this.client.isEnabled(this.walletServiceFlag);
+
+      // We should only emit an update if we already had a value on the instance
+      // and if the value has changed
+      if (this.walletServiceEnabled !== null && (
+        this.walletServiceEnabled !== walletServiceEnabled
+      )) {
+        this.walletServiceEnabled = walletServiceEnabled;
+        this.emit('wallet-service-enabled', walletServiceEnabled);
+      }
+    });
+  }
+
+  /**
+  * Uses the Hathor Unleash Server and Proxy to determine if the
+  * wallet should use the WalletService facade or the old facade
+  *
+  * @params {string} userId An user identifier (e.g. the firstAddress)
+  * @params {string} network The network name ('mainnet' or 'testnet')
+  *
+  * @return {boolean} The result from the unleash feature flag
+  */
+  async shouldUseWalletService() {
+    try {
+      const shouldIgnore = await localStorage.getItem('featureFlags:ignoreWalletServiceFlag');
+      if (shouldIgnore) {
+        return false;
+      }
+      this.client.updateContext({ userId: this.userId });
+
+      // Start polling for feature flag updates
+      await this.client.start();
+
+      // start() method will have already called the fetchToggles, so the flag should be enabled
+      const isWalletServiceEnabled = this.client.isEnabled(this.walletServiceFlag);
+      this.walletServiceEnabled = isWalletServiceEnabled;
+
+      return this.walletServiceEnabled;
+    } catch (e) {
+      // If our feature flag service is unavailable, we default to the
+      // old facade
+      return false;
+    }
+  }
+
+  /**
+   * Sets the ignore flag on the storage to persist it between app restarts
+   */
+  async ignoreWalletServiceFlag() {
+    await localStorage.setItem('featureFlags:ignoreWalletServiceFlag', 'true');
+    this.walletServiceEnabled = false;
+
+    // Stop the client from polling
+    this.client.stop();
+  }
+
+  /**
+   * Removes the ignore flag from the storage
+   */
+  static async clearIgnoreWalletServiceFlag() {
+    await localStorage.removeItem('featureFlags:ignoreWalletServiceFlag');
+  }
+}

--- a/src/featureFlags.js
+++ b/src/featureFlags.js
@@ -6,6 +6,8 @@ import {
   UNLEASH_POLLING_INTERVAL,
 } from './constants';
 
+const IGNORE_WALLET_SERVICE_FLAG = 'featureFlags:ignoreWalletServiceFlag';
+
 export class FeatureFlags extends events.EventEmitter {
   constructor(userId, network) {
     super();
@@ -47,7 +49,7 @@ export class FeatureFlags extends events.EventEmitter {
   */
   async shouldUseWalletService() {
     try {
-      const shouldIgnore = await localStorage.getItem('featureFlags:ignoreWalletServiceFlag');
+      const shouldIgnore = await localStorage.getItem(IGNORE_WALLET_SERVICE_FLAG);
       if (shouldIgnore) {
         return false;
       }
@@ -72,7 +74,7 @@ export class FeatureFlags extends events.EventEmitter {
    * Sets the ignore flag on the storage to persist it between app restarts
    */
   async ignoreWalletServiceFlag() {
-    await localStorage.setItem('featureFlags:ignoreWalletServiceFlag', 'true');
+    await localStorage.setItem(IGNORE_WALLET_SERVICE_FLAG, 'true');
     this.walletServiceEnabled = false;
 
     // Stop the client from polling
@@ -83,6 +85,6 @@ export class FeatureFlags extends events.EventEmitter {
    * Removes the ignore flag from the storage
    */
   static async clearIgnoreWalletServiceFlag() {
-    await localStorage.removeItem('featureFlags:ignoreWalletServiceFlag');
+    await localStorage.removeItem(IGNORE_WALLET_SERVICE_FLAG);
   }
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -450,6 +450,10 @@ svg.svg-wrapper {
   color: white;
 }
 
+.btn-hathor-loading-wrapper > .loading {
+  margin-right: 6px;
+}
+
 .settings hr {
   margin: 3rem 0;
 }

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -53,6 +53,7 @@ const initialState = {
   metadataLoaded: false,
   // Should we use the wallet service facade?
   useWalletService: false,
+  // Promise to be resolved when the user inputs his PIN correctly on the LockedWallet screen
   lockWalletPromise: null,
 };
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -105,8 +105,6 @@ const rootReducer = (state = initialState, action) => {
       return onResetWallet(state, action);
     case 'load_wallet_success':
       return onLoadWalletSuccess(state, action);
-    case 'new_tx':
-      return onNewTx(state, action);
     case 'update_tx':
       return onUpdateTx(state, action);
     case 'update_token_history':
@@ -289,13 +287,6 @@ const onUpdateTx = (state, action) => {
     tokensHistory: newTokensHistory,
     tokensBalance: newTokensBalance,
   });
-};
-
-/**
- * Updates the history and balance when a new tx arrives
- */
-const onNewTx = (state, action) => {
-  return state;
 };
 
 const onUpdateLoadedData = (state, action) => ({

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -51,6 +51,8 @@ const initialState = {
   tokenMetadataErrors: [],
   // When metadata is loaded from the lib
   metadataLoaded: false,
+  // Should we use the wallet service facade?
+  useWalletService: false,
 };
 
 const rootReducer = (state = initialState, action) => {
@@ -116,6 +118,8 @@ const rootReducer = (state = initialState, action) => {
       return removeTokenMetadata(state, action);
     case 'partially_update_history_and_balance':
       return partiallyUpdateHistoryAndBalance(state, action);
+    case 'set_use_wallet_service':
+      return onSetUseWalletService(state, action);
     default:
       return state;
   }
@@ -390,6 +394,18 @@ export const partiallyUpdateHistoryAndBalance = (state, action) => {
       ...state.tokensBalance,
       ...tokensBalance,
     },
+  };
+};
+
+/**
+ * Are we using the wallet service facade?
+ */
+export const onSetUseWalletService = (state, action) => {
+  const useWalletService = action.payload;
+
+  return {
+    ...state,
+    useWalletService,
   };
 };
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -195,23 +195,15 @@ const onLoadWalletSuccess = (state, action) => {
   hathorLib.storage.setItem('wallet:version', VERSION);
   const { tokensHistory, tokensBalance, tokens } = action.payload;
   const allTokens = new Set(tokens);
-  const currentAddress = state.wallet.getCurrentAddress(); //.address;
-  const address = currentAddress.address;
-  let addressIndex
-
-  if (typeof currentAddress.index !== undefined) {
-    addressIndex = currentAddress.index;
-  } else {
-    addressIndex = state.wallet.getAddressIndex(address);
-  }
+  const currentAddress = state.wallet.getCurrentAddress();
 
   return {
     ...state,
     tokensHistory,
     tokensBalance,
     loadingAddresses: false,
-    lastSharedAddress: address,
-    lastSharedIndex: addressIndex,
+    lastSharedAddress: currentAddress.address,
+    lastSharedIndex: currentAddress.index,
     allTokens,
   };
 };

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -53,6 +53,7 @@ const initialState = {
   metadataLoaded: false,
   // Should we use the wallet service facade?
   useWalletService: false,
+  lockWalletPromise: null,
 };
 
 const rootReducer = (state = initialState, action) => {
@@ -120,6 +121,10 @@ const rootReducer = (state = initialState, action) => {
       return partiallyUpdateHistoryAndBalance(state, action);
     case 'set_use_wallet_service':
       return onSetUseWalletService(state, action);
+    case 'lock_wallet_for_result':
+      return onLockWalletForResult(state, action);
+    case 'resolve_lock_wallet_promise':
+      return onResolveLockWalletPromise(state, action);
     default:
       return state;
   }
@@ -407,6 +412,29 @@ export const onSetUseWalletService = (state, action) => {
     ...state,
     useWalletService,
   };
+};
+
+/**
+ * Sets the promise to be resolved after the user typed his PIN on lock screen
+ */
+export const onLockWalletForResult = (state, action) => {
+  return {
+    ...state,
+    lockWalletPromise: action.payload,
+  };
+};
+
+export const onResolveLockWalletPromise = (state, action) => {
+  // Resolve the promise with the result
+  // TODO: I don't like this, but we don't have in this project a way to use middlewares in our
+  // actions (like redux-thunk, or redux-saga). We should refactor this if we ever start using
+  // this kind of mechanism.
+  state.lockWalletPromise(action.payload);
+
+  return {
+    ...state,
+    lockWalletPromise: null,
+  }
 };
 
 export default rootReducer;

--- a/src/screens/CreateNFT.js
+++ b/src/screens/CreateNFT.js
@@ -29,6 +29,7 @@ const mapStateToProps = (state) => {
   return {
     htrBalance,
     wallet: state.wallet,
+    useWalletService: state.useWalletService,
   };
 };
 
@@ -111,7 +112,7 @@ class CreateNFT extends React.Component {
     // Get the address to send the created tokens
     let address = '';
     if (this.autoselectAddressRef.current.checked) {
-      address = hathorLib.wallet.getAddressToUse();
+      address = this.props.wallet.getNextAddress().address;
     } else {
       address = this.addressRef.current.value;
     }
@@ -136,6 +137,15 @@ class CreateNFT extends React.Component {
           createMelt,
         }
       );
+
+      if (this.props.useWalletService) {
+        return new hathorLib.SendTransactionWalletService(this.props.wallet, {
+          transaction,
+          outputs: transaction.outputs,
+          pin,
+        });
+      }
+
       return new hathorLib.SendTransaction({ transaction, pin, network: this.props.wallet.getNetworkObject() });
     } catch (e) {
       this.setState({ errorMessage: e.message });

--- a/src/screens/CreateNFT.js
+++ b/src/screens/CreateNFT.js
@@ -112,7 +112,7 @@ class CreateNFT extends React.Component {
     // Get the address to send the created tokens
     let address = '';
     if (this.autoselectAddressRef.current.checked) {
-      address = this.props.wallet.getNextAddress().address;
+      address = this.props.wallet.getCurrentAddress({ markAsUsed: true }).address;
     } else {
       address = this.addressRef.current.value;
     }

--- a/src/screens/CreateToken.js
+++ b/src/screens/CreateToken.js
@@ -107,7 +107,7 @@ class CreateToken extends React.Component {
     // Get the address to send the created tokens
     let address = '';
     if (this.refs.autoselectAddress.checked) {
-      address = this.props.wallet.getNextAddress().address;
+      address = this.props.wallet.getCurrentAddress({ markAsUsed: true }).address;
     } else {
       address = this.refs.address.value;
     }

--- a/src/screens/CreateToken.js
+++ b/src/screens/CreateToken.js
@@ -29,6 +29,7 @@ const mapStateToProps = (state) => {
   return {
     htrBalance,
     wallet: state.wallet,
+    useWalletService: state.useWalletService,
   };
 };
 
@@ -106,7 +107,7 @@ class CreateToken extends React.Component {
     // Get the address to send the created tokens
     let address = '';
     if (this.refs.autoselectAddress.checked) {
-      address = hathorLib.wallet.getAddressToUse();
+      address = this.props.wallet.getNextAddress().address;
     } else {
       address = this.refs.address.value;
     }
@@ -119,7 +120,20 @@ class CreateToken extends React.Component {
         wallet.decimalToInteger(this.state.amount),
         { address, pinCode: pin }
       );
-      return new hathorLib.SendTransaction({ transaction, pin, network: this.props.wallet.getNetworkObject() });
+
+      if (this.props.useWalletService) {
+        return new hathorLib.SendTransactionWalletService(this.props.wallet, {
+          transaction,
+          outputs: transaction.outputs,
+          pin,
+        });
+      }
+
+      return new hathorLib.SendTransaction({
+        transaction,
+        pin,
+        network: this.props.wallet.getNetworkObject(),
+      });
     } catch (e) {
       this.setState({ errorMessage: e.message });
     }

--- a/src/screens/LockedWallet.js
+++ b/src/screens/LockedWallet.js
@@ -13,7 +13,9 @@ import $ from 'jquery';
 import wallet from '../utils/wallet';
 import RequestErrorModal from '../components/RequestError';
 import hathorLib from '@hathor/wallet-lib';
+import ReactLoading from 'react-loading';
 import { resolveLockWalletPromise } from '../actions';
+import colors from '../index.scss'
 
 
 const mapStateToProps = (state) => {
@@ -41,7 +43,8 @@ class LockedWallet extends React.Component {
      * errorMessage {string} Message to be shown in case of error in modal
      */
     this.state = {
-      errorMessage: ''
+      errorMessage: '',
+      loading: false,
     }
   }
 
@@ -59,6 +62,11 @@ class LockedWallet extends React.Component {
    */
   unlockClicked = (e) => {
     e.preventDefault();
+
+    if (this.state.loading) {
+      return;
+    }
+
     const isValid = this.refs.unlockForm.checkValidity();
     if (isValid) {
       const pin = this.refs.pin.value;
@@ -77,11 +85,19 @@ class LockedWallet extends React.Component {
         return;
       }
 
+      this.setState({
+        loading: true,
+      });
+
       // The last parameter being true means that we are going to start the wallet from an xpriv
       // that's already in localStorage encrypted. Because of that we don't need to send the
       // seed (first parameter) neither the password (second parameter).
       const promise = wallet.startWallet(null, '', pin, '', this.props.history, true);
+
       promise.then(() => {
+        this.setState({
+          loading: false,
+        });
         this.props.history.push('/wallet/');
       });
     } else {
@@ -120,7 +136,18 @@ class LockedWallet extends React.Component {
             {this.state.errorMessage && <p className="mt-4 text-danger">{this.state.errorMessage}</p>}
             <div className="d-flex align-items-center justify-content-between flex-row w-100 mt-4">
               <a className="mt-4" onClick={(e) => this.resetClicked(e)} href="true">{t`Reset all data`}</a>
-              <button onClick={this.unlockClicked} type="button" className="btn btn-hathor">{t`Unlock`}</button>
+              <div className="d-flex align-items-center justify-content-between btn-hathor-loading-wrapper">
+                {this.state.loading && (
+                  <ReactLoading color={colors.purpleHathor} type='spin' width={24} height={24} className="loading" />
+                )}
+                <button
+                  onClick={this.unlockClicked}
+                  type="button"
+                  className="btn btn-hathor"
+                  disabled={this.state.loading}>
+                  {t`Unlock`}
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/src/screens/LockedWallet.js
+++ b/src/screens/LockedWallet.js
@@ -15,7 +15,7 @@ import RequestErrorModal from '../components/RequestError';
 import hathorLib from '@hathor/wallet-lib';
 import ReactLoading from 'react-loading';
 import { resolveLockWalletPromise } from '../actions';
-import colors from '../index.scss'
+import colors from '../index.scss';
 
 
 const mapStateToProps = (state) => {

--- a/src/screens/SendTokens.js
+++ b/src/screens/SendTokens.js
@@ -269,6 +269,7 @@ class SendTokens extends React.Component {
    * It opens the ledger modal to wait for user action on the device
    */
   executeSendLedger = () => {
+    // Wallet Service currently does not support Ledger, so we default to the regular SendTransaction
     this.sendTransaction = new hathorLib.SendTransaction({
       outputs: this.data.outputs,
       inputs: this.data.inputs,

--- a/src/screens/SendTokens.js
+++ b/src/screens/SendTokens.js
@@ -24,12 +24,12 @@ import { IPC_RENDERER, LEDGER_TX_CUSTOM_TOKEN_LIMIT } from '../constants';
 import ReactLoading from 'react-loading';
 import colors from '../index.scss';
 
-
 const mapStateToProps = (state) => {
   return {
     tokens: state.tokens,
     wallet: state.wallet,
     metadataLoaded: state.metadataLoaded,
+    useWalletService: state.useWalletService,
   };
 };
 
@@ -269,7 +269,11 @@ class SendTokens extends React.Component {
    * It opens the ledger modal to wait for user action on the device
    */
   executeSendLedger = () => {
-    this.sendTransaction = new hathorLib.SendTransaction({ outputs: this.data.outputs, inputs: this.data.inputs, network: this.props.wallet.getNetworkObject() });
+    this.sendTransaction = new hathorLib.SendTransaction({
+      outputs: this.data.outputs,
+      inputs: this.data.inputs,
+      network: this.props.wallet.getNetworkObject(),
+    });
     this.data = this.sendTransaction.prepareTxData();
 
     // Complete data with default values
@@ -322,6 +326,14 @@ class SendTokens extends React.Component {
    * @return {SendTransaction} SendTransaction object, in case of success, null otherwise
    */
   prepareSendTransaction = async (pin) => {
+    if (this.props.useWalletService) {
+      return new hathorLib.SendTransactionWalletService(this.props.wallet, {
+        outputs: this.data.outputs,
+        inputs: this.data.inputs,
+        pin,
+      });
+    }
+
     return new hathorLib.SendTransaction({ outputs: this.data.outputs, inputs: this.data.inputs, pin, network: this.props.wallet.getNetworkObject() });
   }
 

--- a/src/screens/Settings.js
+++ b/src/screens/Settings.js
@@ -7,10 +7,11 @@
 
 import React from 'react';
 import { t } from 'ttag';
-
+import { CopyToClipboard } from 'react-copy-to-clipboard';
 import wallet from '../utils/wallet';
 import helpers from '../utils/helpers';
 import { Link } from 'react-router-dom';
+import HathorAlert from '../components/HathorAlert';
 import SpanFmt from '../components/SpanFmt';
 import ModalLedgerResetTokenSignatures from '../components/ModalLedgerResetTokenSignatures';
 import ModalConfirm from '../components/ModalConfirm';
@@ -151,9 +152,25 @@ class Settings extends React.Component {
     $('#resetTokenSignatures').modal('show');
   }
 
+  /**
+   * Method called on copy to clipboard success
+   * Show alert success message
+   *
+   * @param {string} text Text copied to clipboard
+   * @param {*} result Null in case of error
+   */
+  copied = (text, result) => {
+    if (result) {
+      // If copied with success
+      this.refs.alertCopied.show(1000);
+    }
+  }
+
   render() {
     const serverURL = hathorLib.helpers.getServerURL();
     const ledgerCustomTokens = hathorLib.wallet.isHardwareWallet() && version.isLedgerCustomTokenAllowed();
+    const uniqueIdentifier = helpers.getUniqueId();
+
     return (
       <div className="content-wrapper settings">
         <BackButton {...this.props} />
@@ -165,11 +182,17 @@ class Settings extends React.Component {
           <button className="btn btn-hathor" onClick={this.changeServer}>{t`Change server`}</button>
         </div>
         <hr />
+
         <div>
           <h4>{t`Advanced Settings`}</h4>
           <div className="d-flex flex-column align-items-start mt-4">
             <p><strong>{t`Allow notifications:`}</strong> {this.state.isNotificationOn ? <span>{t`Yes`}</span> : <span>{t`No`}</span>} <a className='ml-3' href="true" onClick={this.toggleNotificationSettings}> {t`Change`} </a></p>
             <p><strong>{t`Automatically report bugs to Hathor:`}</strong> {wallet.isSentryAllowed() ? <span>{t`Yes`}</span> : <span>{t`No`}</span>} <Link className='ml-3' to='/permission/'> {t`Change`} </Link></p>
+            <CopyToClipboard text={uniqueIdentifier} onCopy={this.copied}>
+              <span>
+                <p><strong>Unique identifier:</strong> {uniqueIdentifier} <i className="fa fa-clone pointer ml-1" title={t`Copy to clipboard`}></i></p>
+              </span>
+            </CopyToClipboard>
             <button className="btn btn-hathor" onClick={this.addPassphrase}>{t`Set a passphrase`}</button>
             {ledgerCustomTokens && <button className="btn btn-hathor mt-4" onClick={this.untrustClicked}>{t`Untrust all tokens on Ledger`}</button> }
             <button className="btn btn-hathor mt-4" onClick={this.resetClicked}>{t`Reset all data`}</button>
@@ -187,6 +210,7 @@ class Settings extends React.Component {
             </p>
           </div>
         </ModalAlertNotSupported>
+        <HathorAlert ref="alertCopied" text={t`Copied to clipboard!`} type="success" />
       </div>
     );
   }

--- a/src/screens/Settings.js
+++ b/src/screens/Settings.js
@@ -190,7 +190,7 @@ class Settings extends React.Component {
             <p><strong>{t`Automatically report bugs to Hathor:`}</strong> {wallet.isSentryAllowed() ? <span>{t`Yes`}</span> : <span>{t`No`}</span>} <Link className='ml-3' to='/permission/'> {t`Change`} </Link></p>
             <CopyToClipboard text={uniqueIdentifier} onCopy={this.copied}>
               <span>
-                <p><strong>Unique identifier:</strong> {uniqueIdentifier} <i className="fa fa-clone pointer ml-1" title={t`Copy to clipboard`}></i></p>
+                <p><strong>{t`Unique identifier`}:</strong> {uniqueIdentifier} <i className="fa fa-clone pointer ml-1" title={t`Copy to clipboard`}></i></p>
               </span>
             </CopyToClipboard>
             <button className="btn btn-hathor" onClick={this.addPassphrase}>{t`Set a passphrase`}</button>

--- a/src/screens/Wallet.js
+++ b/src/screens/Wallet.js
@@ -43,6 +43,7 @@ const mapStateToProps = (state) => {
     wallet: state.wallet,
     tokenHistory: state.tokensHistory[state.selectedToken] || [],
     tokenBalance: state.tokensBalance[state.selectedToken] || {},
+    useWalletService: state.useWalletService,
   };
 };
 
@@ -147,7 +148,7 @@ class Wallet extends React.Component {
    */
   shouldShowAdministrativeTab = () => {
     // Wallet Service
-    if (this.props.tokenBalance.hasOwnProperty('mint') && this.props.tokenBalance.hasOwnProperty('melt')) {
+    if (this.props.useWalletService) {
       return this.props.tokenBalance.mint || this.props.tokenBalance.melt;
     }
 

--- a/src/screens/Wallet.js
+++ b/src/screens/Wallet.js
@@ -38,9 +38,11 @@ const mapDispatchToProps = dispatch => {
 const mapStateToProps = (state) => {
   return {
     selectedToken: state.selectedToken,
+    entireState: state,
     tokens: state.tokens,
     wallet: state.wallet,
     tokenHistory: state.tokensHistory[state.selectedToken] || [],
+    tokenBalance: state.tokensBalance[state.selectedToken] || {},
   };
 };
 
@@ -144,6 +146,12 @@ class Wallet extends React.Component {
    * @return {boolean} If should show administrative tab
    */
   shouldShowAdministrativeTab = () => {
+    // Wallet Service
+    if (this.props.tokenBalance.hasOwnProperty('mint') && this.props.tokenBalance.hasOwnProperty('melt')) {
+      return this.props.tokenBalance.mint || this.props.tokenBalance.melt;
+    }
+
+    // Old facade
     if (this.props.wallet.getMintAuthority(this.props.selectedToken, { skipSpent: false })) {
       return true;
     }

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -160,6 +160,20 @@ const helpers = {
       }
       return 0;
   },
+
+  getUniqueId() {
+    const currentUniqueId = localStorage.getItem('app:uniqueId');
+
+    if (currentUniqueId) {
+      return currentUniqueId;
+    }
+
+    const uniqueId = Date.now().toString(36) + Math.random().toString(36).substring(2);
+
+    localStorage.setItem('app:uniqueId', uniqueId);
+
+    return uniqueId;
+  }
 }
 
 export default helpers;

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -38,6 +38,20 @@ const helpers = {
     }
   },
 
+  reloadElectron() {
+    // If we don't have window.require, we can assume the app is running on a browser, so we can just
+    // use the regular window.location to reload
+    if (!window.require) {
+      window.location.reload();
+    }
+
+    const { getCurrentWindow } = window.require('electron').remote;
+
+    const currentWindow = getCurrentWindow();
+
+    currentWindow.reload();
+  },
+
   /**
    * Update network variables in redux, storage and lib
    *

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -38,6 +38,12 @@ const helpers = {
     }
   },
 
+  /**
+   * Reloads the page loaded on electron
+   *
+   * @memberof Helpers
+   * @inner
+   */
   reloadElectron() {
     // If we don't have window.require, we can assume the app is running on a browser, so we can just
     // use the regular window.location to reload
@@ -46,7 +52,6 @@ const helpers = {
     }
 
     const { getCurrentWindow } = window.require('electron').remote;
-
     const currentWindow = getCurrentWindow();
 
     currentWindow.reload();
@@ -175,6 +180,15 @@ const helpers = {
       return 0;
   },
 
+  /**
+   * Generates a uniqueId and stores it on localStorage to be persisted
+   * between reloads
+   *
+   * @returns {string} The generated unique identifier
+   *
+   * @memberof Helpers
+   * @inner
+   */
   getUniqueId() {
     const currentUniqueId = localStorage.getItem('app:uniqueId');
 

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -214,8 +214,10 @@ const wallet = {
     if (!wallet.isReady()) {
       return null;
     }
+
     const updatedBalanceMap = {};
-    const balances = await wallet.getTxBalance(tx);
+    const balances = await wallet.getTxBalance(tx, { includeAuthorities: true });
+
     // we now loop through all tokens present in the new tx to get the new balance
     for (const [tokenUid] of Object.entries(balances)) {
       /* eslint-disable no-await-in-loop */

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -21,7 +21,6 @@ import {
   updateLoadedData,
   isOnlineUpdate,
   updateHeight,
-  newTx,
   updateTx,
   loadingAddresses,
   loadWalletSuccess,

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -13,6 +13,7 @@ import {
   WALLET_SERVICE_MAINNET_BASE_URL,
   WALLET_SERVICE_MAINNET_BASE_WS_URL,
 } from '../constants';
+import { FeatureFlags } from '../featureFlags';
 import STORE from '../storageInstance';
 import store from '../store/index';
 import {
@@ -33,6 +34,7 @@ import {
   tokenMetadataUpdated,
   metadataLoaded,
   partiallyUpdateHistoryAndBalance,
+  setUseWalletService,
 } from '../actions/index';
 import {
   helpers,
@@ -52,6 +54,7 @@ import {
 import version from './version';
 import ledger from './ledger';
 import { chunk } from 'lodash';
+import walletHelpers from './helpers';
 
 let Sentry = null;
 // Need to import with window.require in electron (https://github.com/electron/electron/issues/7300)
@@ -340,8 +343,13 @@ const wallet = {
     // then we don't know if we've cleaned up the wallet data in the storage
     // If it's fromXpriv, then we can't clean access data because we need that
     oldWalletUtil.cleanLoadedData({ cleanAccessData: !fromXpriv});
+ 
+    const uniqueDeviceId = walletHelpers.getUniqueId();
+    const featureFlags = new FeatureFlags(uniqueDeviceId, data.network);
+    const useWalletService = await featureFlags.shouldUseWalletService();
 
-    const useWalletService = true;
+    store.dispatch(setUseWalletService(useWalletService));
+
     let wallet;
     let connection;
 

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -35,6 +35,7 @@ import {
   metadataLoaded,
   partiallyUpdateHistoryAndBalance,
   setUseWalletService,
+  lockWalletForResult,
 } from '../actions/index';
 import {
   helpers,
@@ -406,8 +407,13 @@ const wallet = {
         seed: words,
         xpriv,
         xpub,
-        requestPassword: () => {
-        },
+        requestPassword: async () => new Promise((resolve) => {
+          /**
+           * Lock screen will call `resolve` with the pin screen after validation
+           */
+          routerHistory.push('/locked/');
+          store.dispatch(lockWalletForResult(resolve));
+        }),
         passphrase,
         network,
       };

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -341,12 +341,12 @@ const wallet = {
     // This check is important to set the correct network on storage and redux
     const data = await version.checkApiVersion();
 
-    // Fetch metadata of all tokens registered
     const dataToken = tokens.getTokens();
 
     // Before cleaning loaded data we must save in redux what we have of tokens in localStorage
     store.dispatch(reloadData({ tokens: dataToken }));
 
+    // Fetch metadata of all tokens registered
     this.fetchTokensMetadata(dataToken.map((token) => token.uid), data.network);
 
     const uniqueDeviceId = walletHelpers.getUniqueId();

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -156,7 +156,7 @@ const wallet = {
     for (const token of tokens) {
       /* eslint-disable no-await-in-loop */
       // We fetch history count of 5 pages and then we fetch a new page each 'Next' button clicked
-      const history = await wallet.getTxHistory({ token_id: token, count: WALLET_HISTORY_COUNT });
+      const history = await wallet.getTxHistory({ token_id: token, count: 5 * WALLET_HISTORY_COUNT });
       tokensBalance[token] = await this.fetchTokenBalance(wallet, token);
       tokensHistory[token] = history.map((element) => this.mapTokenHistory(element, token));
       /* eslint-enable no-await-in-loop */

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -290,6 +290,15 @@ const wallet = {
     store.dispatch(tokenMetadataUpdated(metadataPerToken, errors));
   },
 
+  /**
+   * Fetches both history and balance for the affected tokens in updatedBalanceMap
+   *
+   * @param {HathorWallet} wallet object
+   * @param {Object} updatedBalanceMap An object containing tokens as the keys and their updated balances as values
+   *
+   * @memberof Wallet
+   * @inner
+   **/
   async handlePartialUpdate (wallet, updatedBalanceMap) {
     const tokens = Object.keys(updatedBalanceMap);
     const tokensHistory = {};

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -377,7 +377,10 @@ const wallet = {
 
     const uniqueDeviceId = walletHelpers.getUniqueId();
     const featureFlags = new FeatureFlags(uniqueDeviceId, data.network);
-    const useWalletService = await featureFlags.shouldUseWalletService();
+    const hardwareWallet = !oldWalletUtil.isSoftwareWallet();
+
+    // For now, the wallet service does not support hardware wallet, so default to the old facade
+    const useWalletService = hardwareWallet ? false : await featureFlags.shouldUseWalletService();
 
     store.dispatch(setUseWalletService(useWalletService));
 

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -661,7 +661,9 @@ const wallet = {
    * @memberof Wallet
    * @inner
    */
-  resetWalletData() {
+  async resetWalletData() {
+    await FeatureFlags.clearIgnoreWalletServiceFlag();
+
     this.cleanWalletRedux();
     oldWalletUtil.resetWalletData();
   },

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -155,27 +155,9 @@ const wallet = {
     // Then for each token we get the balance and history
     for (const token of tokens) {
       /* eslint-disable no-await-in-loop */
-      const balance = await wallet.getBalance(token);
-      const tokenBalance = balance[0].balance;
-      const authorities = balance[0].tokenAuthorities;
-
-      let mint = false;
-      let melt = false;
-
-      if (authorities) {
-        const { unlocked } = authorities;
-        mint = unlocked.mint;
-        melt = unlocked.melt;
-      }
-
-      tokensBalance[token] = {
-        available: tokenBalance.unlocked,
-        locked: tokenBalance.locked,
-        mint,
-        melt,
-      };
       // We fetch history count of 5 pages and then we fetch a new page each 'Next' button clicked
       const history = await wallet.getTxHistory({ token_id: token, count: WALLET_HISTORY_COUNT });
+      tokensBalance[token] = await this.fetchTokenBalance(wallet, token);
       tokensHistory[token] = history.map((element) => this.mapTokenHistory(element, token));
       /* eslint-enable no-await-in-loop */
     }
@@ -315,26 +297,9 @@ const wallet = {
 
     for (const token of tokens) {
       /* eslint-disable no-await-in-loop */
-      const balance = await wallet.getBalance(token);
-      const tokenBalance = balance[0].balance;
-      const authorities = balance[0].tokenAuthorities;
-
-      let mint = false;
-      let melt = false;
-
-      if (authorities) {
-        const { unlocked } = authorities;
-        mint = unlocked.mint;
-        melt = unlocked.melt;
-      }
-
-      tokensBalance[token] = {
-        available: tokenBalance.unlocked,
-        locked: tokenBalance.locked,
-        mint,
-        melt,
-      };
       const history = await wallet.getTxHistory({ token_id: token });
+
+      tokensBalance[token] = await this.fetchTokenBalance(wallet, token);
       tokensHistory[token] = history.map((element) => this.mapTokenHistory(element, token));
       /* eslint-enable no-await-in-loop */
     }

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -759,10 +759,10 @@ const wallet = {
    * @inner
    */
   initSentry(dsn) {
-    /*Sentry.init({
+    Sentry.init({
       dsn: dsn,
       release: process.env.npm_package_version
-    })*/
+    });
   },
 
   /**
@@ -774,7 +774,7 @@ const wallet = {
   updateSentryState() {
     if (this.isSentryAllowed()) {
       // Init Sentry
-      // this.initSentry(SENTRY_DSN);
+      this.initSentry(SENTRY_DSN);
     } else {
       // Turn off Sentry
       this.initSentry('');

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -468,6 +468,11 @@ const wallet = {
     });
 
     wallet.on('update-tx', async (tx) => {
+      // `update-tx` event is not yet being emitted from the wallet-service facade as it is not implemented,
+      // we should ignore this message for now to prevent errors when we start emitting it in the future
+      if (useWalletService) {
+        return;
+      }
       const balances = await wallet.getTxBalance(tx, { includeAuthorities: true });
       const updatedBalanceMap = await this.fetchNewTxTokenBalance(wallet, tx);
       store.dispatch(updateTx(tx, updatedBalanceMap, balances));

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -563,24 +563,6 @@ const wallet = {
   },
 
   /*
-   * Update localStorage and redux when a new tx arrive in the websocket
-   *
-   * @param {Object} data Object with data of the new tx
-   *
-   * @memberof Wallet
-   * @inner
-   */
-  newAddressHistory(data) {
-    const walletData = oldWalletUtil.getWalletData();
-    // Update historyTransactions with new one
-    const historyTransactions = 'historyTransactions' in walletData ? walletData['historyTransactions'] : {};
-    const allTokens = 'allTokens' in walletData ? walletData['allTokens'] : [];
-    oldWalletUtil.updateHistoryData(historyTransactions, allTokens, [data], null, walletData);
-
-    this.afterLoadAddressHistory();
-  },
-
-  /*
    * After load address history we should update redux data
    *
    * @memberof Wallet
@@ -648,84 +630,6 @@ const wallet = {
     const lastSharedIndex = oldWalletUtil.getLastSharedIndex();
     const lastSharedAddress = storage.getItem('wallet:address');
     this.updateSharedAddressRedux(lastSharedAddress, lastSharedIndex);
-  },
-
-  /**
-   * Update address shared in localStorage and redux
-   *
-   * @param {string} lastSharedAddress
-   * @param {number} lastSharedIndex
-   * @memberof Wallet
-   * @inner
-   */
-  updateAddress(lastSharedAddress, lastSharedIndex, updateRedux) {
-    oldWalletUtil.updateAddress(lastSharedAddress, lastSharedIndex);
-    if (updateRedux) {
-      this.updateSharedAddressRedux(lastSharedAddress, lastSharedIndex);
-    }
-  },
-
-  /**
-   * Generate a new address
-   * We update the wallet data and new address shared
-   *
-   * @memberof Wallet
-   * @inner
-   */
-  generateNewAddress() {
-    const { newAddress, newIndex } = oldWalletUtil.generateNewAddress();
-
-    // Save in redux the new shared address
-    this.updateSharedAddressRedux(newAddress.toString(), newIndex);
-
-    return {address: newAddress.toString(), index: newIndex};
-  },
-
-  /**
-   * Get next address after the last shared one (only if it's already generated)
-   * Update the data in localStorage and Redux
-   *
-   * @memberof Wallet
-   * @inner
-   */
-  getNextAddress() {
-    const result = oldWalletUtil.getNextAddress();
-    if (result) {
-      const {address, index} = result;
-      this.updateSharedAddressRedux(address, index);
-      return result;
-    }
-    return null;
-  },
-
-  /**
-   * Get data from localStorage and save to redux
-   *
-   * @return {boolean} if was saved
-   *
-   * @memberof Wallet
-   * @inner
-   */
-  localStorageToRedux() {
-    let data = oldWalletUtil.getWalletData();
-    if (data) {
-      const dataToken = tokens.getTokens();
-      // Saving wallet data
-      store.dispatch(reloadData({
-        historyTransactions: data.historyTransactions || {},
-        allTokens: new Set(data.allTokens || []),
-        tokens: dataToken,
-      }));
-
-      // Saving address data
-      store.dispatch(sharedAddressUpdate({
-        lastSharedAddress: storage.getItem('wallet:address'),
-        lastSharedIndex: oldWalletUtil.getLastSharedIndex(),
-      }));
-      return true;
-    } else {
-      return false;
-    }
   },
 
   /*

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -351,8 +351,7 @@ const wallet = {
 
     const uniqueDeviceId = walletHelpers.getUniqueId();
     const featureFlags = new FeatureFlags(uniqueDeviceId, data.network);
-    const hardwareWallet = !oldWalletUtil.isSoftwareWallet();
-
+    const hardwareWallet = oldWalletUtil.isHardwareWallet();
     // For now, the wallet service does not support hardware wallet, so default to the old facade
     const useWalletService = hardwareWallet ? false : await featureFlags.shouldUseWalletService();
 


### PR DESCRIPTION
## Important points

- To be able to load the wallet from xpriv (that's what the wallet desktop uses after a re-open), we had to start storing a xprivkey on the account level derivation on `localStorage`, this is done on the [wallet-lib PR](https://github.com/HathorNetwork/hathor-wallet-lib/pull/342)
- We are using a random string as the application's unique identifier for Unleash, storing it on local storage to persist it between reloads
- We are only setting the current address on the wallet screen after we reload the addresses after a create token or send token transaction is done. This causes the address to be empty after sending a transaction until this transaction is received from websocket
- We don't yet have a count of authorities coming from the wallet service API so we are displaying a hardcoded value on the administrative tab

## Missing from this PR
- [x] [Tx object is missing version attribute on getTxHistory lambda, causing the transaction history to not display token actions properly (it shows up empty or as “sent” on the “type” column, depending on the token action)](https://github.com/HathorNetwork/hathor-wallet-service/pull/199)
- [X] [We need to return the count of each authority on the wallet service token balance API](https://github.com/HathorNetwork/hathor-wallet/pull/298)
- [X] [The first screen waits until it receives an answer for the /init request before showing load screen, causing the user to be confused wether the command did work or not. Also, clicking multiple times will cause an error](https://github.com/HathorNetwork/hathor-wallet/pull/299)
- [X] [We don't have an API to get a single transaction information, so the wallet desktop is currently querying the full node to fetch token details](https://github.com/HathorNetwork/hathor-wallet-service/pull/202)
- [ ] Change wallet service server (currently hardcoded to main net)
- [x] Token history page size changed from 5 * SIZE to fixed 15 because wallet-service limits it to 15, we should discuss what is best here

### Acceptance Criteria
- Decide which facade to use by requesting our Unleash server
- Load properly when on the wallet service facade
- We should be able to send transactions when on the wallet service facade
- We should be able to mint and melt tokens, delegate authorities and destroy authorities when on the wallet service facade
- We should receive transactions in real-time when on the wallet service facade
- We should get a list of new addresses and those should be updated automatically after they receive a transaction
- We should default to the old facade if using the hardware wallet


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.

