### PR TITLE
chore: Tools for Windows release with EV Code Signature from YubiKey

### DIFF
--- a/ELECTRON.md
+++ b/ELECTRON.md
@@ -53,3 +53,36 @@ For Windows, you need to create the following environment variables:
     export WIN_CSC_KEY_PASSWORD=your_certificate_password
 
 Then, just build it.
+
+### Windows EV Code Signing
+
+To sign using an EV Code Signing Certificate in a YubiKey, [follow this guide](https://www.electron.build/tutorials/code-signing-windows-apps-on-unix.html).
+
+Use [JSign](https://ebourg.github.io/jsign/) to sign files; use osslsigncode to verify the signature.
+
+On macOS, you should install the following: `brew install yubico-piv-tool osslsigncode1`.
+
+You can use the following commands to test whether it is working on your computer:
+
+```bash
+
+# First, sign the exe.
+java \
+  --add-exports jdk.crypto.cryptoki/sun.security.pkcs11=ALL-UNNAMED \
+  --add-exports jdk.crypto.cryptoki/sun.security.pkcs11.wrapper=ALL-UNNAMED \
+  --add-opens java.base/java.security=ALL-UNNAMED \
+  -jar jsign-4.2.jar \
+  --storetype YUBIKEY \
+  --certfile "$WIN_EV_CERTIFICATE_FILE" \
+  --storepass "$WIN_EV_TOKEN_PASSWORD" \
+  --alias "$WIN_EV_CERTIFICATE_NAME" \
+  ./dist/Hathor\ Wallet\ Setup\ 0.24.0.exe
+
+# Then, verify the signature is correct.
+osslsigncode verify dist/Hathor\ Wallet\ Setup\ 0.24.0.exe
+```
+
+#### Troubleshooting:
+
+Error: YubiKey PKCS11 module (ykcs11) is not installed
+Fix: `brew install yubico-piv-tool`

--- a/package.json
+++ b/package.json
@@ -105,19 +105,17 @@
     "win": {
       "icon": "build/icon.png",
       "target": "nsis",
-      "publisherName": "Hathor Labs"
+      "publisherName": "Hathor Labs",
+      "sign": "./scripts/win-ev-sign.js"
     },
     "mac": {
-      "provisioningProfile": "mac_production.provisionprofile",
+      "provisioningProfile": "keys/mac_production.provisionprofile",
       "hardenedRuntime": true,
       "gatekeeperAssess": false,
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.plist",
       "icon": "build/icon.icns",
-      "target": [
-        "dmg",
-        "pkg"
-      ]
+      "target": "dmg"
     },
     "linux": {
       "target": [

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# Script to release new versions for Windows, macOS, and Linux.
+#
+# This script expects a file `./env` with exported envvars to sign executables
+# for Windows and macOS.
+#
+# The commented cmdlines were used in the past to fix different kind of issues.
+# They were left here because they might be useful for troubleshooting in the future.
+
+set -e  # Exit on any command failure.
+set -u  # Exit on unset variables.
+
+step1() {
+	echo step1: cleaning and installing dependencies
+	rm -rf node_modules/
+	npm install
+}
+
+step2() {
+	echo step2: transaction checks and building
+	make check
+	make i18n
+
+	rm -rf build/
+	#export NODE_OPTIONS=--max_old_space_size=2048
+	npm run build
+}
+
+step3() {
+	echo "step3: (empty)"
+	#echo step3: install missing packing tools
+	#npm install electron-builder@latest
+}
+
+step4() {
+	echo step4: packing
+	source ./env
+	npm run electron-pack-linux
+	npm run electron-pack-win
+	npm run electron-pack-mac
+}
+
+step1
+step2
+step3
+step4

--- a/scripts/win-ev-sign.js
+++ b/scripts/win-ev-sign.js
@@ -1,0 +1,40 @@
+// Script to sign a file using an EV Code Signing Certificate in a YubiKey.
+//
+// It expects `jsign-4.2.jar` to be at the same folder you are running this script.
+// JSign depends on having `yubico-piv-tool` installed.
+//
+// Envvars:
+// - WIN_EV_CERTIFICATE_FILE: Path to certificate (crt file)
+// - WIN_EV_CERTIFICATE_NAME: Certificate name in YubiKey (use YubiKey Manager to check)
+// - WIN_EV_TOKEN_PASSWORD: PIN for YubiKey PIV Certificate
+//
+// For further information, see Windows EV Code Signing in ELECTRON.md.
+//
+// Adapted from: https://www.electron.build/tutorials/code-signing-windows-apps-on-unix.html
+
+
+exports.default = async function(configuration) {
+  const CERTIFICATE_FILE = process.env.WIN_EV_CERTIFICATE_FILE;
+  const CERTIFICATE_NAME = process.env.WIN_EV_CERTIFICATE_NAME;
+  const TOKEN_PASSWORD = process.env.WIN_EV_TOKEN_PASSWORD;
+
+  cmdline = [
+    "java",
+    "--add-exports jdk.crypto.cryptoki/sun.security.pkcs11=ALL-UNNAMED",
+    "--add-exports jdk.crypto.cryptoki/sun.security.pkcs11.wrapper=ALL-UNNAMED",
+    "--add-opens java.base/java.security=ALL-UNNAMED",
+    "-jar jsign-4.2.jar",
+    "--storetype YUBIKEY",
+    `--certfile "${CERTIFICATE_FILE}"`,
+    `--storepass "${TOKEN_PASSWORD}"`,
+    `--alias "${CERTIFICATE_NAME}"`,
+    `"${configuration.path}"`
+  ];
+
+  require("child_process").execSync(
+    cmdline.join(" "),
+    {
+      stdio: "inherit"
+    }
+  );
+};


### PR DESCRIPTION
### Acceptance Criteria
- Sign Windows executable using an EV Code Signing Certificate in a YubiKey.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
