### PR TITLE
feat: option to hide zero-balance tokens

### DIFF
--- a/locale/texts.pot
+++ b/locale/texts.pot
@@ -112,7 +112,7 @@ msgid "Confirm"
 msgstr ""
 
 #: src/screens/ChoosePassphrase.js:161
-#: src/screens/Settings.js:208
+#: src/screens/Settings.js:266
 msgid "Set a passphrase"
 msgstr ""
 
@@ -375,7 +375,7 @@ msgstr ""
 
 #: src/components/ModalResetAllData.js:113
 #: src/screens/LockedWallet.js:138
-#: src/screens/Settings.js:210
+#: src/screens/Settings.js:268
 msgid "Reset all data"
 msgstr ""
 
@@ -638,99 +638,128 @@ msgstr ""
 msgid "Cancel change"
 msgstr ""
 
-#: src/screens/Settings.js:112
+#: src/screens/Settings.js:116
 msgid "Turn notifications off"
 msgstr ""
 
-#: src/screens/Settings.js:113
+#: src/screens/Settings.js:117
 msgid "Are you sure you don't want to receive wallet notifications?"
 msgstr ""
 
-#: src/screens/Settings.js:120
+#: src/screens/Settings.js:124
 msgid "Turn notifications on"
 msgstr ""
 
-#: src/screens/Settings.js:121
+#: src/screens/Settings.js:125
 msgid "Are you sure you want to receive wallet notifications?"
 msgstr ""
 
-#: src/screens/Settings.js:185
+#: src/screens/Settings.js:144
+msgid "Show zero-balance tokens"
+msgstr ""
+
+#: src/screens/Settings.js:145
+msgid "Are you sure you want to show all tokens, including those with zero balance?"
+msgstr ""
+
+#: src/screens/Settings.js:152
+msgid "Hide zero-balance tokens"
+msgstr ""
+
+#: src/screens/Settings.js:153
+msgid "Are you sure you want to hide tokens with zero balance?"
+msgstr ""
+
+#: src/screens/Settings.js:232
 msgid "Date and time:"
 msgstr ""
 
-#: src/screens/Settings.js:188
+#: src/screens/Settings.js:235
 #, javascript-format
 msgid "**Server:** You are connected to ${ serverURL }"
 msgstr ""
 
-#: src/screens/Settings.js:191
+#: src/screens/Settings.js:238
 msgid "**Real-time server:** You are connected to ${ wsServerURL }"
 msgstr ""
 
 #: src/components/RequestError.js:184
-#: src/screens/Settings.js:194
+#: src/screens/Settings.js:241
 msgid "Change server"
 msgstr ""
 
-#: src/screens/Settings.js:199
+#: src/screens/Settings.js:246
 msgid "Advanced Settings"
 msgstr ""
 
-#: src/screens/Settings.js:201
+#: src/screens/Settings.js:248
 msgid "Allow notifications:"
 msgstr ""
 
 #: src/components/ModalResetAllData.js:147
-#: src/screens/Settings.js:201
-#: src/screens/Settings.js:202
+#: src/screens/Settings.js:248
+#: src/screens/Settings.js:252
+#: src/screens/Settings.js:260
 msgid "Yes"
 msgstr ""
 
 #: src/components/ModalResetAllData.js:146
-#: src/screens/Settings.js:201
-#: src/screens/Settings.js:202
+#: src/screens/Settings.js:248
+#: src/screens/Settings.js:253
+#: src/screens/Settings.js:260
 msgid "No"
 msgstr ""
 
-#: src/screens/Settings.js:201
-#: src/screens/Settings.js:202
+#: src/screens/Settings.js:248
+#: src/screens/Settings.js:255
+#: src/screens/Settings.js:260
 msgid "Change"
 msgstr ""
 
-#: src/screens/Settings.js:202
+#: src/screens/Settings.js:250
+msgid "Hide zero-balance tokens:"
+msgstr ""
+
+#: src/screens/Settings.js:257
+msgid ""
+"When selected, any tokens with a balance of zero will not be displayed "
+"anywhere in the wallet."
+msgstr ""
+
+#: src/screens/Settings.js:260
 msgid "Automatically report bugs to Hathor:"
 msgstr ""
 
-#: src/screens/Settings.js:205
+#: src/screens/Settings.js:263
 msgid "Unique identifier"
 msgstr ""
 
 #: src/components/ModalAddressQRCode.js:93
 #: src/components/TokenGeneralInfo.js:160
 #: src/components/WalletAddress.js:153
-#: src/screens/Settings.js:205
+#: src/screens/Settings.js:263
 msgid "Copy to clipboard"
 msgstr ""
 
-#: src/screens/Settings.js:209
+#: src/screens/Settings.js:267
 msgid "Untrust all tokens on Ledger"
 msgstr ""
 
-#: src/screens/Settings.js:216
+#: src/screens/Settings.js:274
 msgid "Complete action on your hardware wallet"
 msgstr ""
 
-#: src/screens/Settings.js:218
+#: src/screens/Settings.js:276
 msgid "You can set your passphrase directly on your hardware wallet."
 msgstr ""
 
-#: src/screens/Settings.js:220
+#: src/screens/Settings.js:278
 msgid "|fn:More info| about this on Ledger."
 msgstr ""
 
 #: src/components/TxData.js:730
 #: src/components/WalletAddress.js:182
-#: src/screens/Settings.js:225
+#: src/screens/Settings.js:283
 msgid "Copied to clipboard!"
 msgstr ""
 
@@ -761,44 +790,44 @@ msgid "See on explorer"
 msgstr ""
 
 #: src/components/WalletBalance.js:44
-#: src/screens/UnknownTokens.js:142
+#: src/screens/UnknownTokens.js:152
 msgid "Total:"
 msgstr ""
 
 #: src/components/WalletBalance.js:45
-#: src/screens/UnknownTokens.js:143
+#: src/screens/UnknownTokens.js:153
 msgid "Available:"
 msgstr ""
 
 #: src/components/WalletBalance.js:46
-#: src/screens/UnknownTokens.js:144
+#: src/screens/UnknownTokens.js:154
 msgid "Locked:"
 msgstr ""
 
-#: src/screens/UnknownTokens.js:148
+#: src/screens/UnknownTokens.js:158
 msgid "Show history"
 msgstr ""
 
-#: src/screens/UnknownTokens.js:149
+#: src/screens/UnknownTokens.js:159
 msgid "Hide history"
 msgstr ""
 
-#: src/screens/UnknownTokens.js:165
+#: src/screens/UnknownTokens.js:175
 msgid "Unknown Tokens"
 msgstr ""
 
-#: src/screens/UnknownTokens.js:166
+#: src/screens/UnknownTokens.js:176
 msgid "Register Tokens"
 msgstr ""
 
-#: src/screens/UnknownTokens.js:168
+#: src/screens/UnknownTokens.js:178
 msgid ""
 "Those are the custom tokens which you have at least one transaction. They "
 "are still unregistered in this wallet. You need to register a custom token "
 "in order to send new transactions using it."
 msgstr ""
 
-#: src/screens/UnknownTokens.js:169
+#: src/screens/UnknownTokens.js:179
 msgid ""
 "If you have reset your wallet, you need to register your custom tokens "
 "again."
@@ -1593,17 +1622,17 @@ msgstr ""
 msgid "Your balance available:"
 msgstr ""
 
-#: src/components/TokenBar.js:142
+#: src/components/TokenBar.js:165
 msgid "Tokens"
 msgstr ""
 
-#: src/components/TokenBar.js:170
-#: src/components/TokenBar.js:171
+#: src/components/TokenBar.js:193
+#: src/components/TokenBar.js:194
 msgid "Lock wallet"
 msgstr ""
 
-#: src/components/TokenBar.js:174
-#: src/components/TokenBar.js:175
+#: src/components/TokenBar.js:197
+#: src/components/TokenBar.js:198
 msgid "Settings"
 msgstr ""
 

--- a/locale/texts.pot
+++ b/locale/texts.pot
@@ -281,11 +281,11 @@ msgstr ""
 msgid "Token ${ _this.state.name } created"
 msgstr ""
 
-#: src/screens/CustomTokens.js:68
+#: src/screens/CustomTokens.js:79
 msgid "Custom Tokens"
 msgstr ""
 
-#: src/screens/CustomTokens.js:69
+#: src/screens/CustomTokens.js:80
 msgid ""
 "You can create your own digital token with customized specifications on "
 "Hathor Network with only a few clicks. They will fully work under the same "
@@ -294,13 +294,13 @@ msgid ""
 "price of the native HTR token, and they can serve multiple purposes."
 msgstr ""
 
-#: src/screens/CustomTokens.js:70
+#: src/screens/CustomTokens.js:81
 msgid ""
 "Every custom token has a unique **Configuration String** which must be "
 "shared with all other people that will use the custom token."
 msgstr ""
 
-#: src/screens/CustomTokens.js:71
+#: src/screens/CustomTokens.js:82
 msgid ""
 "If you want to use a custom token that already exists, you need to register "
 "this token in your Hathor Wallet. For this, you will need the custom "
@@ -308,19 +308,19 @@ msgid ""
 "token."
 msgstr ""
 
-#: src/screens/CustomTokens.js:73
+#: src/screens/CustomTokens.js:84
 msgid "Create a new token"
 msgstr ""
 
-#: src/screens/CustomTokens.js:74
+#: src/screens/CustomTokens.js:85
 msgid "Create an NFT"
 msgstr ""
 
-#: src/screens/CustomTokens.js:75
+#: src/screens/CustomTokens.js:86
 msgid "Register a token"
 msgstr ""
 
-#: src/screens/CustomTokens.js:78
+#: src/screens/CustomTokens.js:89
 msgid "Token registered with success!"
 msgstr ""
 
@@ -437,7 +437,7 @@ msgid "Backup now"
 msgstr ""
 
 #: src/screens/NewWallet.js:208
-#: src/screens/Wallet.js:121
+#: src/screens/Wallet.js:122
 msgid "Backup completed!"
 msgstr ""
 
@@ -697,6 +697,7 @@ msgid "Allow notifications:"
 msgstr ""
 
 #: src/components/ModalResetAllData.js:147
+#: src/components/TokenGeneralInfo.js:205
 #: src/screens/Settings.js:248
 #: src/screens/Settings.js:252
 #: src/screens/Settings.js:260
@@ -704,12 +705,14 @@ msgid "Yes"
 msgstr ""
 
 #: src/components/ModalResetAllData.js:146
+#: src/components/TokenGeneralInfo.js:206
 #: src/screens/Settings.js:248
 #: src/screens/Settings.js:253
 #: src/screens/Settings.js:260
 msgid "No"
 msgstr ""
 
+#: src/components/TokenGeneralInfo.js:208
 #: src/screens/Settings.js:248
 #: src/screens/Settings.js:255
 #: src/screens/Settings.js:260
@@ -735,7 +738,7 @@ msgid "Unique identifier"
 msgstr ""
 
 #: src/components/ModalAddressQRCode.js:93
-#: src/components/TokenGeneralInfo.js:160
+#: src/components/TokenGeneralInfo.js:225
 #: src/components/WalletAddress.js:153
 #: src/screens/Settings.js:263
 msgid "Copy to clipboard"
@@ -853,52 +856,52 @@ msgstr ""
 msgid "Change Server"
 msgstr ""
 
-#: src/screens/Wallet.js:189
+#: src/screens/Wallet.js:192
 msgid ""
 "You haven't done the backup of your wallet yet. You should do it as soon as "
 "possible for your own safety."
 msgstr ""
 
-#: src/screens/Wallet.js:189
+#: src/screens/Wallet.js:192
 msgid "Do it now"
 msgstr ""
 
-#: src/screens/Wallet.js:222
+#: src/screens/Wallet.js:225
 msgid "Administrative Tools"
 msgstr ""
 
-#: src/screens/Wallet.js:250
+#: src/screens/Wallet.js:253
 msgid "Balance & History"
 msgstr ""
 
-#: src/screens/Wallet.js:253
+#: src/screens/Wallet.js:256
 #, javascript-format
 msgid "About ${ token.name }"
 msgstr ""
 
-#: src/screens/Wallet.js:276
+#: src/screens/Wallet.js:279
 #, javascript-format
 msgid ""
 "Are you sure you want to unregister the token **${ token.name } (${ "
 "token.symbol })**?"
 msgstr ""
 
-#: src/screens/Wallet.js:277
+#: src/screens/Wallet.js:280
 msgid ""
 "You won't lose your tokens, you just won't see this token on the side bar "
 "anymore."
 msgstr ""
 
-#: src/screens/Wallet.js:288
+#: src/screens/Wallet.js:291
 msgid "Sign token on Ledger"
 msgstr ""
 
-#: src/screens/Wallet.js:289
+#: src/screens/Wallet.js:292
 msgid "Token signed with Ledger"
 msgstr ""
 
-#: src/screens/Wallet.js:298
-#: src/screens/Wallet.js:328
+#: src/screens/Wallet.js:301
+#: src/screens/Wallet.js:331
 msgid "Unregister token"
 msgstr ""
 
@@ -1058,40 +1061,57 @@ msgid "Previous"
 msgstr ""
 
 #: src/components/LedgerSignTokenInfo.js:21
-#: src/components/TokenGeneralInfo.js:138
+#: src/components/TokenGeneralInfo.js:192
 msgid "UID:"
 msgstr ""
 
 #: src/components/LedgerSignTokenInfo.js:31
-#: src/components/TokenGeneralInfo.js:141
+#: src/components/TokenGeneralInfo.js:195
 msgid "Symbol:"
 msgstr ""
 
 #: src/components/LedgerSignTokenInfo.js:32
-#: src/components/TokenGeneralInfo.js:140
+#: src/components/TokenGeneralInfo.js:194
 msgid "Name:"
 msgstr ""
 
-#: src/components/ModalAddManyTokens.js:52
+#: src/components/ModalAddManyTokens.js:79
 msgid "Must provide configuration string"
 msgstr ""
 
-#: src/components/ModalAddManyTokens.js:91
+#: src/components/ModalAddManyTokens.js:143
+msgid ""
+"The following tokens have no balance on your wallet and you have the \"hide "
+"zero-balance tokens\" settings on.\n"
+"Do you wish to always show these tokens? (You can always undo this on the "
+"token info screen.)"
+msgstr ""
+
+#: src/components/ModalAddManyTokens.js:169
+msgid "Always show these tokens"
+msgstr ""
+
+#: src/components/ModalAddManyTokens.js:172
+#: src/components/TokenGeneralInfo.js:210
+msgid "If selected, it will overwrite the \"Hide zero-balance tokens\" settings."
+msgstr ""
+
+#: src/components/ModalAddManyTokens.js:194
 msgid "Register Custom Tokens"
 msgstr ""
 
-#: src/components/ModalAddManyTokens.js:97
+#: src/components/ModalAddManyTokens.js:200
 msgid ""
 "You can register one or more tokens writing the configuration string of "
 "each one below."
 msgstr ""
 
-#: src/components/ModalAddManyTokens.js:100
+#: src/components/ModalAddManyTokens.js:204
 msgid "Configuration strings"
 msgstr ""
 
-#: src/components/ModalAddManyTokens.js:112
-#: src/components/ModalAddToken.js:91
+#: src/components/ModalAddManyTokens.js:219
+#: src/components/ModalAddToken.js:171
 #: src/components/ModalBackupWords.js:201
 #: src/components/ModalEditToken.js:95
 #: src/components/ModalSendTx.js:196
@@ -1100,26 +1120,44 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/components/ModalAddManyTokens.js:113
-#: src/components/ModalAddToken.js:92
+#: src/components/ModalAddManyTokens.js:220
+#: src/components/ModalAddToken.js:172
 msgid "Register"
 msgstr ""
 
-#: src/components/ModalAddToken.js:51
+#: src/components/ModalAddToken.js:76
 msgid "Must provide configuration string or uid, name, and symbol"
 msgstr ""
 
-#: src/components/ModalAddToken.js:70
+#: src/components/ModalAddToken.js:101
+msgid ""
+"This token has no balance on your wallet and you have the \"hide "
+"zero-balance tokens\" settings on.\n"
+"Do you wish to always show this token? (You can always undo this on the "
+"token info screen.)"
+msgstr ""
+
+#: src/components/ModalAddToken.js:122
+msgid "Always show this token"
+msgstr ""
+
+#: src/components/ModalAddToken.js:125
+msgid ""
+"If selected, it will overwrite the \"Hide zero-balance tokens\" settings "
+"for this token."
+msgstr ""
+
+#: src/components/ModalAddToken.js:146
 msgid "Register a new token"
 msgstr ""
 
-#: src/components/ModalAddToken.js:76
+#: src/components/ModalAddToken.js:152
 msgid ""
 "To register a token that already exists, just write down its configuration "
 "string"
 msgstr ""
 
-#: src/components/ModalAddToken.js:79
+#: src/components/ModalAddToken.js:156
 msgid "Configuration string"
 msgstr ""
 
@@ -1135,7 +1173,7 @@ msgstr ""
 
 #: src/components/ModalAddressQRCode.js:96
 #: src/components/ModalAddressQRCode.js:101
-#: src/components/TokenGeneralInfo.js:164
+#: src/components/TokenGeneralInfo.js:229
 msgid "Download"
 msgstr ""
 
@@ -1614,7 +1652,7 @@ msgid "Melt authority management"
 msgstr ""
 
 #: src/components/TokenAdministrative.js:242
-#: src/components/TokenGeneralInfo.js:142
+#: src/components/TokenGeneralInfo.js:196
 msgid "Total supply:"
 msgstr ""
 
@@ -1622,59 +1660,84 @@ msgstr ""
 msgid "Your balance available:"
 msgstr ""
 
-#: src/components/TokenBar.js:165
+#: src/components/TokenBar.js:164
 msgid "Tokens"
 msgstr ""
 
+#: src/components/TokenBar.js:192
 #: src/components/TokenBar.js:193
-#: src/components/TokenBar.js:194
 msgid "Lock wallet"
 msgstr ""
 
+#: src/components/TokenBar.js:196
 #: src/components/TokenBar.js:197
-#: src/components/TokenBar.js:198
 msgid "Settings"
 msgstr ""
 
-#: src/components/TokenGeneralInfo.js:111
+#: src/components/TokenGeneralInfo.js:107
+msgid "Disable always show"
+msgstr ""
+
+#: src/components/TokenGeneralInfo.js:108
+#, javascript-format
+msgid ""
+"Are you sure you don't want to always show token ${ "
+"_this.props.token.symbol }? If you continue you won't see this token if it "
+"has zero balance and you selected to hide zero balance tokens."
+msgstr ""
+
+#: src/components/TokenGeneralInfo.js:115
+msgid "Enable always show"
+msgstr ""
+
+#: src/components/TokenGeneralInfo.js:116
+#, javascript-format
+msgid "Are you sure you want to always show token ${ _this.props.token.symbol }?"
+msgstr ""
+
+#: src/components/TokenGeneralInfo.js:165
 #.  If copied with success
 msgid "Configuration string copied to clipboard!"
 msgstr ""
 
-#: src/components/TokenGeneralInfo.js:139
+#: src/components/TokenGeneralInfo.js:193
 #: src/components/TxData.js:666
 msgid "Type:"
 msgstr ""
 
-#: src/components/TokenGeneralInfo.js:143
+#: src/components/TokenGeneralInfo.js:197
 msgid "Can mint new tokens:"
 msgstr ""
 
-#: src/components/TokenGeneralInfo.js:144
+#: src/components/TokenGeneralInfo.js:198
 msgid ""
 "Indicates whether the token owner can create new tokens, increasing the "
 "total supply"
 msgstr ""
 
-#: src/components/TokenGeneralInfo.js:145
+#: src/components/TokenGeneralInfo.js:199
 msgid "Can melt tokens:"
 msgstr ""
 
-#: src/components/TokenGeneralInfo.js:146
+#: src/components/TokenGeneralInfo.js:200
 msgid ""
 "Indicates whether the token owner can destroy tokens, decreasing the total "
 "supply"
 msgstr ""
 
-#: src/components/TokenGeneralInfo.js:147
+#: src/components/TokenGeneralInfo.js:201
 msgid "Total number of transactions:"
 msgstr ""
 
-#: src/components/TokenGeneralInfo.js:156
+#: src/components/TokenGeneralInfo.js:203
+msgid "Always show this token:"
+msgstr ""
+
+#: src/components/TokenGeneralInfo.js:221
 msgid "Configuration String"
 msgstr ""
 
-#: src/components/TokenGeneralInfo.js:164
+#: src/components/TokenGeneralInfo.js:229
 msgid "Download QRCode"
 msgstr ""
 

--- a/locale/texts.pot
+++ b/locale/texts.pot
@@ -112,7 +112,7 @@ msgid "Confirm"
 msgstr ""
 
 #: src/screens/ChoosePassphrase.js:161
-#: src/screens/Settings.js:227
+#: src/screens/Settings.js:255
 msgid "Set a passphrase"
 msgstr ""
 
@@ -375,7 +375,7 @@ msgstr ""
 
 #: src/components/ModalResetAllData.js:113
 #: src/screens/LockedWallet.js:138
-#: src/screens/Settings.js:229
+#: src/screens/Settings.js:257
 msgid "Reset all data"
 msgstr ""
 
@@ -634,92 +634,108 @@ msgstr ""
 msgid "Are you sure you want to receive wallet notifications?"
 msgstr ""
 
-#: src/screens/Settings.js:198
+#: src/screens/Settings.js:138
+msgid "Show zero-balance tokens"
+msgstr ""
+
+#: src/screens/Settings.js:139
+msgid "Are you sure you want to show all tokens, including those with zero balance?"
+msgstr ""
+
+#: src/screens/Settings.js:146
+msgid "Hide zero-balance tokens"
+msgstr ""
+
+#: src/screens/Settings.js:147
+msgid "Are you sure you want to hide tokens with zero balance?"
+msgstr ""
+
+#: src/screens/Settings.js:226
 msgid "Date and time:"
 msgstr ""
 
-#: src/screens/Settings.js:201
+#: src/screens/Settings.js:229
 #, javascript-format
 msgid "**Server:** You are connected to ${ serverURL }"
 msgstr ""
 
 #: src/components/RequestError.js:184
-#: src/screens/Settings.js:202
+#: src/screens/Settings.js:230
 msgid "Change server"
 msgstr ""
 
-#: src/screens/Settings.js:207
+#: src/screens/Settings.js:235
 msgid "Advanced Settings"
 msgstr ""
 
-#: src/screens/Settings.js:209
+#: src/screens/Settings.js:237
 msgid "Allow notifications:"
 msgstr ""
 
 #: src/components/ModalResetAllData.js:147
-#: src/screens/Settings.js:209
-#: src/screens/Settings.js:213
-#: src/screens/Settings.js:221
+#: src/screens/Settings.js:237
+#: src/screens/Settings.js:241
+#: src/screens/Settings.js:249
 msgid "Yes"
 msgstr ""
 
 #: src/components/ModalResetAllData.js:146
-#: src/screens/Settings.js:209
-#: src/screens/Settings.js:214
-#: src/screens/Settings.js:221
+#: src/screens/Settings.js:237
+#: src/screens/Settings.js:242
+#: src/screens/Settings.js:249
 msgid "No"
 msgstr ""
 
-#: src/screens/Settings.js:209
-#: src/screens/Settings.js:216
-#: src/screens/Settings.js:221
+#: src/screens/Settings.js:237
+#: src/screens/Settings.js:244
+#: src/screens/Settings.js:249
 msgid "Change"
 msgstr ""
 
-#: src/screens/Settings.js:211
+#: src/screens/Settings.js:239
 msgid "Hide zero-balance tokens:"
 msgstr ""
 
-#: src/screens/Settings.js:218
+#: src/screens/Settings.js:246
 msgid ""
 "When selected, any tokens with a balance of zero will not be displayed "
-"anywhere in the wallets."
+"anywhere in the wallet."
 msgstr ""
 
-#: src/screens/Settings.js:221
+#: src/screens/Settings.js:249
 msgid "Automatically report bugs to Hathor:"
 msgstr ""
 
-#: src/screens/Settings.js:224
+#: src/screens/Settings.js:252
 msgid "Unique identifier"
 msgstr ""
 
 #: src/components/ModalAddressQRCode.js:93
 #: src/components/TokenGeneralInfo.js:160
 #: src/components/WalletAddress.js:153
-#: src/screens/Settings.js:224
+#: src/screens/Settings.js:252
 msgid "Copy to clipboard"
 msgstr ""
 
-#: src/screens/Settings.js:228
+#: src/screens/Settings.js:256
 msgid "Untrust all tokens on Ledger"
 msgstr ""
 
-#: src/screens/Settings.js:235
+#: src/screens/Settings.js:263
 msgid "Complete action on your hardware wallet"
 msgstr ""
 
-#: src/screens/Settings.js:237
+#: src/screens/Settings.js:265
 msgid "You can set your passphrase directly on your hardware wallet."
 msgstr ""
 
-#: src/screens/Settings.js:239
+#: src/screens/Settings.js:267
 msgid "|fn:More info| about this on Ledger."
 msgstr ""
 
 #: src/components/TxData.js:730
 #: src/components/WalletAddress.js:182
-#: src/screens/Settings.js:244
+#: src/screens/Settings.js:272
 msgid "Copied to clipboard!"
 msgstr ""
 
@@ -1582,17 +1598,17 @@ msgstr ""
 msgid "Your balance available:"
 msgstr ""
 
-#: src/components/TokenBar.js:152
+#: src/components/TokenBar.js:158
 msgid "Tokens"
 msgstr ""
 
-#: src/components/TokenBar.js:180
-#: src/components/TokenBar.js:181
+#: src/components/TokenBar.js:186
+#: src/components/TokenBar.js:187
 msgid "Lock wallet"
 msgstr ""
 
-#: src/components/TokenBar.js:184
-#: src/components/TokenBar.js:185
+#: src/components/TokenBar.js:190
+#: src/components/TokenBar.js:191
 msgid "Settings"
 msgstr ""
 

--- a/locale/texts.pot
+++ b/locale/texts.pot
@@ -47,7 +47,7 @@ msgstr ""
 
 #: src/components/ModalSendTx.js:116
 #: src/screens/ChoosePassphrase.js:64
-#: src/screens/LockedWallet.js:67
+#: src/screens/LockedWallet.js:75
 #: src/screens/Server.js:86
 msgid "Invalid PIN"
 msgstr ""
@@ -74,7 +74,7 @@ msgid "Password"
 msgstr ""
 
 #: src/screens/ChoosePassphrase.js:140
-#: src/screens/LockedWallet.js:118
+#: src/screens/LockedWallet.js:134
 #: src/screens/Server.js:217
 msgid "PIN"
 msgstr ""
@@ -112,7 +112,7 @@ msgid "Confirm"
 msgstr ""
 
 #: src/screens/ChoosePassphrase.js:161
-#: src/screens/Settings.js:196
+#: src/screens/Settings.js:227
 msgid "Set a passphrase"
 msgstr ""
 
@@ -369,17 +369,17 @@ msgstr ""
 msgid "**Transactions found:** ${ this.props.transactionsFound }"
 msgstr ""
 
-#: src/screens/LockedWallet.js:116
+#: src/screens/LockedWallet.js:132
 msgid "Your wallet is locked. Please write down your PIN to unlock it."
 msgstr ""
 
 #: src/components/ModalResetAllData.js:113
-#: src/screens/LockedWallet.js:122
-#: src/screens/Settings.js:198
+#: src/screens/LockedWallet.js:138
+#: src/screens/Settings.js:229
 msgid "Reset all data"
 msgstr ""
 
-#: src/screens/LockedWallet.js:123
+#: src/screens/LockedWallet.js:148
 msgid "Unlock"
 msgstr ""
 
@@ -437,7 +437,7 @@ msgid "Backup now"
 msgstr ""
 
 #: src/screens/NewWallet.js:208
-#: src/screens/Wallet.js:113
+#: src/screens/Wallet.js:121
 msgid "Backup completed!"
 msgstr ""
 
@@ -454,7 +454,7 @@ msgid "Invalid custom tokens"
 msgstr ""
 
 #: src/screens/SendTokens.js:189
-#: src/screens/SendTokens.js:515
+#: src/screens/SendTokens.js:516
 msgid "Sending transaction"
 msgstr ""
 
@@ -464,7 +464,7 @@ msgstr ""
 msgid "Unverified custom tokens"
 msgstr ""
 
-#: src/screens/SendTokens.js:381
+#: src/screens/SendTokens.js:382
 #.  limit is 10 custom tokens per tx
 #, javascript-format
 msgid ""
@@ -472,39 +472,39 @@ msgid ""
 "per transaction."
 msgstr ""
 
-#: src/screens/SendTokens.js:383
+#: src/screens/SendTokens.js:384
 msgid "Token limit reached"
 msgstr ""
 
-#: src/screens/SendTokens.js:392
+#: src/screens/SendTokens.js:393
 msgid "All your tokens were already added"
 msgstr ""
 
 #: src/components/tokens/TokenAction.js:137
-#: src/screens/SendTokens.js:455
+#: src/screens/SendTokens.js:456
 msgid "Loading metadata..."
 msgstr ""
 
-#: src/screens/SendTokens.js:463
+#: src/screens/SendTokens.js:464
 msgid "Add another token"
 msgstr ""
 
-#: src/screens/SendTokens.js:464
-#: src/screens/SendTokens.js:513
+#: src/screens/SendTokens.js:465
+#: src/screens/SendTokens.js:514
 msgid "Send Tokens"
 msgstr ""
 
-#: src/screens/SendTokens.js:476
+#: src/screens/SendTokens.js:477
 msgid ""
 "Please go to you Ledger and validate each output of your transaction. Press "
 "both buttons in case the output is correct."
 msgstr ""
 
-#: src/screens/SendTokens.js:477
+#: src/screens/SendTokens.js:478
 msgid "In the end, a final screen will ask you to confirm sending the transaction."
 msgstr ""
 
-#: src/screens/SendTokens.js:496
+#: src/screens/SendTokens.js:497
 msgid ""
 "Unfortunately this feature is not supported with the Hathor app version on "
 "your Ledger device. If you need this feature, you can use it by installing "
@@ -515,7 +515,7 @@ msgstr ""
 #: src/components/ModalAlertNotSupported.js:34
 #: src/components/ModalLedgerResetTokenSignatures.js:117
 #: src/components/ModalLedgerSignToken.js:218
-#: src/screens/SendTokens.js:505
+#: src/screens/SendTokens.js:506
 msgid "Close"
 msgstr ""
 
@@ -618,95 +618,108 @@ msgstr ""
 msgid "Cancel change"
 msgstr ""
 
-#: src/screens/Settings.js:106
+#: src/screens/Settings.js:110
 msgid "Turn notifications off"
 msgstr ""
 
-#: src/screens/Settings.js:107
+#: src/screens/Settings.js:111
 msgid "Are you sure you don't want to receive wallet notifications?"
 msgstr ""
 
-#: src/screens/Settings.js:114
+#: src/screens/Settings.js:118
 msgid "Turn notifications on"
 msgstr ""
 
-#: src/screens/Settings.js:115
+#: src/screens/Settings.js:119
 msgid "Are you sure you want to receive wallet notifications?"
 msgstr ""
 
-#: src/screens/Settings.js:178
+#: src/screens/Settings.js:198
 msgid "Date and time:"
 msgstr ""
 
-#: src/screens/Settings.js:181
+#: src/screens/Settings.js:201
 #, javascript-format
 msgid "**Server:** You are connected to ${ serverURL }"
 msgstr ""
 
 #: src/components/RequestError.js:184
-#: src/screens/Settings.js:182
+#: src/screens/Settings.js:202
 msgid "Change server"
 msgstr ""
 
-#: src/screens/Settings.js:187
+#: src/screens/Settings.js:207
 msgid "Advanced Settings"
 msgstr ""
 
-#: src/screens/Settings.js:189
+#: src/screens/Settings.js:209
 msgid "Allow notifications:"
 msgstr ""
 
 #: src/components/ModalResetAllData.js:147
-#: src/screens/Settings.js:189
-#: src/screens/Settings.js:190
+#: src/screens/Settings.js:209
+#: src/screens/Settings.js:213
+#: src/screens/Settings.js:221
 msgid "Yes"
 msgstr ""
 
 #: src/components/ModalResetAllData.js:146
-#: src/screens/Settings.js:189
-#: src/screens/Settings.js:190
+#: src/screens/Settings.js:209
+#: src/screens/Settings.js:214
+#: src/screens/Settings.js:221
 msgid "No"
 msgstr ""
 
-#: src/screens/Settings.js:189
-#: src/screens/Settings.js:190
+#: src/screens/Settings.js:209
+#: src/screens/Settings.js:216
+#: src/screens/Settings.js:221
 msgid "Change"
 msgstr ""
 
-#: src/screens/Settings.js:190
+#: src/screens/Settings.js:211
+msgid "Hide zero-balance tokens:"
+msgstr ""
+
+#: src/screens/Settings.js:218
+msgid ""
+"When selected, any tokens with a balance of zero will not be displayed "
+"anywhere in the wallets."
+msgstr ""
+
+#: src/screens/Settings.js:221
 msgid "Automatically report bugs to Hathor:"
 msgstr ""
 
-#: src/screens/Settings.js:193
+#: src/screens/Settings.js:224
 msgid "Unique identifier"
 msgstr ""
 
 #: src/components/ModalAddressQRCode.js:93
-#: src/components/TokenGeneralInfo.js:157
+#: src/components/TokenGeneralInfo.js:160
 #: src/components/WalletAddress.js:153
-#: src/screens/Settings.js:193
+#: src/screens/Settings.js:224
 msgid "Copy to clipboard"
 msgstr ""
 
-#: src/screens/Settings.js:197
+#: src/screens/Settings.js:228
 msgid "Untrust all tokens on Ledger"
 msgstr ""
 
-#: src/screens/Settings.js:204
+#: src/screens/Settings.js:235
 msgid "Complete action on your hardware wallet"
 msgstr ""
 
-#: src/screens/Settings.js:206
+#: src/screens/Settings.js:237
 msgid "You can set your passphrase directly on your hardware wallet."
 msgstr ""
 
-#: src/screens/Settings.js:208
+#: src/screens/Settings.js:239
 msgid "|fn:More info| about this on Ledger."
 msgstr ""
 
 #: src/components/TxData.js:730
 #: src/components/WalletAddress.js:182
-#: src/screens/Settings.js:213
+#: src/screens/Settings.js:244
 msgid "Copied to clipboard!"
 msgstr ""
 
@@ -737,44 +750,44 @@ msgid "See on explorer"
 msgstr ""
 
 #: src/components/WalletBalance.js:44
-#: src/screens/UnknownTokens.js:142
+#: src/screens/UnknownTokens.js:152
 msgid "Total:"
 msgstr ""
 
 #: src/components/WalletBalance.js:45
-#: src/screens/UnknownTokens.js:143
+#: src/screens/UnknownTokens.js:153
 msgid "Available:"
 msgstr ""
 
 #: src/components/WalletBalance.js:46
-#: src/screens/UnknownTokens.js:144
+#: src/screens/UnknownTokens.js:154
 msgid "Locked:"
 msgstr ""
 
-#: src/screens/UnknownTokens.js:148
+#: src/screens/UnknownTokens.js:158
 msgid "Show history"
 msgstr ""
 
-#: src/screens/UnknownTokens.js:149
+#: src/screens/UnknownTokens.js:159
 msgid "Hide history"
 msgstr ""
 
-#: src/screens/UnknownTokens.js:165
+#: src/screens/UnknownTokens.js:175
 msgid "Unknown Tokens"
 msgstr ""
 
-#: src/screens/UnknownTokens.js:166
+#: src/screens/UnknownTokens.js:176
 msgid "Register Tokens"
 msgstr ""
 
-#: src/screens/UnknownTokens.js:168
+#: src/screens/UnknownTokens.js:178
 msgid ""
 "Those are the custom tokens which you have at least one transaction. They "
 "are still unregistered in this wallet. You need to register a custom token "
 "in order to send new transactions using it."
 msgstr ""
 
-#: src/screens/UnknownTokens.js:169
+#: src/screens/UnknownTokens.js:179
 msgid ""
 "If you have reset your wallet, you need to register your custom tokens "
 "again."
@@ -800,52 +813,52 @@ msgstr ""
 msgid "Change Server"
 msgstr ""
 
-#: src/screens/Wallet.js:177
+#: src/screens/Wallet.js:189
 msgid ""
 "You haven't done the backup of your wallet yet. You should do it as soon as "
 "possible for your own safety."
 msgstr ""
 
-#: src/screens/Wallet.js:177
+#: src/screens/Wallet.js:189
 msgid "Do it now"
 msgstr ""
 
-#: src/screens/Wallet.js:210
+#: src/screens/Wallet.js:222
 msgid "Administrative Tools"
 msgstr ""
 
-#: src/screens/Wallet.js:238
+#: src/screens/Wallet.js:250
 msgid "Balance & History"
 msgstr ""
 
-#: src/screens/Wallet.js:241
+#: src/screens/Wallet.js:253
 #, javascript-format
 msgid "About ${ token.name }"
 msgstr ""
 
-#: src/screens/Wallet.js:264
+#: src/screens/Wallet.js:276
 #, javascript-format
 msgid ""
 "Are you sure you want to unregister the token **${ token.name } (${ "
 "token.symbol })**?"
 msgstr ""
 
-#: src/screens/Wallet.js:265
+#: src/screens/Wallet.js:277
 msgid ""
 "You won't lose your tokens, you just won't see this token on the side bar "
 "anymore."
 msgstr ""
 
-#: src/screens/Wallet.js:276
+#: src/screens/Wallet.js:288
 msgid "Sign token on Ledger"
 msgstr ""
 
-#: src/screens/Wallet.js:277
+#: src/screens/Wallet.js:289
 msgid "Token signed with Ledger"
 msgstr ""
 
-#: src/screens/Wallet.js:286
-#: src/screens/Wallet.js:316
+#: src/screens/Wallet.js:298
+#: src/screens/Wallet.js:328
 msgid "Unregister token"
 msgstr ""
 
@@ -1005,17 +1018,17 @@ msgid "Previous"
 msgstr ""
 
 #: src/components/LedgerSignTokenInfo.js:21
-#: src/components/TokenGeneralInfo.js:135
+#: src/components/TokenGeneralInfo.js:138
 msgid "UID:"
 msgstr ""
 
 #: src/components/LedgerSignTokenInfo.js:31
-#: src/components/TokenGeneralInfo.js:138
+#: src/components/TokenGeneralInfo.js:141
 msgid "Symbol:"
 msgstr ""
 
 #: src/components/LedgerSignTokenInfo.js:32
-#: src/components/TokenGeneralInfo.js:137
+#: src/components/TokenGeneralInfo.js:140
 msgid "Name:"
 msgstr ""
 
@@ -1082,7 +1095,7 @@ msgstr ""
 
 #: src/components/ModalAddressQRCode.js:96
 #: src/components/ModalAddressQRCode.js:101
-#: src/components/TokenGeneralInfo.js:161
+#: src/components/TokenGeneralInfo.js:164
 msgid "Download"
 msgstr ""
 
@@ -1509,119 +1522,119 @@ msgid ""
 "have support for Ledger."
 msgstr ""
 
-#: src/components/TokenAdministrative.js:176
+#: src/components/TokenAdministrative.js:163
 msgid "This feature is not currently supported for a hardware wallet."
 msgstr ""
 
-#: src/components/TokenAdministrative.js:211
-#: src/components/TokenAdministrative.js:222
+#: src/components/TokenAdministrative.js:198
+#: src/components/TokenAdministrative.js:209
 msgid "Operations"
 msgstr ""
 
-#: src/components/TokenAdministrative.js:212
+#: src/components/TokenAdministrative.js:199
 #: src/components/tokens/TokenMelt.js:166
 msgid "Melt tokens"
 msgstr ""
 
-#: src/components/TokenAdministrative.js:213
+#: src/components/TokenAdministrative.js:200
 msgid "Delegate melt"
 msgstr ""
 
-#: src/components/TokenAdministrative.js:214
+#: src/components/TokenAdministrative.js:201
 msgid "Destroy melt"
 msgstr ""
 
-#: src/components/TokenAdministrative.js:223
+#: src/components/TokenAdministrative.js:210
 #: src/components/tokens/TokenMint.js:212
 msgid "Mint tokens"
 msgstr ""
 
-#: src/components/TokenAdministrative.js:223
+#: src/components/TokenAdministrative.js:210
 msgid "Mint more tokens"
 msgstr ""
 
-#: src/components/TokenAdministrative.js:224
+#: src/components/TokenAdministrative.js:211
 msgid "Delegate mint"
 msgstr ""
 
-#: src/components/TokenAdministrative.js:225
+#: src/components/TokenAdministrative.js:212
 msgid "Destroy mint"
 msgstr ""
 
-#: src/components/TokenAdministrative.js:232
+#: src/components/TokenAdministrative.js:219
 msgid "You have no more authority outputs for this token"
 msgstr ""
 
-#: src/components/TokenAdministrative.js:238
+#: src/components/TokenAdministrative.js:225
 msgid "Mint authority management"
 msgstr ""
 
-#: src/components/TokenAdministrative.js:243
+#: src/components/TokenAdministrative.js:230
 msgid "Melt authority management"
 msgstr ""
 
-#: src/components/TokenAdministrative.js:255
-#: src/components/TokenGeneralInfo.js:139
+#: src/components/TokenAdministrative.js:242
+#: src/components/TokenGeneralInfo.js:142
 msgid "Total supply:"
 msgstr ""
 
-#: src/components/TokenAdministrative.js:256
+#: src/components/TokenAdministrative.js:243
 msgid "Your balance available:"
 msgstr ""
 
-#: src/components/TokenBar.js:142
+#: src/components/TokenBar.js:152
 msgid "Tokens"
 msgstr ""
 
-#: src/components/TokenBar.js:170
-#: src/components/TokenBar.js:171
+#: src/components/TokenBar.js:180
+#: src/components/TokenBar.js:181
 msgid "Lock wallet"
 msgstr ""
 
-#: src/components/TokenBar.js:174
-#: src/components/TokenBar.js:175
+#: src/components/TokenBar.js:184
+#: src/components/TokenBar.js:185
 msgid "Settings"
 msgstr ""
 
-#: src/components/TokenGeneralInfo.js:108
+#: src/components/TokenGeneralInfo.js:111
 #.  If copied with success
 msgid "Configuration string copied to clipboard!"
 msgstr ""
 
-#: src/components/TokenGeneralInfo.js:136
+#: src/components/TokenGeneralInfo.js:139
 #: src/components/TxData.js:666
 msgid "Type:"
 msgstr ""
 
-#: src/components/TokenGeneralInfo.js:140
+#: src/components/TokenGeneralInfo.js:143
 msgid "Can mint new tokens:"
 msgstr ""
 
-#: src/components/TokenGeneralInfo.js:141
+#: src/components/TokenGeneralInfo.js:144
 msgid ""
 "Indicates whether the token owner can create new tokens, increasing the "
 "total supply"
 msgstr ""
 
-#: src/components/TokenGeneralInfo.js:142
+#: src/components/TokenGeneralInfo.js:145
 msgid "Can melt tokens:"
 msgstr ""
 
-#: src/components/TokenGeneralInfo.js:143
+#: src/components/TokenGeneralInfo.js:146
 msgid ""
 "Indicates whether the token owner can destroy tokens, decreasing the total "
 "supply"
 msgstr ""
 
-#: src/components/TokenGeneralInfo.js:144
+#: src/components/TokenGeneralInfo.js:147
 msgid "Total number of transactions:"
 msgstr ""
 
-#: src/components/TokenGeneralInfo.js:153
+#: src/components/TokenGeneralInfo.js:156
 msgid "Configuration String"
 msgstr ""
 
-#: src/components/TokenGeneralInfo.js:161
+#: src/components/TokenGeneralInfo.js:164
 msgid "Download QRCode"
 msgstr ""
 

--- a/src/components/ModalAddManyTokens.js
+++ b/src/components/ModalAddManyTokens.js
@@ -10,6 +10,7 @@ import { t } from 'ttag';
 import $ from 'jquery';
 import tokens from '../utils/tokens';
 import hathorLib from '@hathor/wallet-lib';
+import wallet from "../utils/wallet";
 
 
 /**
@@ -19,14 +20,39 @@ import hathorLib from '@hathor/wallet-lib';
  */
 class ModalAddManyTokens extends React.Component {
   /**
-   * errorMessage {string} Message that will be shown to the user in case of error
+   * @property {string} errorMessage Message that will be shown to the user in case of error
+   * @property {string} warningMessage Message that will be shown to the user in warning scenarios
+   * @property {boolean} shouldExhibitAlwaysShowCheckbox Defines "always show" checkbox rendering
+   * @property {boolean} alwaysShow Defines if tokens will be added with "Always Show" setting
+   * @property {string} tokensToAdd Stores the tokens that will be added. Used on user messages.
    */
-  state = { errorMessage: '' };
+  state = {
+    errorMessage: '',
+    warningMessage: '',
+    shouldExhibitAlwaysShowCheckbox: false,
+    alwaysShow: false,
+    tokensToAdd: '',
+  };
+
+  /**
+   * Handles the click on the "Always show this token" checkbox
+   * @param {Event} e
+   */
+  handleToggleAlwaysShow = (e) => {
+    const newValue = !this.state.alwaysShow;
+    this.setState( { alwaysShow: newValue });
+  }
 
   componentDidMount = () => {
     $('#addManyTokensModal').on('hide.bs.modal', (e) => {
       this.refs.configs.value = '';
-      this.setState({ errorMessage: '' });
+      this.setState({
+        errorMessage: '',
+        warningMessage: '',
+        shouldExhibitAlwaysShowCheckbox: false,
+        alwaysShow: false,
+        tokensToAdd: '',
+      });
     })
 
     $('#addManyTokensModal').on('shown.bs.modal', (e) => {
@@ -40,12 +66,13 @@ class ModalAddManyTokens extends React.Component {
   }
 
   /**
-   * Method called when user clicks the button to add the tokens  
-   * Validates that all configuration strings written are valid
+   * Method called when user clicks the button to add the tokens
+   * Validates that all configuration strings written are valid and applies logic to warn/ask the
+   * user about tokens that would be hidden under current settings.
    *
    * @param {Object} e Event emitted when user clicks the button
    */
-  handleAdd = (e) => {
+  handleAdd = async (e) => {
     e.preventDefault();
     const configs = this.refs.configs.value.trim();
     if (configs === '') {
@@ -70,19 +97,95 @@ class ModalAddManyTokens extends React.Component {
       }
     }
 
-    Promise.all(validations).then((toAdd) => {
-      // If all promises succeed, we add the tokens and show success message
+    try {
+      const toAdd = await Promise.all(validations)
+      const tokensBalance = this.props.tokensBalance;
+      const areZeroBalanceTokensHidden = wallet.areZeroBalanceTokensHidden();
+      const tokensWithoutBalance = [];
+      const tokensToAdd = [];
+
+      // All promises succeeded, validating token balances
       for (const config of toAdd) {
-        tokens.addToken(config.uid, config.name, config.symbol);
+        const tokenUid = config.uid;
+        const tokenBalance = tokensBalance[tokenUid];
+        const tokenHasZeroBalance = !tokenBalance
+          || (tokenBalance.available + tokenBalance.locked) === 0;
+
+        /*
+         * We only make this validation if the "Hide Zero-Balance Tokens" setting is active,
+         * and only do it once. If the warning message was shown, we will accept the "alwaysShow"
+         * checkbox value as the user decision already.
+         */
+        if (
+          areZeroBalanceTokensHidden
+          && tokenHasZeroBalance
+          && !this.state.shouldExhibitAlwaysShowCheckbox
+        ) {
+          tokensWithoutBalance.push(config);
+          continue;
+        }
+
+        // Prepare the token to be added to the wallet
+        tokensToAdd.push(config)
       }
+
+      /*
+       * This array will only be populated if the "Hide zero balance tokens" setting is active and
+       * the user tried to add tokens with zero balance.
+       * In this case, we will stop the process and render a warning message with an option to
+       * always show these tokens being added.
+       * No tokens will be added here.
+       */
+      if (tokensWithoutBalance.length) {
+        const emptyTokenNames = tokensWithoutBalance.map(t => t.symbol).join(', ')
+        this.setState({
+          shouldExhibitAlwaysShowCheckbox: true,
+          warningMessage: t`The following tokens have no balance on your wallet and you have the "hide zero-balance tokens" settings on.\nDo you wish to always show these tokens? (You can always undo this on the token info screen.)`,
+          tokensToAdd: emptyTokenNames,
+        })
+        return;
+      }
+
+      // Adding the tokens to the wallet and returning with the success callback
+      for (const config of tokensToAdd) {
+        tokens.addToken(config.uid, config.name, config.symbol);
+        wallet.setTokenAlwaysShow(config.uid, this.state.alwaysShow);
+      }
+
       this.props.success(toAdd.length);
-    }, (e) => {
-      // If one fails, we show error message
-      this.setState({ errorMessage: e.message });
-    });
+    } catch (e) {
+      // If one of the promises fail, we show an error message
+      this.setState({errorMessage: e.message});
+    }
   }
 
   render() {
+    const renderAlwaysShowCheckbox = () => {
+      return (
+        <div className="form-check">
+          <input className="form-check-input" type="checkbox" id="alwaysShowToken"
+                 checked={this.state.alwaysShow} onChange={this.handleToggleAlwaysShow}/>
+          <label className="form-check-label" htmlFor="alwaysShowToken">
+            {t`Always show these tokens`}
+          </label>
+          <i className="fa fa-question-circle pointer ml-3"
+             title={t`If selected, it will overwrite the "Hide zero-balance tokens" settings.`}>
+          </i>
+        </div>
+      );
+    }
+
+    const renderWarningMessage = () => {
+      return (
+        <div className="col-12 col-sm-12">
+          <div ref="warningText" className="alert alert-warning" role="alert">
+            {this.state.warningMessage}<br/>
+            <strong>{this.state.tokensToAdd}</strong>
+          </div>
+        </div>
+      );
+    }
+
     return (
       <div className="modal fade" id="addManyTokensModal" tabIndex="-1" role="dialog" aria-labelledby="addManyTokensModal" aria-hidden="true">
         <div className="modal-dialog" role="document">
@@ -97,7 +200,9 @@ class ModalAddManyTokens extends React.Component {
               <p>{t`You can register one or more tokens writing the configuration string of each one below.`}</p>
               <form ref="formAddToken">
                 <div className="form-group">
-                  <textarea className="form-control" rows={8} ref="configs" placeholder={t`Configuration strings`} />
+                  <textarea className="form-control" rows={8} ref="configs"
+                            placeholder={t`Configuration strings`}
+                            readOnly={this.state.shouldExhibitAlwaysShowCheckbox} />
                 </div>
                 <div className="row">
                   <div className="col-12 col-sm-10">
@@ -105,7 +210,9 @@ class ModalAddManyTokens extends React.Component {
                         {this.state.errorMessage}
                       </p>
                   </div>
+                  { this.state.warningMessage.length && renderWarningMessage() }
                 </div>
+                { this.state.shouldExhibitAlwaysShowCheckbox && renderAlwaysShowCheckbox() }
               </form>
             </div>
             <div className="modal-footer">

--- a/src/components/ModalAddToken.js
+++ b/src/components/ModalAddToken.js
@@ -10,6 +10,7 @@ import { t } from 'ttag';
 import $ from 'jquery';
 import tokens from '../utils/tokens';
 import hathorLib from '@hathor/wallet-lib';
+import wallet from "../utils/wallet";
 
 
 /**
@@ -19,14 +20,36 @@ import hathorLib from '@hathor/wallet-lib';
  */
 class ModalAddToken extends React.Component {
   /**
-   * errorMessage {string} Message that will be shown to the user in case of error
+   * @property {string} errorMessage Message that will be shown to the user in case of error
+   * @property {string} warningMessage Message that will be shown to the user in warning scenarios
+   * @property {boolean} shouldExhibitAlwaysShowCheckbox Defines "always show" checkbox rendering
+   * @property {boolean} alwaysShow Defines if tokens will be added with "Always Show" setting
    */
-  state = { errorMessage: '' };
+  state = {
+    errorMessage: '',
+    warningMessage: '',
+    shouldExhibitAlwaysShowCheckbox: false,
+    alwaysShow: false,
+  };
+
+  /**
+   * Handles the click on the "Always show this token" checkbox
+   * @param {Event} e
+   */
+  handleToggleAlwaysShow = (e) => {
+    const newValue = !this.state.alwaysShow;
+    this.setState({ alwaysShow: newValue });
+  }
 
   componentDidMount = () => {
     $('#addTokenModal').on('hide.bs.modal', (e) => {
       this.refs.config.value = '';
-      this.setState({ errorMessage: '' });
+      this.setState({
+        errorMessage: '',
+        warningMessage: '',
+        shouldExhibitAlwaysShowCheckbox: false,
+        alwaysShow: false,
+      });
     })
 
     $('#addTokenModal').on('shown.bs.modal', (e) => {
@@ -40,28 +63,81 @@ class ModalAddToken extends React.Component {
   }
 
   /**
-   * Method called when user clicks the button to register the token  
+   * Method called when user clicks the button to register the token
    * Validates that the data written is valid
    *
    * @param {Object} e Event emitted when user clicks the button
    */
-  handleAdd = (e) => {
+  handleAdd = async (e) => {
     e.preventDefault();
+
+    // Validating input field contents
     if (this.refs.config.value === '') {
       this.setState({ errorMessage: t`Must provide configuration string or uid, name, and symbol` });
       return;
     }
-    const promise = hathorLib.tokens.validateTokenToAddByConfigurationString(this.refs.config.value, null);
-    promise.then((tokenData) => {
-      tokens.addToken(tokenData.uid, tokenData.name, tokenData.symbol);
+
+    try {
+      const tokenData = await hathorLib.tokens.validateTokenToAddByConfigurationString(this.refs.config.value, null);
+      const tokensBalance = this.props.tokensBalance;
+
+      const tokenUid = tokenData.uid;
+      const tokenBalance = tokensBalance[tokenUid];
+      const tokenHasZeroBalance = !tokenBalance
+        || (tokenBalance.available + tokenBalance.locked) === 0;
+
+      /*
+       * We only make this validation if the "Hide Zero-Balance Tokens" setting is active,
+       * and only do it once. If the warning message was shown, we will accept the "alwaysShow"
+       * checkbox value as the user decision already.
+       */
+      if (
+        wallet.areZeroBalanceTokensHidden()
+        && tokenHasZeroBalance
+        && !this.state.shouldExhibitAlwaysShowCheckbox
+      ) {
+        this.setState({
+          shouldExhibitAlwaysShowCheckbox: true,
+          warningMessage: t`This token has no balance on your wallet and you have the "hide zero-balance tokens" settings on.\nDo you wish to always show this token? (You can always undo this on the token info screen.)`
+        })
+        return;
+      }
+
+      // Adding the token to the wallet and returning with the success callback
+      tokens.addToken(tokenUid, tokenData.name, tokenData.symbol);
+      wallet.setTokenAlwaysShow(tokenUid, this.state.alwaysShow);
       this.props.success();
-    }, (e) => {
-      this.setState({ errorMessage: e.message });
-      return;
-    });
+    } catch (e) {
+      this.setState({errorMessage: e.message});
+    }
   }
 
   render() {
+    const renderAlwaysShowCheckbox = () => {
+      return (
+        <div className="form-check">
+          <input className="form-check-input" type="checkbox" id="alwaysShowTokenCheckbox"
+                 checked={this.state.alwaysShow} onChange={this.handleToggleAlwaysShow}/>
+          <label className="form-check-label" htmlFor="alwaysShowToken">
+            {t`Always show this token`}
+          </label>
+          <i className="fa fa-question-circle pointer ml-3"
+             title={t`If selected, it will overwrite the "Hide zero-balance tokens" settings for this token.`}>
+          </i>
+        </div>
+      );
+    }
+
+    const renderWarningMessage = () => {
+      return (
+        <div className="col-12 col-sm-12">
+          <div ref="warningText" className="alert alert-warning" role="alert">
+            {this.state.warningMessage}
+          </div>
+        </div>
+      );
+    }
+
     return (
       <div className="modal fade" id="addTokenModal" tabIndex="-1" role="dialog" aria-labelledby="addTokenModal" aria-hidden="true">
         <div className="modal-dialog" role="document">
@@ -76,7 +152,9 @@ class ModalAddToken extends React.Component {
               <p>{t`To register a token that already exists, just write down its configuration string`}</p>
               <form ref="formAddToken">
                 <div className="form-group">
-                  <textarea type="text" className="form-control" ref="config" placeholder={t`Configuration string`} />
+                  <textarea type="text" className="form-control" ref="config"
+                            placeholder={t`Configuration string`}
+                            readOnly={this.state.shouldExhibitAlwaysShowCheckbox} />
                 </div>
                 <div className="row">
                   <div className="col-12 col-sm-10">
@@ -84,7 +162,9 @@ class ModalAddToken extends React.Component {
                         {this.state.errorMessage}
                       </p>
                   </div>
+                  { this.state.warningMessage.length && renderWarningMessage() }
                 </div>
+                { this.state.shouldExhibitAlwaysShowCheckbox && renderAlwaysShowCheckbox() }
               </form>
             </div>
             <div className="modal-footer">

--- a/src/components/TokenBar.js
+++ b/src/components/TokenBar.js
@@ -11,6 +11,7 @@ import { connect } from "react-redux";
 import { selectToken } from '../actions/index';
 import hathorLib from '@hathor/wallet-lib';
 import helpers from '../utils/helpers';
+import wallet from "../utils/wallet";
 
 
 const mapStateToProps = (state) => {
@@ -76,7 +77,7 @@ class TokenBar extends React.Component {
 
   /**
    * Called when user selects another token
-   * 
+   *
    * @param {string} uid UID of token user selected
    */
   tokenSelected = (uid) => {
@@ -127,10 +128,23 @@ class TokenBar extends React.Component {
     const unknownTokens = this.getUnknownTokens();
 
     const renderTokens = () => {
+      const shouldHideZeroBalanceTokens = wallet.areZeroBalanceTokensHidden();
       return this.props.registeredTokens.map((token) => {
+        let hideThisToken = false;
+        const tokenUid = token.uid;
+        const isTokenHTR = tokenUid === '00';
+        const tokenBalance = this.getTokenBalance(tokenUid);
+
+        // The "hide" setting should apply for every token except HTR
+        if (shouldHideZeroBalanceTokens && !isTokenHTR && tokenBalance === '0.00') {
+          hideThisToken = true;
+        }
+
+        // Deciding if this token should be hidden.
+        if (hideThisToken) return;
         return (
-          <div key={token.uid} className={`token-wrapper ${token.uid === this.props.selectedToken ? 'selected' : ''}`} onClick={(e) => {this.tokenSelected(token.uid)}}>
-            <span className='ellipsis'>{token.symbol} {this.state.opened && ` | ${this.getTokenBalance(token.uid)}`}</span>
+          <div key={tokenUid} className={`token-wrapper ${tokenUid === this.props.selectedToken ? 'selected' : ''}`} onClick={(e) => {this.tokenSelected(tokenUid)}}>
+            <span className='ellipsis'>{token.symbol} {this.state.opened && ` | ${tokenBalance}`}</span>
           </div>
         )
       });

--- a/src/components/TokenBar.js
+++ b/src/components/TokenBar.js
@@ -56,13 +56,24 @@ class TokenBar extends React.Component {
    *
    * @return {number} Quantity of unknown tokens
    */
-  getUnknownTokens = () => {
+  getUnknownTokens = (hideZeroBalance) => {
     let diff = 0;
     for (const uid of this.props.allTokens) {
       const index = this.props.registeredTokens.findIndex((token) => token.uid === uid);
       if (index === -1) {
         // Token still does not exist in registered tokens
-        diff += 1;
+
+        // Checking if it should be hidden because it has zero balance
+        const balance = this.props.tokensBalance[uid];
+        let hideThisToken = false;
+        const totalBalance = balance.available + balance.locked;
+        if (hideZeroBalance && totalBalance === 0) {
+          hideThisToken = true;
+        }
+
+        if (!hideThisToken) {
+          diff += 1;
+        }
       }
     }
     return diff;
@@ -125,10 +136,10 @@ class TokenBar extends React.Component {
   }
 
   render() {
-    const unknownTokens = this.getUnknownTokens();
+    const shouldHideZeroBalanceTokens = wallet.areZeroBalanceTokensHidden();
+    const unknownTokens = this.getUnknownTokens(shouldHideZeroBalanceTokens);
 
     const renderTokens = () => {
-      const shouldHideZeroBalanceTokens = wallet.areZeroBalanceTokensHidden();
       return this.props.registeredTokens.map((token) => {
         let hideThisToken = false;
         const tokenUid = token.uid;

--- a/src/components/TokenBar.js
+++ b/src/components/TokenBar.js
@@ -99,14 +99,12 @@ class TokenBar extends React.Component {
   }
 
   /**
-   * Gets the balance of one token formatted for exhibition
+   * Gets the balance of one token
    *
    * @param {string} uid UID to get balance from
-   * @param {boolean} [returnInteger] Returns the total value as an integer
-   *
-   * @return {string|number} Available balance of token in the specified format
+   * @return {number} Total token balance
    */
-  getTokenBalance = (uid, returnInteger = false) => {
+  getTokenBalance = (uid) => {
     const balance = this.props.tokensBalance[uid];
     let total = 0;
     if (balance) {
@@ -114,8 +112,17 @@ class TokenBar extends React.Component {
       total = balance.available + balance.locked;
     }
 
-    // Returning the raw integer value, according to parameter
-    if (returnInteger) return total;
+    return total;
+  }
+
+  /**
+   * Gets the balance of one token formatted for exhibition
+   *
+   * @param {string} uid UID to get balance from
+   * @return {string} String formatted balance, ready for exhibition
+   */
+  getTokenBalanceFormatted = (uid) => {
+    const total = this.getTokenBalance(uid);
 
     // Formatting to string for exhibition
     const isNFT = helpers.isTokenNFT(uid, this.props.tokenMetadata);
@@ -137,7 +144,7 @@ class TokenBar extends React.Component {
       return this.props.registeredTokens.map((token) => {
         const tokenUid = token.uid;
         const isTokenHTR = tokenUid === hathorLib.constants.HATHOR_TOKEN_CONFIG.uid;
-        const totalBalance = this.getTokenBalance(tokenUid, true);
+        const totalBalance = this.getTokenBalance(tokenUid);
 
         // Skip every token without balance, except HTR, if the hiding flag is active
         if (shouldHideZeroBalanceTokens && !isTokenHTR && totalBalance === 0) {
@@ -146,7 +153,7 @@ class TokenBar extends React.Component {
 
         return (
           <div key={tokenUid} className={`token-wrapper ${tokenUid === this.props.selectedToken ? 'selected' : ''}`} onClick={(e) => {this.tokenSelected(tokenUid)}}>
-            <span className='ellipsis'>{token.symbol} {this.state.opened && ` | ${(this.getTokenBalance(tokenUid))}`}</span>
+            <span className='ellipsis'>{token.symbol} {this.state.opened && ` | ${(this.getTokenBalanceFormatted(tokenUid))}`}</span>
           </div>
         )
       });

--- a/src/components/TokenBar.js
+++ b/src/components/TokenBar.js
@@ -57,26 +57,14 @@ class TokenBar extends React.Component {
    * @return {number} Quantity of unknown tokens
    */
   getUnknownTokens = (hideZeroBalance) => {
-    let diff = 0;
-    for (const uid of this.props.allTokens) {
-      const index = this.props.registeredTokens.findIndex((token) => token.uid === uid);
-      if (index === -1) {
-        // Token still does not exist in registered tokens
+    const unknownTokens = wallet.fetchUnknownTokens({
+      allTokens: this.props.allTokens,
+      registeredTokens: this.props.registeredTokens,
+      tokensBalance: this.props.tokensBalance,
+      hideZeroBalance,
+    })
 
-        // Checking if it should be hidden because it has zero balance
-        const balance = this.props.tokensBalance[uid];
-        let hideThisToken = false;
-        const totalBalance = balance.available + balance.locked;
-        if (hideZeroBalance && totalBalance === 0) {
-          hideThisToken = true;
-        }
-
-        if (!hideThisToken) {
-          diff += 1;
-        }
-      }
-    }
-    return diff;
+    return unknownTokens.length;
   }
 
   /**

--- a/src/components/TokenBar.js
+++ b/src/components/TokenBar.js
@@ -57,12 +57,12 @@ class TokenBar extends React.Component {
    * @return {number} Quantity of unknown tokens
    */
   getUnknownTokens = (hideZeroBalance) => {
-    const unknownTokens = wallet.fetchUnknownTokens({
-      allTokens: this.props.allTokens,
-      registeredTokens: this.props.registeredTokens,
-      tokensBalance: this.props.tokensBalance,
+    const unknownTokens = wallet.fetchUnknownTokens(
+      this.props.allTokens,
+      this.props.registeredTokens,
+      this.props.tokensBalance,
       hideZeroBalance,
-    })
+    );
 
     return unknownTokens.length;
   }
@@ -141,15 +141,14 @@ class TokenBar extends React.Component {
     const unknownTokens = this.getUnknownTokens(shouldHideZeroBalanceTokens);
 
     const renderTokens = () => {
-      return this.props.registeredTokens.map((token) => {
-        const tokenUid = token.uid;
-        const isTokenHTR = tokenUid === hathorLib.constants.HATHOR_TOKEN_CONFIG.uid;
-        const totalBalance = this.getTokenBalance(tokenUid);
+      const registeredTokens = wallet.fetchRegisteredTokens(
+        this.props.registeredTokens,
+        this.props.tokensBalance,
+        shouldHideZeroBalanceTokens,
+      );
 
-        // Skip every token without balance, except HTR, if the hiding flag is active
-        if (shouldHideZeroBalanceTokens && !isTokenHTR && totalBalance === 0) {
-          return;
-        }
+      return registeredTokens.map((token) => {
+        const tokenUid = token.uid;
 
         return (
           <div key={tokenUid} className={`token-wrapper ${tokenUid === this.props.selectedToken ? 'selected' : ''}`} onClick={(e) => {this.tokenSelected(tokenUid)}}>

--- a/src/components/TokenBar.js
+++ b/src/components/TokenBar.js
@@ -99,19 +99,25 @@ class TokenBar extends React.Component {
   }
 
   /**
-   * Get the balance of one token
+   * Gets the balance of one token formatted for exhibition
    *
    * @param {string} uid UID to get balance from
+   * @param {boolean} [returnInteger] Returns the total value as an integer
    *
-   * @return {string} Available balance of token formatted
+   * @return {string|number} Available balance of token in the specified format
    */
-  getTokenBalance = (uid) => {
+  getTokenBalance = (uid, returnInteger = false) => {
     const balance = this.props.tokensBalance[uid];
     let total = 0;
     if (balance) {
       // If we don't have any transaction for the token, balance will be undefined
       total = balance.available + balance.locked;
     }
+
+    // Converting a possible "undefined" result to a valid integer.
+    if (returnInteger) return total;
+
+    // Formatting to string for exhibition
     const isNFT = helpers.isTokenNFT(uid, this.props.tokenMetadata);
     return helpers.renderValue(total, isNFT);
   }
@@ -131,16 +137,16 @@ class TokenBar extends React.Component {
       return this.props.registeredTokens.map((token) => {
         const tokenUid = token.uid;
         const isTokenHTR = tokenUid === hathorLib.constants.HATHOR_TOKEN_CONFIG.uid;
-        const tokenBalance = this.getTokenBalance(tokenUid);
+        const totalBalance = this.getTokenBalance(tokenUid, true);
 
         // Skip every token without balance, except HTR, if the hiding flag is active
-        if (shouldHideZeroBalanceTokens && !isTokenHTR && tokenBalance === '0.00') {
+        if (shouldHideZeroBalanceTokens && !isTokenHTR && totalBalance === 0) {
           return;
         }
 
         return (
           <div key={tokenUid} className={`token-wrapper ${tokenUid === this.props.selectedToken ? 'selected' : ''}`} onClick={(e) => {this.tokenSelected(tokenUid)}}>
-            <span className='ellipsis'>{token.symbol} {this.state.opened && ` | ${tokenBalance}`}</span>
+            <span className='ellipsis'>{token.symbol} {this.state.opened && ` | ${(this.getTokenBalance(tokenUid))}`}</span>
           </div>
         )
       });

--- a/src/components/TokenBar.js
+++ b/src/components/TokenBar.js
@@ -114,7 +114,7 @@ class TokenBar extends React.Component {
       total = balance.available + balance.locked;
     }
 
-    // Converting a possible "undefined" result to a valid integer.
+    // Returning the raw integer value, according to parameter
     if (returnInteger) return total;
 
     // Formatting to string for exhibition

--- a/src/components/TokenBar.js
+++ b/src/components/TokenBar.js
@@ -129,18 +129,15 @@ class TokenBar extends React.Component {
 
     const renderTokens = () => {
       return this.props.registeredTokens.map((token) => {
-        let hideThisToken = false;
         const tokenUid = token.uid;
-        const isTokenHTR = tokenUid === '00';
+        const isTokenHTR = tokenUid === hathorLib.constants.HATHOR_TOKEN_CONFIG.uid;
         const tokenBalance = this.getTokenBalance(tokenUid);
 
-        // The "hide" setting should apply for every token except HTR
+        // Skip every token without balance, except HTR, if the hiding flag is active
         if (shouldHideZeroBalanceTokens && !isTokenHTR && tokenBalance === '0.00') {
-          hideThisToken = true;
+          return;
         }
 
-        // Deciding if this token should be hidden.
-        if (hideThisToken) return;
         return (
           <div key={tokenUid} className={`token-wrapper ${tokenUid === this.props.selectedToken ? 'selected' : ''}`} onClick={(e) => {this.tokenSelected(tokenUid)}}>
             <span className='ellipsis'>{token.symbol} {this.state.opened && ` | ${tokenBalance}`}</span>

--- a/src/screens/CustomTokens.js
+++ b/src/screens/CustomTokens.js
@@ -16,7 +16,18 @@ import BackButton from '../components/BackButton';
 import ModalAlertNotSupported from '../components/ModalAlertNotSupported';
 import { NFT_ENABLED } from '../constants';
 import hathorLib from '@hathor/wallet-lib';
+import { connect } from 'react-redux';
 
+/**
+ * Maps redux state to instance props
+ * @param state
+ * @returns {{tokensBalance:Object}}
+ */
+const mapStateToProps = (state) => {
+  return {
+    tokensBalance: state.tokensBalance,
+  };
+};
 
 /**
  * Initial screen of custom tokens
@@ -74,7 +85,7 @@ class CustomTokens extends React.Component {
           { NFT_ENABLED && <button className="btn btn-hathor mr-4" onClick={this.createNFTClicked}>{t`Create an NFT`}</button> }
           <button className="btn btn-hathor" onClick={this.registerTokenClicked}>{t`Register a token`}</button>
         </div>
-        <ModalAddToken success={this.newTokenSuccess} />
+        <ModalAddToken success={this.newTokenSuccess} tokensBalance={this.props.tokensBalance} />
         <HathorAlert ref="alertSuccess" text={t`Token registered with success!`} type="success" />
         <ModalAlertNotSupported />
       </div>
@@ -82,4 +93,4 @@ class CustomTokens extends React.Component {
   }
 }
 
-export default CustomTokens;
+export default connect(mapStateToProps)(CustomTokens);

--- a/src/screens/Settings.js
+++ b/src/screens/Settings.js
@@ -124,6 +124,10 @@ class Settings extends React.Component {
     $('#confirmModal').modal('show');
   }
 
+  /**
+   * Activates or deactivates the option to hide zero-balance tokens from the UI.
+   * @param {Event} e
+   */
   toggleZeroBalanceTokens = (e) => {
     e.preventDefault();
     const areZeroBalanceTokensHidden = wallet.areZeroBalanceTokensHidden();

--- a/src/screens/Settings.js
+++ b/src/screens/Settings.js
@@ -48,7 +48,10 @@ class Settings extends React.Component {
   dateSetTimeoutInterval = null
 
   componentDidMount() {
-    this.setState({ isNotificationOn: wallet.isNotificationOn() });
+    this.setState({
+      isNotificationOn: wallet.isNotificationOn(),
+      zeroBalanceTokensHidden: wallet.areZeroBalanceTokensHidden()
+    });
 
     this.dateSetTimeoutInterval = setInterval(() => {
       this.setState({ now: new Date() });
@@ -130,7 +133,7 @@ class Settings extends React.Component {
     } else {
       wallet.hideZeroBalanceTokens();
     }
-    this.setState({ zeroBalanceTokensHidden: areZeroBalanceTokensHidden });
+    this.setState({ zeroBalanceTokensHidden: !areZeroBalanceTokensHidden });
   }
 
   /**

--- a/src/screens/Settings.js
+++ b/src/screens/Settings.js
@@ -39,6 +39,7 @@ class Settings extends React.Component {
   state = {
     confirmData: {},
     isNotificationOn: null,
+    zeroBalanceTokensHidden: null,
     now: new Date(),
     showTimestamp: false,
   }
@@ -93,7 +94,7 @@ class Settings extends React.Component {
   }
 
   /**
-   * Called when user clicks to change notification settings  
+   * Called when user clicks to change notification settings
    * Sets modal state, depending on the current settings and open it
    *
    * @param {Object} e Event emitted on link click
@@ -120,8 +121,20 @@ class Settings extends React.Component {
     $('#confirmModal').modal('show');
   }
 
+  toggleZeroBalanceTokens = (e) => {
+    e.preventDefault();
+    const areZeroBalanceTokensHidden = wallet.areZeroBalanceTokensHidden();
+
+    if (areZeroBalanceTokensHidden) {
+      wallet.showZeroBalanceTokens();
+    } else {
+      wallet.hideZeroBalanceTokens();
+    }
+    this.setState({ zeroBalanceTokensHidden: areZeroBalanceTokensHidden });
+  }
+
   /**
-   * Called after user confirms the notification toggle action  
+   * Called after user confirms the notification toggle action
    * Toggle user notification settings, update screen state and close the confirm modal
    */
   handleToggleNotificationSettings = () => {
@@ -187,6 +200,7 @@ class Settings extends React.Component {
           <h4>{t`Advanced Settings`}</h4>
           <div className="d-flex flex-column align-items-start mt-4">
             <p><strong>{t`Allow notifications:`}</strong> {this.state.isNotificationOn ? <span>{t`Yes`}</span> : <span>{t`No`}</span>} <a className='ml-3' href="true" onClick={this.toggleNotificationSettings}> {t`Change`} </a></p>
+            <p><strong>{t`Hide zero-balance tokens:`}</strong> {this.state.zeroBalanceTokensHidden ? <span>{t`Yes`}</span> : <span>{t`No`}</span>} <a className='ml-3' href="true" onClick={this.toggleZeroBalanceTokens}> {t`Change`} </a></p>
             <p><strong>{t`Automatically report bugs to Hathor:`}</strong> {wallet.isSentryAllowed() ? <span>{t`Yes`}</span> : <span>{t`No`}</span>} <Link className='ml-3' to='/permission/'> {t`Change`} </Link></p>
             <CopyToClipboard text={uniqueIdentifier} onCopy={this.copied}>
               <span>

--- a/src/screens/Settings.js
+++ b/src/screens/Settings.js
@@ -154,9 +154,8 @@ class Settings extends React.Component {
 
   /**
    * Activates or deactivates the option to hide zero-balance tokens from the UI.
-   * @param {Event} e
    */
-  handleToggleZeroBalanceTokens = (e) => {
+  handleToggleZeroBalanceTokens = () => {
     const areZeroBalanceTokensHidden = wallet.areZeroBalanceTokensHidden();
 
     if (areZeroBalanceTokensHidden) {

--- a/src/screens/Settings.js
+++ b/src/screens/Settings.js
@@ -215,7 +215,7 @@ class Settings extends React.Component {
               }
               <a className="ml-3" href="true" onClick={this.toggleZeroBalanceTokens}> {t`Change`} </a>
               <i className="fa fa-question-circle pointer ml-3"
-                 title={t`When selected, any tokens with a balance of zero will not be displayed anywhere in the wallets.`}>
+                 title={t`When selected, any tokens with a balance of zero will not be displayed anywhere in the wallet.`}>
               </i>
             </p>
             <p><strong>{t`Automatically report bugs to Hathor:`}</strong> {wallet.isSentryAllowed() ? <span>{t`Yes`}</span> : <span>{t`No`}</span>} <Link className='ml-3' to='/permission/'> {t`Change`} </Link></p>

--- a/src/screens/Settings.js
+++ b/src/screens/Settings.js
@@ -200,7 +200,17 @@ class Settings extends React.Component {
           <h4>{t`Advanced Settings`}</h4>
           <div className="d-flex flex-column align-items-start mt-4">
             <p><strong>{t`Allow notifications:`}</strong> {this.state.isNotificationOn ? <span>{t`Yes`}</span> : <span>{t`No`}</span>} <a className='ml-3' href="true" onClick={this.toggleNotificationSettings}> {t`Change`} </a></p>
-            <p><strong>{t`Hide zero-balance tokens:`}</strong> {this.state.zeroBalanceTokensHidden ? <span>{t`Yes`}</span> : <span>{t`No`}</span>} <a className='ml-3' href="true" onClick={this.toggleZeroBalanceTokens}> {t`Change`} </a></p>
+            <p>
+              <strong>{t`Hide zero-balance tokens:`}</strong> {
+              this.state.zeroBalanceTokensHidden
+                ? <span>{t`Yes`}</span>
+                : <span>{t`No`}</span>
+              }
+              <a className="ml-3" href="true" onClick={this.toggleZeroBalanceTokens}> {t`Change`} </a>
+              <i className="fa fa-question-circle pointer ml-3"
+                 title={t`When selected, any tokens with a balance of zero will not be displayed anywhere in the wallets.`}>
+              </i>
+            </p>
             <p><strong>{t`Automatically report bugs to Hathor:`}</strong> {wallet.isSentryAllowed() ? <span>{t`Yes`}</span> : <span>{t`No`}</span>} <Link className='ml-3' to='/permission/'> {t`Change`} </Link></p>
             <CopyToClipboard text={uniqueIdentifier} onCopy={this.copied}>
               <span>

--- a/src/screens/Settings.js
+++ b/src/screens/Settings.js
@@ -125,11 +125,38 @@ class Settings extends React.Component {
   }
 
   /**
-   * Activates or deactivates the option to hide zero-balance tokens from the UI.
-   * @param {Event} e
+   * Called when user clicks to change the "Hide zero-balance tokens" flag.
+   * Sets modal state, depending on the current settings and open it.
+   *
+   * @param {Object} e Event emitted on link click
    */
   toggleZeroBalanceTokens = (e) => {
     e.preventDefault();
+    if (wallet.areZeroBalanceTokensHidden()) {
+      this.setState({
+        confirmData: {
+          title: t`Show zero-balance tokens`,
+          body: t`Are you sure you want to show all tokens, including those with zero balance?`,
+          handleYes: this.handleToggleZeroBalanceTokens
+        }
+      });
+    } else {
+      this.setState({
+        confirmData: {
+          title: t`Hide zero-balance tokens`,
+          body: t`Are you sure you want to hide tokens with zero balance?`,
+          handleYes: this.handleToggleZeroBalanceTokens
+        }
+      });
+    }
+    $('#confirmModal').modal('show');
+  }
+
+  /**
+   * Activates or deactivates the option to hide zero-balance tokens from the UI.
+   * @param {Event} e
+   */
+  handleToggleZeroBalanceTokens = (e) => {
     const areZeroBalanceTokensHidden = wallet.areZeroBalanceTokensHidden();
 
     if (areZeroBalanceTokensHidden) {
@@ -138,6 +165,7 @@ class Settings extends React.Component {
       wallet.hideZeroBalanceTokens();
     }
     this.setState({ zeroBalanceTokensHidden: !areZeroBalanceTokensHidden });
+    $('#confirmModal').modal('hide');
   }
 
   /**

--- a/src/screens/UnknownTokens.js
+++ b/src/screens/UnknownTokens.js
@@ -61,34 +61,30 @@ class UnknownTokens extends React.Component {
    * @return {Array} Array with unknown tokens {uid, balance, history}
    */
   getUnknownTokens = (hideZeroBalance) => {
-    let unknownTokens = [];
     this.historyRefs = [];
     this.anchorOpenRefs = [];
     this.anchorHideRefs = [];
-    for (const token of this.props.allTokens) {
-      // If has balance but does not have token saved yet
-      if (this.props.registeredTokens.find((x) => x.uid === token) === undefined) {
-        const filteredHistoryTransactions = hathorLib.wallet.filterHistoryTransactions(this.props.historyTransactions, token, false);
-        const balance = this.props.tokensBalance[token];
 
-        // Filtering tokens according to "hide zero balance tokens" setting
-        let hideThisToken = false;
-        const totalBalance = balance.available + balance.locked;
-        if (hideZeroBalance && totalBalance === 0) {
-          hideThisToken = true;
-        }
-        console.log({ hideThisToken, token, balance })
-        if (hideThisToken) {
-          continue;
-        }
+    const unknownTokens = wallet.fetchUnknownTokens({
+      allTokens: this.props.allTokens,
+      registeredTokens: this.props.registeredTokens,
+      tokensBalance: this.props.tokensBalance,
+      hideZeroBalance,
+    })
 
-        unknownTokens.push({'uid': token, 'balance': balance, 'history': filteredHistoryTransactions});
+    for (const tokenObj of unknownTokens) {
+      // Populating token transaction history on the object
+      tokenObj.history = hathorLib.wallet.filterHistoryTransactions(
+        this.props.historyTransactions,
+        tokenObj.uid,
+        false
+      );
 
-        this.historyRefs.push(React.createRef());
-        this.anchorOpenRefs.push(React.createRef());
-        this.anchorHideRefs.push(React.createRef());
-      }
+      this.historyRefs.push(React.createRef());
+      this.anchorOpenRefs.push(React.createRef());
+      this.anchorHideRefs.push(React.createRef());
     }
+
     return unknownTokens;
   }
 

--- a/src/screens/UnknownTokens.js
+++ b/src/screens/UnknownTokens.js
@@ -65,12 +65,12 @@ class UnknownTokens extends React.Component {
     this.anchorOpenRefs = [];
     this.anchorHideRefs = [];
 
-    const unknownTokens = wallet.fetchUnknownTokens({
-      allTokens: this.props.allTokens,
-      registeredTokens: this.props.registeredTokens,
-      tokensBalance: this.props.tokensBalance,
+    const unknownTokens = wallet.fetchUnknownTokens(
+      this.props.allTokens,
+      this.props.registeredTokens,
+      this.props.tokensBalance,
       hideZeroBalance,
-    })
+    );
 
     for (const tokenObj of unknownTokens) {
       // Populating token transaction history on the object
@@ -178,7 +178,7 @@ class UnknownTokens extends React.Component {
         <p>{t`Those are the custom tokens which you have at least one transaction. They are still unregistered in this wallet. You need to register a custom token in order to send new transactions using it.`}</p>
         <p className="mb-5">{t`If you have reset your wallet, you need to register your custom tokens again.`}</p>
         {unknownTokens && renderTokens()}
-        <ModalAddManyTokens success={this.massiveImportSuccess} />
+        <ModalAddManyTokens success={this.massiveImportSuccess} tokensBalance={this.props.tokensBalance} />
         <HathorAlert ref="alertSuccess" text={this.state.successMessage} type="success" />
         <TokenBar {...this.props}  />
       </div>

--- a/src/screens/Wallet.js
+++ b/src/screens/Wallet.js
@@ -25,6 +25,7 @@ import { connect } from "react-redux";
 import hathorLib from '@hathor/wallet-lib';
 import tokens from '../utils/tokens';
 import version from '../utils/version';
+import wallet from '../utils/wallet';
 import BackButton from '../components/BackButton';
 
 
@@ -140,18 +141,20 @@ class Wallet extends React.Component {
   /**
    * When user confirms the unregister of the token, hide the modal and execute it
    */
-  unregisterConfirmed = () => {
-    const promise = tokens.unregisterToken(this.props.selectedToken);
-    promise.then(() => {
+  unregisterConfirmed = async () => {
+    const tokenUid = this.props.selectedToken;
+    try {
+      await tokens.unregisterToken(tokenUid);
+      wallet.setTokenAlwaysShow(tokenUid, false); // Remove this token from "always show"
       $('#unregisterModal').modal('hide');
-    }, (e) => {
+    } catch (e) {
       this.unregisterModalRef.current.updateErrorMessage(e.message);
-    });
+    }
   }
 
   /*
    * We show the administrative tools tab only for the users that one day had an authority output, even if it was already spent
-   * 
+   *
    * This will set the shouldShowAdministrativeTab state param based on the response of getMintAuthority and getMeltAuthority
    */
   shouldShowAdministrativeTab = async (tokenId) => {

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -832,6 +832,38 @@ const wallet = {
   },
 
   /**
+   * Checks if the zero-balance tokens are set to be hidden
+   *
+   * @return {boolean} If the tokens are hidden
+   *
+   * @memberof Wallet
+   * @inner
+   */
+  areZeroBalanceTokensHidden() {
+    return storage.getItem('wallet:hide_zero_balance_tokens') !== false;
+  },
+
+  /**
+   * Turns on the hiding of zero-balance tokens
+   *
+   * @memberof Wallet
+   * @inner
+   */
+  hideZeroBalanceTokens() {
+    storage.setItem('wallet:hide_zero_balance_tokens', true);
+  },
+
+  /**
+   * Turns off the hiding of zero-balance tokens
+   *
+   * @memberof Wallet
+   * @inner
+   */
+  showZeroBalanceTokens() {
+    storage.setItem('wallet:hide_zero_balance_tokens', false);
+  },
+
+  /**
    * Converts a decimal value to integer. On the full node and the wallet lib, we only deal with
    * integer values for amount. So a value of 45.97 for the user is handled by them as 4597.
    * We need the Math.round because of some precision errors in js

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -65,6 +65,27 @@ if (window.require) {
 }
 
 /**
+ * Key string constants for manipulating the storage
+ * @type {{
+ * lastSharedIndex: string,
+ * notification: string,
+ * address: string,
+ * data: string,
+ * hideZeroBalanceTokens: string,
+ * sentry: string
+ * }}
+ * @readonly
+ */
+const storageKeys = {
+  address: 'wallet:address',
+  lastSharedIndex: 'wallet:lastSharedIndex',
+  data: 'wallet:data',
+  sentry: 'wallet:sentry',
+  notification: 'wallet:notification',
+  hideZeroBalanceTokens: 'wallet:hide_zero_balance_tokens',
+}
+
+/**
  * We use localStorage and Redux to save data.
  * In localStorage we have the following keys (prefixed by wallet:)
  * - data: object with data from the wallet including (all have full description in the reducers file)
@@ -598,8 +619,8 @@ const wallet = {
     const allTokens = 'allTokens' in data ? data['allTokens'] : [];
     const transactionsFound = Object.keys(historyTransactions).length;
 
-    const address = storage.getItem('wallet:address');
-    const lastSharedIndex = storage.getItem('wallet:lastSharedIndex');
+    const address = storage.getItem(storageKeys.address);
+    const lastSharedIndex = storage.getItem(storageKeys.lastSharedIndex);
     const lastGeneratedIndex = oldWalletUtil.getLastGeneratedIndex();
 
     store.dispatch(historyUpdate({
@@ -650,7 +671,7 @@ const wallet = {
    */
   updateSharedAddress() {
     const lastSharedIndex = oldWalletUtil.getLastSharedIndex();
-    const lastSharedAddress = storage.getItem('wallet:address');
+    const lastSharedAddress = storage.getItem(storageKeys.address);
     this.updateSharedAddressRedux(lastSharedAddress, lastSharedIndex);
   },
 
@@ -713,10 +734,10 @@ const wallet = {
       // XXX from v0.12.0 to v0.13.0, xpubkey changes from wallet:data to access:data.
       // That's not a problem if wallet is being initialized. However, if it's already
       // initialized, we need to set the xpubkey in the correct place.
-      const oldData = JSON.parse(localStorage.getItem('wallet:data'));
+      const oldData = JSON.parse(localStorage.getItem(storageKeys.data));
       accessData.xpubkey = oldData.xpubkey;
       oldWalletUtil.setWalletAccessData(accessData);
-      localStorage.removeItem('wallet:data');
+      localStorage.removeItem(storageKeys.data);
     }
 
     // Load history from new server
@@ -746,7 +767,7 @@ const wallet = {
    * @inner
    */
   allowSentry() {
-    storage.setItem('wallet:sentry', true);
+    storage.setItem(storageKeys.sentry, true);
     this.updateSentryState();
   },
 
@@ -757,7 +778,7 @@ const wallet = {
    * @inner
    */
   disallowSentry() {
-    storage.setItem('wallet:sentry', false);
+    storage.setItem(storageKeys.sentry, false);
     this.updateSentryState();
   },
 
@@ -770,7 +791,7 @@ const wallet = {
    * @inner
    */
   getSentryPermission() {
-    return storage.getItem('wallet:sentry');
+    return storage.getItem(storageKeys.sentry);
   },
 
   /**
@@ -850,7 +871,7 @@ const wallet = {
    * @inner
    */
   isNotificationOn() {
-    return storage.getItem('wallet:notification') !== false;
+    return storage.getItem(storageKeys.notification) !== false;
   },
 
   /**
@@ -860,7 +881,7 @@ const wallet = {
    * @inner
    */
   turnNotificationOn() {
-    storage.setItem('wallet:notification', true);
+    storage.setItem(storageKeys.notification, true);
   },
 
   /**
@@ -870,7 +891,7 @@ const wallet = {
    * @inner
    */
   turnNotificationOff() {
-    storage.setItem('wallet:notification', false);
+    storage.setItem(storageKeys.notification, false);
   },
 
   /**
@@ -882,7 +903,7 @@ const wallet = {
    * @inner
    */
   areZeroBalanceTokensHidden() {
-    return storage.getItem('wallet:hide_zero_balance_tokens') !== false;
+    return storage.getItem(storageKeys.hideZeroBalanceTokens) !== false;
   },
 
   /**
@@ -892,7 +913,7 @@ const wallet = {
    * @inner
    */
   hideZeroBalanceTokens() {
-    storage.setItem('wallet:hide_zero_balance_tokens', true);
+    storage.setItem(storageKeys.hideZeroBalanceTokens, true);
   },
 
   /**
@@ -902,7 +923,7 @@ const wallet = {
    * @inner
    */
   showZeroBalanceTokens() {
-    storage.setItem('wallet:hide_zero_balance_tokens', false);
+    storage.setItem(storageKeys.hideZeroBalanceTokens, false);
   },
 
   /**


### PR DESCRIPTION
This feature adds a new option in the wallet settings, “Hide zero-balance tokens”. When checked, any tokens with a balance of zero would not be displayed anywhere in the wallets.

### Acceptance Criteria
- When “Hide zero-balance tokens” is checked, any tokens without a balance should be hidden everywhere in the wallet.
- If the user unchecks the option again, they should be shown.
- User should be allowed to register zero-balance tokens even if the flag is active.
- User should be able to create exceptions for selected tokens ( "Always show" flag )
  - [ ] #310 

#### Changes demonstration
The video below shows a wallet with registered and unregistered tokens with zero balance. When the "hide" flag is activated on the settings screen, those tokens are hidden from the user on all screens.

https://user-images.githubusercontent.com/1299409/167445861-fc63d095-db50-4f5b-8310-6793fe0d0d3a.mp4


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
