### PR TITLE
feat: add feature to export configuration strings for registered tokens

### DIFF
--- a/src/components/ModalResetAllData.js
+++ b/src/components/ModalResetAllData.js
@@ -117,6 +117,7 @@ class ModalResetAllData extends React.Component {
             </div>
             <div className="modal-body">
               <p>{getFirstMessage()}</p>
+              <p>{t`You will need to register all your tokens again when your import your words. If you prefer, you can go to Settings > Export Registered Tokens, in order to have a list of your tokens, so you don't need to register them one by one after you start your wallet again.`}</p>
               <p><SpanFmt>{t`If you still wanna do it, we need your password and for you to write down **'${CONFIRM_RESET_MESSAGE}'** to confirm the operation.`}</SpanFmt></p>
               <form ref="formConfirm">
                 <div className="form-group">

--- a/src/screens/Settings.js
+++ b/src/screens/Settings.js
@@ -27,6 +27,7 @@ import { connect } from "react-redux";
 const mapStateToProps = (state) => {
   return {
     useWalletService: state.useWalletService,
+    registeredTokens: state.tokens,
   };
 };
 
@@ -93,6 +94,35 @@ class Settings extends React.Component {
     } else {
       this.props.history.push('/wallet/passphrase/');
     }
+  }
+
+  /**
+   * When user clicks Export Registered Tokens button, then we save all config strings in a txt file
+   */
+  exportTokens = () => {
+    // The file text will be the configuration strings of each registered token, one each line
+    //
+    // First we get all token configs from registered tokens array,
+    // remove the HTR token with filter, then map to each configuration string
+    const configurationStrings = this.props.registeredTokens.filter((token) => {
+      return token.uid !== hathorLib.constants.HATHOR_TOKEN_CONFIG.uid;
+    }).map((token) => {
+      return hathorLib.tokens.getConfigurationString(token.uid, token.name, token.symbol);
+    });
+
+    // The text will be all the configuration strings, one for each line
+    const text = configurationStrings.join('\n');
+
+    // Create the hidden a element to trigger the download
+    const element = document.createElement('a');
+    const file = new Blob([text], {
+      type: 'text/plain'
+    });
+    element.href = URL.createObjectURL(file);
+    element.download = 'Hathor Wallet - Tokens.txt';
+    document.body.appendChild(element);
+    element.click();
+    element.remove();
   }
 
   /**
@@ -263,7 +293,8 @@ class Settings extends React.Component {
                 <p><strong>{t`Unique identifier`}:</strong> {uniqueIdentifier} <i className="fa fa-clone pointer ml-1" title={t`Copy to clipboard`}></i></p>
               </span>
             </CopyToClipboard>
-            <button className="btn btn-hathor" onClick={this.addPassphrase}>{t`Set a passphrase`}</button>
+            <button className="btn btn-hathor" onClick={this.exportTokens}>{t`Export Registered Tokens`}</button>
+            <button className="btn btn-hathor mt-4" onClick={this.addPassphrase}>{t`Set a passphrase`}</button>
             {ledgerCustomTokens && <button className="btn btn-hathor mt-4" onClick={this.untrustClicked}>{t`Untrust all tokens on Ledger`}</button> }
             <button className="btn btn-hathor mt-4" onClick={this.resetClicked}>{t`Reset all data`}</button>
           </div>


### PR DESCRIPTION
### Summary

Many users have hundreds of tokens and, when they reset their wallets, or change devices, they must register all of them again. We already have in the desktop wallet the possibility of a bulk import in the Unknown Tokens screen, we only needed a feature to export all registered tokens, so the users won't have to register all of them again.

### Acceptance Criteria
- Users should be able to export the configuration strings of all registered tokens


https://user-images.githubusercontent.com/3298774/176432891-98d8d429-b338-43b0-8463-4fd6c613615d.mov

- Following @tuliomir's suggestion (https://github.com/HathorNetwork/hathor-wallet/pull/331#issuecomment-1170330708) I've added a message in the reset modal about the export tokens feature.

<img width="1009" alt="image" src="https://user-images.githubusercontent.com/3298774/177189460-566d839a-dcad-494b-84e8-aafb8432be8d.png">

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
