### PR TITLE
chore: enable require on renderer process

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -60,6 +60,7 @@ function createWindow () {
     icon: path.join(__dirname, iconOS),
     webPreferences: {
       nodeIntegration: true,
+      contextIsolation: false,
       preload: path.join(__dirname, 'preload.js')
     }
   })

--- a/src/components/ModalLedgerSignToken.js
+++ b/src/components/ModalLedgerSignToken.js
@@ -111,7 +111,8 @@ function ModalLedgerSignToken({token, modalId, cb}) {
     setWaitingLedger(false);
     if (arg.success) {
       // save token signature on storage
-      tokens.addTokenSignature(token.uid, arg.data.toString("hex"));
+      const hexSignature = Buffer.from(arg.data).toString('hex');
+      tokens.addTokenSignature(token.uid, hexSignature);
       setOk(true);
       // Signal parent that the token signature has been added
       cb(true);

--- a/src/screens/WalletType.js
+++ b/src/screens/WalletType.js
@@ -72,7 +72,7 @@ class WalletType extends React.Component {
   handleVersion = (event, arg) => {
     if (arg.success) {
       // compare ledger version with our min version
-      const version = arg.data.slice(3, 6).join('.');
+      const version = Buffer.from(arg.data).slice(3, 6).join('.');
       hathorLib.storage.setItem('ledger:version', version);
       if (
         helpers.cmpVersionString(version, LEDGER_MIN_VERSION) < 0 ||
@@ -121,11 +121,11 @@ class WalletType extends React.Component {
     }
 
     if (arg.success) {
-      const data = arg.data;
+      const data = Buffer.from(arg.data);
       const uncompressedPubkey = data.slice(0, 65);
       const compressedPubkey = hathorLib.wallet.toPubkeyCompressed(uncompressedPubkey);
-      const chainCode = Buffer.from(data.slice(65, 97));
-      const fingerprint = Buffer.from(data.slice(97, 101));
+      const chainCode = data.slice(65, 97);
+      const fingerprint = data.slice(97, 101);
       const xpub = hathorLib.wallet.xpubFromData(compressedPubkey, chainCode, fingerprint);
 
       wallet.startWallet(null, '', null, '', this.props.history, false, xpub);


### PR DESCRIPTION
### Acceptance Criteria
- Enable Ledger to work with upgraded dependencies

### Explanation

To communicate with Ledger we use a library to send/receive data to the USB port and the version we currently use of this library cannot run on the renderer process. So we run any call to Ledger on the main process and use the `electron.IpcRenderer` to send and receive events between the main process and the renderer process.

On electron version 12 a breaking change was introduced ([changelog here](https://www.electronjs.org/docs/latest/breaking-changes#default-changed-contextisolation-defaults-to-true)) that changed the default of the `contextIsolation` which (among other things) enables or disables the use of `require` to import node packages on the renderer process, including the 'electron' package itself.

Once we disabled the `contextIsolation`  there was a second issue, in some places the binary type `Uint8Array` was being used instead of `Buffer` so we converted to `Buffer` where needed to use a consistent api for binary data.

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
