### PR TITLE
feat: release ledger transport when not in use

### DIFF
--- a/public/ledger.js
+++ b/public/ledger.js
@@ -128,8 +128,10 @@ class Ledger {
           this.hathorAppOpened = false;
           // If we don't close it when changing the app we get an error
           // https://github.com/LedgerHQ/ledgerjs/issues/22
-          this.transport.device.close();
-          this.transport = null;
+          if (this.transport) {
+            this.transport.device.close();
+            this.transport = null;
+          }
         }
       },
       error: error => {},
@@ -170,6 +172,11 @@ class Ledger {
         this.checkSendQueue();
       });
     } else {
+      // no more commands on queue, we can release the transport connection
+      if (this.transport) {
+        this.transport.device.close();
+        this.transport = null;
+      }
       this.canSend = true;
     }
   }


### PR DESCRIPTION
### Acceptance Criteria

- Close transport when not in use
- Do not change behavior for current Hardware wallet

### Behavior

https://user-images.githubusercontent.com/15909384/178019501-d1458fe6-d3c0-4ae2-87c3-94d527bdb43c.mp4

When opening the manager, no interaction with the Ledger was made.
Ledger Live manager closed the Hathor app, which signaled to the wallet to close, then asked confirmation to trust the manager. 

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
