### PR TITLE
feat: loading on locked wallet button

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -450,6 +450,10 @@ svg.svg-wrapper {
   color: white;
 }
 
+.btn-hathor-loading-wrapper > .loading {
+  margin-right: 6px;
+}
+
 .settings hr {
   margin: 3rem 0;
 }

--- a/src/screens/LockedWallet.js
+++ b/src/screens/LockedWallet.js
@@ -13,7 +13,9 @@ import $ from 'jquery';
 import wallet from '../utils/wallet';
 import RequestErrorModal from '../components/RequestError';
 import hathorLib from '@hathor/wallet-lib';
+import ReactLoading from 'react-loading';
 import { resolveLockWalletPromise } from '../actions';
+import colors from '../index.scss';
 
 
 const mapStateToProps = (state) => {
@@ -41,7 +43,8 @@ class LockedWallet extends React.Component {
      * errorMessage {string} Message to be shown in case of error in modal
      */
     this.state = {
-      errorMessage: ''
+      errorMessage: '',
+      loading: false,
     }
   }
 
@@ -59,6 +62,11 @@ class LockedWallet extends React.Component {
    */
   unlockClicked = (e) => {
     e.preventDefault();
+
+    if (this.state.loading) {
+      return;
+    }
+
     const isValid = this.refs.unlockForm.checkValidity();
     if (isValid) {
       const pin = this.refs.pin.value;
@@ -77,11 +85,19 @@ class LockedWallet extends React.Component {
         return;
       }
 
+      this.setState({
+        loading: true,
+      });
+
       // The last parameter being true means that we are going to start the wallet from an xpriv
       // that's already in localStorage encrypted. Because of that we don't need to send the
       // seed (first parameter) neither the password (second parameter).
       const promise = wallet.startWallet(null, '', pin, '', this.props.history, true);
+
       promise.then(() => {
+        this.setState({
+          loading: false,
+        });
         this.props.history.push('/wallet/');
       });
     } else {
@@ -120,7 +136,13 @@ class LockedWallet extends React.Component {
             {this.state.errorMessage && <p className="mt-4 text-danger">{this.state.errorMessage}</p>}
             <div className="d-flex align-items-center justify-content-between flex-row w-100 mt-4">
               <a className="mt-4" onClick={(e) => this.resetClicked(e)} href="true">{t`Reset all data`}</a>
-              <button onClick={this.unlockClicked} type="button" className="btn btn-hathor">{t`Unlock`}</button>
+              <button onClick={this.unlockClicked} type="button" className="btn btn-hathor">
+                {
+                  this.state.loading ?
+                  <ReactLoading type='spin' width={24} height={24} /> :
+                  t`Unlock`
+                }
+              </button>
             </div>
           </div>
         </div>

--- a/src/screens/LockedWallet.js
+++ b/src/screens/LockedWallet.js
@@ -15,6 +15,7 @@ import RequestErrorModal from '../components/RequestError';
 import hathorLib from '@hathor/wallet-lib';
 import ReactLoading from 'react-loading';
 import { resolveLockWalletPromise } from '../actions';
+import colors from '../index.scss'
 
 
 const mapStateToProps = (state) => {
@@ -135,13 +136,18 @@ class LockedWallet extends React.Component {
             {this.state.errorMessage && <p className="mt-4 text-danger">{this.state.errorMessage}</p>}
             <div className="d-flex align-items-center justify-content-between flex-row w-100 mt-4">
               <a className="mt-4" onClick={(e) => this.resetClicked(e)} href="true">{t`Reset all data`}</a>
-              <button onClick={this.unlockClicked} type="button" className="btn btn-hathor">
-                {
-                  this.state.loading ?
-                  <ReactLoading type='spin' width={24} height={24} /> :
-                  t`Unlock`
-                }
-              </button>
+              <div className="d-flex align-items-center justify-content-between btn-hathor-loading-wrapper">
+                {this.state.loading && (
+                  <ReactLoading color={colors.purpleHathor} type='spin' width={24} height={24} className="loading" />
+                )}
+                <button
+                  onClick={this.unlockClicked}
+                  type="button"
+                  className="btn btn-hathor"
+                  disabled={this.state.loading}>
+                  {t`Unlock`}
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/src/screens/LockedWallet.js
+++ b/src/screens/LockedWallet.js
@@ -15,7 +15,6 @@ import RequestErrorModal from '../components/RequestError';
 import hathorLib from '@hathor/wallet-lib';
 import ReactLoading from 'react-loading';
 import { resolveLockWalletPromise } from '../actions';
-import colors from '../index.scss';
 
 
 const mapStateToProps = (state) => {


### PR DESCRIPTION
## Motivation

Currently, we allow the user to click multiple times on the "Unlock" button on the LockedWallet screen, this causes the app to trigger multiple requests when on the wallet-service facade.


https://user-images.githubusercontent.com/3586068/163487704-df08402b-f8bc-42ef-b3c0-24e8898d6916.mov


### Acceptance Criteria
- The Locked Wallet screen should display a loading on the Unlock button and prevent multiple calls to `startWallet` if the user presses the button multiple times


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
