### PR TITLE
feat: get mint melt authority from new facade methods

### DIFF
--- a/src/components/TokenAdministrative.js
+++ b/src/components/TokenAdministrative.js
@@ -98,34 +98,16 @@ class TokenAdministrative extends React.Component {
   /**
    * Update token state after didmount or props update
    */
-  updateWalletInfo = () => {
-    if (!this.props.token || !this.props.token.uid) {
+  updateWalletInfo = async () => {
+    if (!this.props.token && !this.props.token.uid) {
       return;
     }
 
-    const { uid } = this.props.token;
+    const mintUtxos = await this.props.wallet.getMintAuthority(this.props.token.uid, { many: true });
+    const meltUtxos = await this.props.wallet.getMeltAuthority(this.props.token.uid, { many: true });
 
-    let mintCount = 0;
-    let meltCount = 0;
-
-    const tokenBalance = this.props.tokensBalance[uid];
-
-    if (this.props.useWalletService) {
-      // Wallet Service
-      // TODO: This should come from the wallet service and display the count properly
-      const canMintUtxos = tokenBalance.mint;
-      const canMeltUtxos = tokenBalance.melt;
-
-      mintCount = canMintUtxos ? 1 : 0;
-      meltCount = canMeltUtxos ? 1 : 0;
-    } else {
-      // Old Facade
-      const mintUtxos = this.props.wallet.getMintAuthority(this.props.token.uid, { many: true });
-      const meltUtxos = this.props.wallet.getMeltAuthority(this.props.token.uid, { many: true });
-
-      mintCount = mintUtxos ? mintUtxos.length : 0;
-      meltCount = meltUtxos ? meltUtxos.length : 0;
-    }
+    const mintCount = mintUtxos ? mintUtxos.length : 0;
+    const meltCount = meltUtxos ? meltUtxos.length : 0;
 
     const balance = this.props.token.uid in this.props.tokensBalance ? this.props.tokensBalance[this.props.token.uid].available : 0;
 

--- a/src/components/TokenAdministrative.js
+++ b/src/components/TokenAdministrative.js
@@ -106,8 +106,8 @@ class TokenAdministrative extends React.Component {
     const mintUtxos = await this.props.wallet.getMintAuthority(this.props.token.uid, { many: true });
     const meltUtxos = await this.props.wallet.getMeltAuthority(this.props.token.uid, { many: true });
 
-    const mintCount = mintUtxos ? mintUtxos.length : 0;
-    const meltCount = meltUtxos ? meltUtxos.length : 0;
+    const mintCount = mintUtxos.length;
+    const meltCount = meltUtxos.length;
 
     const balance = this.props.token.uid in this.props.tokensBalance ? this.props.tokensBalance[this.props.token.uid].available : 0;
 

--- a/src/screens/Wallet.js
+++ b/src/screens/Wallet.js
@@ -147,12 +147,6 @@ class Wallet extends React.Component {
    * @return {boolean} If should show administrative tab
    */
   shouldShowAdministrativeTab = () => {
-    // Wallet Service
-    if (this.props.useWalletService) {
-      return this.props.tokenBalance.mint || this.props.tokenBalance.melt;
-    }
-
-    // Old facade
     if (this.props.wallet.getMintAuthority(this.props.selectedToken, { skipSpent: false })) {
       return true;
     }

--- a/src/screens/Wallet.js
+++ b/src/screens/Wallet.js
@@ -57,11 +57,13 @@ class Wallet extends React.Component {
   /**
    * backupDone {boolean} if words backup was already done
    * successMessage {string} Message to be shown on alert success
+   * shouldShowAdministrativeTab {boolean} If we should display the Administrative Tools tab
    */
   state = {
     backupDone: true,
     successMessage: '',
     hasTokenSignature: false,
+    shouldShowAdministrativeTab: false,
   };
 
   // Reference for the TokenGeneralInfo component
@@ -91,6 +93,8 @@ class Wallet extends React.Component {
   componentWillReceiveProps(nextProps) {
     const signature = tokens.getTokenSignature(nextProps.selectedToken);
     this.setState({hasTokenSignature: !!signature});
+
+    this.shouldShowAdministrativeTab(nextProps.selectedToken);
   }
 
   /**
@@ -143,19 +147,29 @@ class Wallet extends React.Component {
 
   /*
    * We show the administrative tools tab only for the users that one day had an authority output, even if it was already spent
-   *
-   * @return {boolean} If should show administrative tab
+   * 
+   * This will set the shouldShowAdministrativeTab state param based on the response of getMintAuthority and getMeltAuthority
    */
-  shouldShowAdministrativeTab = () => {
-    if (this.props.wallet.getMintAuthority(this.props.selectedToken, { skipSpent: false })) {
-      return true;
+  shouldShowAdministrativeTab = async (tokenId) => {
+    const mintAuthorities = await this.props.wallet.getMintAuthority(tokenId, { skipSpent: false });
+
+    if (mintAuthorities.length > 0) {
+      return this.setState({
+        shouldShowAdministrativeTab: true,
+      });
     }
 
-    if (this.props.wallet.getMeltAuthority(this.props.selectedToken, { skipSpent: false })) {
-      return true;
+    const meltAuthorities = await this.props.wallet.getMeltAuthority(tokenId, { skipSpent: false });
+
+    if (meltAuthorities.length > 0) {
+      return this.setState({
+        shouldShowAdministrativeTab: true,
+      });
     }
 
-    return false;
+    return this.setState({
+      shouldShowAdministrativeTab: false,
+    });
   }
 
   goToAllAddresses = () => {
@@ -198,7 +212,7 @@ class Wallet extends React.Component {
     }
 
     const renderTabAdmin = () => {
-      if (this.shouldShowAdministrativeTab()) {
+      if (this.state.shouldShowAdministrativeTab) {
         return (
             <li className="nav-item">
               <a className="nav-link" id="administrative-tab" data-toggle="tab" href="#administrative" role="tab" aria-controls="administrative" aria-selected="false">{t`Administrative Tools`}</a>
@@ -210,7 +224,7 @@ class Wallet extends React.Component {
     }
 
     const renderContentAdmin = () => {
-      if (this.shouldShowAdministrativeTab()) {
+      if (this.state.shouldShowAdministrativeTab) {
         return (
           <div className="tab-pane fade" id="administrative" role="tabpanel" aria-labelledby="administrative-tab">
             <TokenAdministrative key={this.props.selectedToken} token={token} ref={this.administrativeRef} />

--- a/src/screens/Wallet.js
+++ b/src/screens/Wallet.js
@@ -94,7 +94,11 @@ class Wallet extends React.Component {
     const signature = tokens.getTokenSignature(nextProps.selectedToken);
     this.setState({hasTokenSignature: !!signature});
 
-    this.shouldShowAdministrativeTab(nextProps.selectedToken);
+    // This will be called everytime the props are updated, so check if
+    // the selected token changed
+    if (this.props.selectedToken !== nextProps.selectedToken) {
+      this.shouldShowAdministrativeTab(nextProps.selectedToken);
+    }
   }
 
   /**


### PR DESCRIPTION
## Motivation

The wallet-service did not have the `getMintAuthority` and `getMeltAuthority` methods, they have been added on **this PR**, so this PR is the implementation of those methods on the wallet-desktop

### Acceptance Criteria
- We should use the `getMintAuthority` and `getMeltAuthority` from the [new normalized method on both facades](https://github.com/HathorNetwork/hathor-wallet-lib/pull/344)

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
