### PR TITLE
feat: update local storage with metadata on nft creation

### DIFF
--- a/src/screens/CreateNFT.js
+++ b/src/screens/CreateNFT.js
@@ -170,7 +170,7 @@ class CreateNFT extends React.Component {
     tokens.addToken(token.uid, name, symbol);
     // Must update the shared address, in case we have used one for the change
     wallet.updateSharedAddress();
-    // Also update the local storage with the NFT metadata for correct exhibition on all screens
+    // Also update the redux state with the NFT metadata for correct exhibition on all screens
     wallet.setLocalTokenMetadata(token.uid, {
       id: token.uid,
       nft: true,

--- a/src/screens/CreateNFT.js
+++ b/src/screens/CreateNFT.js
@@ -257,7 +257,7 @@ class CreateNFT extends React.Component {
     // so this must be 0.01 (the text will show 0.01%) because the amount to create for NFTs is an integer.
     // Then to create 100 units, the deposit is 0.01 HTR, to create 1,000 units the deposit is 0.1 HTR
     const htrDeposit = hathorLib.tokens.getDepositPercentage();
-    const depositAmount = hathorLib.tokens.getDepositAmount(this.state.amount);
+    const depositAmount = hathorLib.tokens.getDepositAmount(this.state.amount); 
     const nftFee = hathorLib.helpers.prettyValue(tokens.getNFTFee());
 
     return (

--- a/src/screens/CreateNFT.js
+++ b/src/screens/CreateNFT.js
@@ -170,6 +170,11 @@ class CreateNFT extends React.Component {
     tokens.addToken(token.uid, name, symbol);
     // Must update the shared address, in case we have used one for the change
     wallet.updateSharedAddress();
+    // Also update the local storage with the NFT metadata for correct exhibition on all screens
+    wallet.setLocalTokenMetadata(token.uid, {
+      id: token.uid,
+      nft: true,
+    });
     this.showAlert(token);
   }
 
@@ -252,7 +257,7 @@ class CreateNFT extends React.Component {
     // so this must be 0.01 (the text will show 0.01%) because the amount to create for NFTs is an integer.
     // Then to create 100 units, the deposit is 0.01 HTR, to create 1,000 units the deposit is 0.1 HTR
     const htrDeposit = hathorLib.tokens.getDepositPercentage();
-    const depositAmount = hathorLib.tokens.getDepositAmount(this.state.amount); 
+    const depositAmount = hathorLib.tokens.getDepositAmount(this.state.amount);
     const nftFee = hathorLib.helpers.prettyValue(tokens.getNFTFee());
 
     return (

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -314,6 +314,23 @@ const wallet = {
   },
 
   /**
+   * Updates the local database with known token metadata.
+   *
+   * When a token is created on the application (e.g. an NFT), we do not need to wait until the
+   * metadata service validates it to have some of its information that we already know. ( e.g.:
+   * hide the decimals on amount of tokens exhibition )
+   *
+   * @param {string} tokenUid Token hash
+   * @param {Object} metadata Metadata to be inserted for this token
+   */
+  setLocalTokenMetadata(tokenUid, metadata) {
+    const metadataPerToken = {};
+    metadataPerToken[tokenUid] = metadata;
+
+    store.dispatch(tokenMetadataUpdated(metadataPerToken, []));
+  },
+
+  /**
    * Fetches both history and balance for the affected tokens in updatedBalanceMap
    *
    * @param {HathorWallet} wallet object


### PR DESCRIPTION
When a user creates an NFT, the application creates a simplified version of the NFT metadata locally instead of waiting for the `explorer-service`'s response with the complete metadata.

The wallet service's response will still override the simplified local version, but the user will have the improved NFT experience immediately.

### Acceptance Criteria
- Show newly-created NFT's correct type on the token screen

### Preview
----- 

**Before: Custom token exhibition**
![Screenshot Custom Token](https://user-images.githubusercontent.com/1299409/178036521-fa947248-325f-4076-9a82-b23bee7c64b9.png)

-----

**After: NFT Exhibition**
![Screenshot NFT](https://user-images.githubusercontent.com/1299409/178036463-d9be070f-a5fc-4691-960c-fe0ad38b13ad.png)

-----

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
