### PR TITLE
fix: add scroll to token bar component

### DIFF
--- a/src/components/TokenBar.js
+++ b/src/components/TokenBar.js
@@ -178,7 +178,7 @@ class TokenBar extends React.Component {
 
     return (
       <div className={`d-flex flex-column align-items-center justify-content-between token-bar ${this.state.opened ? 'opened' : 'closed'}`}>
-        <div className='d-flex flex-column align-items-center justify-content-between w-100'>
+        <div className='d-flex flex-column align-items-center justify-content-between w-100 first-child'>
           <div className='header d-flex align-items-center justify-content-center w-100' onClick={this.toggleExpand}>
             {this.state.opened ? renderExpandedHeader() : <i className='fa fa-chevron-right' title='Expand bar'></i>}
           </div>

--- a/src/index.scss
+++ b/src/index.scss
@@ -573,6 +573,10 @@ svg.svg-wrapper {
   font-size: 1.2rem;
 }
 
+.token-bar .first-child {
+  overflow: auto;
+}
+
 .token-bar .body {
   width: 100%;
   overflow-y: auto;


### PR DESCRIPTION
### Summary

With the upgrade of sass in the new version, the scroll in the token bar stopped working. The solution for this new version is to add a style `overflow: auto;` to the parent element to the one that needs to have a scroll.

### Acceptance Criteria
- Add scroll to token bar
- Add this test to the QA


#### Before the fix

<img width="79" alt="image" src="https://user-images.githubusercontent.com/3298774/174328006-cf942415-b847-488c-87a4-e87cdec59911.png">

#### After the fix

<img width="78" alt="image" src="https://user-images.githubusercontent.com/3298774/174327886-8c40a7c5-7d5d-4af9-ab63-8322b5a1b400.png">

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
