### PR TITLE
refactor: revert tx history size initial download

### DIFF
--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -156,7 +156,7 @@ const wallet = {
     for (const token of tokens) {
       /* eslint-disable no-await-in-loop */
       // We fetch history count of 5 pages and then we fetch a new page each 'Next' button clicked
-      const history = await wallet.getTxHistory({ token_id: token, count: WALLET_HISTORY_COUNT });
+      const history = await wallet.getTxHistory({ token_id: token, count: 5 * WALLET_HISTORY_COUNT });
       tokensBalance[token] = await this.fetchTokenBalance(wallet, token);
       tokensHistory[token] = history.map((element) => this.mapTokenHistory(element, token));
       /* eslint-enable no-await-in-loop */


### PR DESCRIPTION
# Motivation

To avoid doing multiple requests to the `tx_history` API, we should download more transactions from the transaction history API 

### Acceptance Criteria
- After https://github.com/HathorNetwork/hathor-wallet-service/pull/208 is merged, we should be able to request 50 transactions from the tx history API



### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
