### PR TITLE
feat: wallet service token details

### DIFF
--- a/src/components/TokenAdministrative.js
+++ b/src/components/TokenAdministrative.js
@@ -82,17 +82,20 @@ class TokenAdministrative extends React.Component {
   /**
    * Upadte token info getting data from the full node (can mint, can melt, total supply)
    */
-  updateTokenInfo = () => {
+  updateTokenInfo = async () => {
     this.setState({ errorMessage: '' });
-    hathorLib.walletApi.getGeneralTokenInfo(this.props.token.uid, (response) => {
-      if (response.success) {
-        this.setState({
-          totalSupply: response.total,
-        });
-      } else {
-        this.setState({ errorMessage: response.message });
-      }
-    });
+
+    try {
+      const tokenDetails = await this.props.wallet.getTokenDetails(this.props.token.uid);
+      this.setState({
+        totalSupply: tokenDetails.total,
+        canMint: tokenDetails.mint.length > 0,
+        canMelt: tokenDetails.melt.length > 0,
+        transactionsCount: tokenDetails.transactions_count,
+      });
+    } catch (e) {
+      this.setState({ errorMessage: e.message });
+    }
   }
 
   /**

--- a/src/components/TokenAdministrative.js
+++ b/src/components/TokenAdministrative.js
@@ -80,18 +80,20 @@ class TokenAdministrative extends React.Component {
   }
 
   /**
-   * Upadte token info getting data from the full node (can mint, can melt, total supply)
+   * Update token info getting data from the full node (can mint, can melt, total supply)
    */
   updateTokenInfo = async () => {
     this.setState({ errorMessage: '' });
 
     try {
       const tokenDetails = await this.props.wallet.getTokenDetails(this.props.token.uid);
+      const { totalSupply, totalTransactions, authorities } = tokenDetails;
+
       this.setState({
-        totalSupply: tokenDetails.total,
-        canMint: tokenDetails.mint.length > 0,
-        canMelt: tokenDetails.melt.length > 0,
-        transactionsCount: tokenDetails.transactions_count,
+        totalSupply,
+        canMint: authorities.mint,
+        canMelt: authorities.melt,
+        transactionsCount: totalTransactions,
       });
     } catch (e) {
       this.setState({ errorMessage: e.message });

--- a/src/components/TokenAdministrative.js
+++ b/src/components/TokenAdministrative.js
@@ -80,7 +80,7 @@ class TokenAdministrative extends React.Component {
   }
 
   /**
-   * Update token info getting data from the full node (can mint, can melt, total supply)
+   * Update token info getting data from the facade (can mint, can melt, total supply, total transactions)
    */
   updateTokenInfo = async () => {
     this.setState({ errorMessage: '' });

--- a/src/components/TokenGeneralInfo.js
+++ b/src/components/TokenGeneralInfo.js
@@ -64,11 +64,13 @@ class TokenGeneralInfo extends React.Component {
 
     try {
       const tokenDetails = await this.props.wallet.getTokenDetails(this.props.token.uid);
+      const { totalSupply, totalTransactions, authorities } = tokenDetails;
+
       this.setState({
-        totalSupply: tokenDetails.total,
-        canMint: tokenDetails.mint.length > 0,
-        canMelt: tokenDetails.melt.length > 0,
-        transactionsCount: tokenDetails.transactions_count,
+        totalSupply,
+        canMint: authorities.mint,
+        canMelt: authorities.melt,
+        transactionsCount: totalTransactions,
       });
     } catch (e) {
       this.setState({ errorMessage: e.message });

--- a/src/components/TokenGeneralInfo.js
+++ b/src/components/TokenGeneralInfo.js
@@ -20,6 +20,7 @@ import { get } from 'lodash';
 const mapStateToProps = (state) => {
   return {
     tokenMetadata: state.tokenMetadata,
+    wallet: state.wallet,
   };
 };
 
@@ -58,20 +59,20 @@ class TokenGeneralInfo extends React.Component {
   /**
    * Upadte token info getting data from the full node (can mint, can melt, total supply)
    */
-  updateTokenInfo = () => {
+  updateTokenInfo = async () => {
     this.setState({ errorMessage: '' });
-    hathorLib.walletApi.getGeneralTokenInfo(this.props.token.uid, (response) => {
-      if (response.success) {
-        this.setState({
-          totalSupply: response.total,
-          canMint: response.mint.length > 0,
-          canMelt: response.melt.length > 0,
-          transactionsCount: response.transactions_count,
-        });
-      } else {
-        this.setState({ errorMessage: response.message });
-      }
-    });
+
+    try {
+      const tokenDetails = await this.props.wallet.getTokenDetails(this.props.token.uid);
+      this.setState({
+        totalSupply: tokenDetails.total,
+        canMint: tokenDetails.mint.length > 0,
+        canMelt: tokenDetails.melt.length > 0,
+        transactionsCount: tokenDetails.transactions_count,
+      });
+    } catch (e) {
+      this.setState({ errorMessage: e.message });
+    }
   }
 
   /**

--- a/src/components/TokenGeneralInfo.js
+++ b/src/components/TokenGeneralInfo.js
@@ -57,7 +57,7 @@ class TokenGeneralInfo extends React.Component {
   }
 
   /**
-   * Upadte token info getting data from the full node (can mint, can melt, total supply)
+   * Update token info getting data from the facade (can mint, can melt, total supply and total transactions)
    */
   updateTokenInfo = async () => {
     this.setState({ errorMessage: '' });

--- a/src/screens/LockedWallet.js
+++ b/src/screens/LockedWallet.js
@@ -15,7 +15,7 @@ import RequestErrorModal from '../components/RequestError';
 import hathorLib from '@hathor/wallet-lib';
 import ReactLoading from 'react-loading';
 import { resolveLockWalletPromise } from '../actions';
-import colors from '../index.scss'
+import colors from '../index.scss';
 
 
 const mapStateToProps = (state) => {


### PR DESCRIPTION
## Motivation

Currently, our wallet desktop is querying the fullnode for token details, we should use the same method on both facades to query this information from the wallet-service (if on the facade) or the full-node. This new method [has been created on the wallet-lib](https://github.com/HathorNetwork/hathor-wallet-lib/pull/345) to utilize the token info API, [created on the wallet-service](https://github.com/HathorNetwork/hathor-wallet-service/pull/202)

### Acceptance Criteria
- The wallet desktop should query the wallet service for token details when on the wallet service facade
- The wallet desktop should use the `getTokenDetails` method from the wallet facades to query token information


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
