### PR TITLE
refactor: using new feature flag schema

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,13 +13,20 @@ on:
 jobs:
   cypress-run:
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        node-version: [14.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Setup nodejs
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
       # Install NPM dependencies, cache them correctly
       # and run all Cypress tests
       - name: Cypress run
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v5
         with:
           start: npm start
           wait-on: 'http://localhost:3000'

--- a/src/constants.js
+++ b/src/constants.js
@@ -256,3 +256,8 @@ export const DEFAULT_WALLET_SERVICE_WS_SERVERS = [
 export const UNLEASH_URL = 'https://unleash-proxy.b7e6a7f52ee9fefaf0c53e300cfcb014.hathor.network/proxy';
 export const UNLEASH_CLIENT_KEY = 'wKNhpEXKa39aTRgIjcNsO4Im618bRGTq';
 export const UNLEASH_POLLING_INTERVAL = 120; // seconds
+
+/**
+ * The feature toggle configured in Unleash
+ */
+export const WALLET_SERVICE_FEATURE_TOGGLE = 'wallet-service-desktop.rollout';

--- a/src/featureFlags.js
+++ b/src/featureFlags.js
@@ -4,6 +4,7 @@ import {
   UNLEASH_URL,
   UNLEASH_CLIENT_KEY,
   UNLEASH_POLLING_INTERVAL,
+  WALLET_SERVICE_FEATURE_TOGGLE,
 } from './constants';
 
 const IGNORE_WALLET_SERVICE_FLAG = 'featureFlags:ignoreWalletServiceFlag';
@@ -18,7 +19,7 @@ export class FeatureFlags extends events.EventEmitter {
 
     this.userId = userId;
     this.network = network;
-    this.walletServiceFlag = `wallet-service-wallet-desktop-${this.network}.rollout`;
+    this.walletServiceFlag = WALLET_SERVICE_FEATURE_TOGGLE;
     this.walletServiceEnabled = null;
     this.client = new UnleashClient({
       url: UNLEASH_URL,
@@ -57,7 +58,10 @@ export class FeatureFlags extends events.EventEmitter {
       if (shouldIgnore) {
         return false;
       }
-      this.client.updateContext({ userId: this.userId });
+      this.client.updateContext({
+        userId: this.userId,
+        stage: this.network,
+      });
 
       // Start polling for feature flag updates
       await this.client.start();

--- a/src/featureFlags.js
+++ b/src/featureFlags.js
@@ -6,6 +6,7 @@ import {
   UNLEASH_POLLING_INTERVAL,
   WALLET_SERVICE_FEATURE_TOGGLE,
 } from './constants';
+import helpers from './utils/helpers';
 
 const IGNORE_WALLET_SERVICE_FLAG = 'featureFlags:ignoreWalletServiceFlag';
 
@@ -60,7 +61,10 @@ export class FeatureFlags extends events.EventEmitter {
       }
       this.client.updateContext({
         userId: this.userId,
-        stage: this.network,
+        properties: {
+          stage: this.network,
+          platform: helpers.getCurrentOS(),
+        },
       });
 
       // Start polling for feature flag updates

--- a/src/featureFlags.js
+++ b/src/featureFlags.js
@@ -62,7 +62,7 @@ export class FeatureFlags extends events.EventEmitter {
       this.client.updateContext({
         userId: this.userId,
         properties: {
-          stage: this.network,
+          network: this.network,
           platform: helpers.getCurrentOS(),
         },
       });

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -5,11 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import path from 'path';
+import hathorLib from '@hathor/wallet-lib';
+import { get } from 'lodash';
 import store from '../store/index';
 import { networkUpdate } from '../actions/index';
-import hathorLib from '@hathor/wallet-lib';
 import { EXPLORER_BASE_URL, TESTNET_EXPLORER_BASE_URL } from '../constants';
-import path from 'path';
 
 let shell = null;
 if (window.require) {
@@ -228,7 +229,7 @@ const helpers = {
      * Since the wallet-desktop only runs in desktops, we can return 'other' for any other
      * platform that is not windows, mac or linux
      */
-    const platform = window.clientInformation['platform'].toLowerCase();
+    const platform = get(window, 'clientInformation.platform', 'other').toLowerCase();
 
     if (platform.includes('win')) {
       return 'windows';

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -200,7 +200,46 @@ const helpers = {
       is_voided: Boolean(tx.voided),
       version: tx.version,
     };
-  }
+  },
+
+  /**
+   * Returns the current OS
+   *
+   * @returns {string} 'macos', 'windows', 'linux' or 'other'
+   */
+  getCurrentOS() {
+    if (!window) {
+      return 'other';
+    }
+
+    /**
+     * Possible values for clientInformation['platform'] are:
+     * "Win32" - indicates the browser is running on a 32-bit version of Windows.
+     * "Win64" - indicates the browser is running on a 64-bit version of Windows.
+     * "MacIntel" - indicates the browser is running on an Intel-based Mac.
+     * "MacPPC" - indicates the browser is running on a PowerPC-based Mac.
+     * "Linux i686" - indicates the browser is running on a 32-bit version of Linux.
+     * "Linux x86_64" - indicates the browser is running on a 64-bit version of Linux.
+     * "Android" - indicates the browser is running on an Android device.
+     * "iPhone" - indicates the browser is running on an iPhone.
+     * "iPad" - indicates the browser is running on an iPad.
+     * "iPod" - indicates the browser is running on an iPod.
+     *
+     * Since the wallet-desktop only runs in desktops, we can return 'other' for any other
+     * platform that is not windows, mac or linux
+     */
+    const platform = window.clientInformation['platform'].toLowerCase();
+
+    if (platform.includes('win')) {
+      return 'windows';
+    } else if (platform.includes('mac')) {
+      return 'macos';
+    } else if (platform.includes('linux')) {
+      return 'linux';
+    }
+
+    return 'other';
+  },
 }
 
 export default helpers;


### PR DESCRIPTION
This is the new configured feature flag in unleash: 

![image](https://user-images.githubusercontent.com/3586068/220949792-539d775f-c7c7-4998-aad5-6f34145be728.png)


### Acceptance Criteria
- We should pass the network as the `stage` property when updating unleash context to make use of the [new wallet-desktop feature flag](https://unleash.internal.hathor.network/projects/default/features/wallet-service-desktop.rollout)


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
