### PR TITLE
refactor: Dedicated pin modal

### DIFF
--- a/src/__tests__/components/ModalPin.test.js
+++ b/src/__tests__/components/ModalPin.test.js
@@ -8,6 +8,7 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
 let container = null;
+const MODAL_ID = '#modalPin';
 
 // This allows the calls to Bootstrap's $('#modalId').modal('show') to work.
 $.fn.modal = jest.fn();
@@ -49,7 +50,7 @@ describe('rendering tests', () => {
     )
 
     // Force creating the event, since the whole `modal` bootstrap class is mocked
-    $('#modalPin').trigger('shown.bs.modal');
+    $(MODAL_ID).trigger('shown.bs.modal');
     const element = screen.getByText('This is an extra element');
     expect(element instanceof HTMLElement).toStrictEqual(true);
   })
@@ -159,7 +160,7 @@ describe('pin validation', () => {
     expect(element).toBeNull();
 
     // Force creating the event, since the whole `modal` bootstrap class is mocked
-    $('#modalPin').trigger('hidden.bs.modal');
+    $(MODAL_ID).trigger('hidden.bs.modal');
     expect(successCallback).toHaveBeenCalledWith({ pin: pinText });
     expect(closeCallback).toHaveBeenCalled();
   });

--- a/src/__tests__/components/ModalPin.test.js
+++ b/src/__tests__/components/ModalPin.test.js
@@ -154,4 +154,43 @@ describe('pin validation', () => {
     expect(successCallback).toHaveBeenCalledWith({ pin: pinText });
     expect(closeCallback).toHaveBeenCalled();
   });
+
+  it('invokes handleChangePin callback correctly', async () => {
+    const successCallback = jest.fn();
+    const closeCallback = jest.fn();
+
+    // Validating that all inputs are correctly processed in order
+    const pinText = '123321';
+    const receivedEvents = [];
+    const expectedReceivedEvents = [
+      '1',
+      '12',
+      '123',
+      '1233',
+      '12332',
+      '123321',
+    ]
+    const changePinCallback = jest.fn().mockImplementation((e) => {
+      receivedEvents.push(e.target.value);
+    });
+
+    act(() => {
+      render(
+        <ModalPin
+          onSuccess={successCallback}
+          onClose={closeCallback}
+          handleChangePin={changePinCallback}
+        />,
+        container
+      )
+    });
+
+    // Get the pin input element
+    /** @type HTMLElement */
+    const pinInput = screen.getByTestId('pin-input');
+
+    await userEvent.type(pinInput, pinText);
+    expect(changePinCallback).toHaveBeenCalledTimes(6);
+    expect(receivedEvents).toStrictEqual(expectedReceivedEvents);
+  });
 });

--- a/src/__tests__/components/ModalPin.test.js
+++ b/src/__tests__/components/ModalPin.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { unmountComponentAtNode } from 'react-dom';
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import $ from 'jquery'
 import hathorLib from '@hathor/wallet-lib';
 import { ModalPin } from '../../components/ModalPin';
@@ -29,7 +29,8 @@ describe('rendering tests', () => {
   it('renders without crashing', () => {
     render(
       <ModalPin
-        wallet={{ }}
+        onSuccess={jest.fn()}
+        onClose={jest.fn()}
       />,
       container
     )
@@ -40,7 +41,8 @@ describe('rendering tests', () => {
 
     render(
       <ModalPin
-        wallet={{ }}
+        onSuccess={jest.fn()}
+        onClose={jest.fn()}
         bodyTop={bodyTop}
       />,
       container
@@ -61,7 +63,8 @@ describe('pin validation', () => {
     act(() => {
       render(
         <ModalPin
-          wallet={{ }}
+          onSuccess={jest.fn()}
+          onClose={jest.fn()}
         />,
         container
       )
@@ -95,7 +98,8 @@ describe('pin validation', () => {
     act(() => {
       render(
         <ModalPin
-          wallet={{ }}
+          onSuccess={jest.fn()}
+          onClose={jest.fn()}
         />,
         container
       )
@@ -124,7 +128,6 @@ describe('pin validation', () => {
     act(() => {
       render(
         <ModalPin
-          wallet={{ }}
           onSuccess={successCallback}
           onClose={closeCallback}
         />,

--- a/src/__tests__/components/ModalPin.test.js
+++ b/src/__tests__/components/ModalPin.test.js
@@ -46,6 +46,8 @@ describe('rendering tests', () => {
       container
     )
 
+    // Force creating the event, since the whole `modal` bootstrap class is mocked
+    $('#modalPin').trigger('shown.bs.modal');
     const element = screen.getByText('This is an extra element');
     expect(element instanceof HTMLElement).toStrictEqual(true);
   })
@@ -68,17 +70,25 @@ describe('pin validation', () => {
     expect(new RegExp(validationPattern).test(failingPin)).toStrictEqual(false);
     expect(new RegExp(validationPattern).test(passingPin)).toStrictEqual(true);
 
+    const pinMock = jest.spyOn(hathorLib.wallet, 'isPinCorrect')
+      .mockImplementation(() => false);
+
     // Get the element
     /** @type HTMLElement */
     const pinInput = screen.getByTestId('pin-input');
+    const goButton = screen.getByText('Go');
     await userEvent.type(pinInput, failingPin);
+    await userEvent.click(goButton);
     expect(pinInput.validity.patternMismatch).toStrictEqual(true);
     expect(pinInput.checkValidity()).toStrictEqual(false);
 
     await userEvent.clear(pinInput);
     await userEvent.type(pinInput, passingPin);
+    await userEvent.click(goButton);
     expect(pinInput.validity.patternMismatch).toStrictEqual(false);
     expect(pinInput.checkValidity()).toStrictEqual(true);
+
+    pinMock.mockRestore();
   });
 
   it('displays error on incorrect pin', async () => {

--- a/src/__tests__/components/ModalPin.test.js
+++ b/src/__tests__/components/ModalPin.test.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import { unmountComponentAtNode } from "react-dom";
+import { unmountComponentAtNode } from 'react-dom';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import $ from 'jquery'
 import hathorLib from '@hathor/wallet-lib';
-import { ModalPin } from "../../components/ModalPin";
-import userEvent from "@testing-library/user-event";
+import { ModalPin } from '../../components/ModalPin';
+import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
 let container = null;
@@ -14,7 +14,7 @@ $.fn.modal = jest.fn();
 
 beforeEach(() => {
   // setup a DOM element as a render target
-  container = document.createElement("div");
+  container = document.createElement('div');
   document.body.appendChild(container);
 });
 

--- a/src/__tests__/components/ModalPin.test.js
+++ b/src/__tests__/components/ModalPin.test.js
@@ -1,0 +1,144 @@
+import React from 'react';
+import { unmountComponentAtNode } from "react-dom";
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import $ from 'jquery'
+import hathorLib from '@hathor/wallet-lib';
+import { ModalPin } from "../../components/ModalPin";
+import userEvent from "@testing-library/user-event";
+import '@testing-library/jest-dom';
+
+let container = null;
+
+// This allows the calls to Bootstrap's $('#modalId').modal('show') to work.
+$.fn.modal = jest.fn();
+
+beforeEach(() => {
+  // setup a DOM element as a render target
+  container = document.createElement("div");
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  // cleanup on exiting
+  unmountComponentAtNode(container);
+  container.remove();
+  container = null;
+});
+
+describe('rendering tests', () => {
+  it('renders without crashing', () => {
+    render(
+      <ModalPin
+        wallet={{ }}
+      />,
+      container
+    )
+  })
+
+  it('renders the bodyTop prop', () => {
+    const bodyTop = <p>This is an extra element</p>;
+
+    render(
+      <ModalPin
+        wallet={{ }}
+        bodyTop={bodyTop}
+      />,
+      container
+    )
+
+    const element = screen.getByText('This is an extra element');
+    expect(element instanceof HTMLElement).toStrictEqual(true);
+  })
+});
+describe('pin validation', () => {
+
+  it('displays correctly on invalid pin pattern', async () => {
+    const validationPattern = '[0-9]{6}';
+    const failingPin = 'abc123';
+    const passingPin = '123321'
+    act(() => {
+      render(
+        <ModalPin
+          wallet={{ }}
+        />,
+        container
+      )
+    });
+
+    expect(new RegExp(validationPattern).test(failingPin)).toStrictEqual(false);
+    expect(new RegExp(validationPattern).test(passingPin)).toStrictEqual(true);
+
+    // Get the element
+    /** @type HTMLElement */
+    const pinInput = screen.getByTestId('pin-input');
+    await userEvent.type(pinInput, failingPin);
+    expect(pinInput.validity.patternMismatch).toStrictEqual(true);
+    expect(pinInput.checkValidity()).toStrictEqual(false);
+
+    await userEvent.clear(pinInput);
+    await userEvent.type(pinInput, passingPin);
+    expect(pinInput.validity.patternMismatch).toStrictEqual(false);
+    expect(pinInput.checkValidity()).toStrictEqual(true);
+  });
+
+  it('displays error on incorrect pin', async () => {
+    act(() => {
+      render(
+        <ModalPin
+          wallet={{ }}
+        />,
+        container
+      )
+    });
+
+    // Get the element
+    /** @type HTMLElement */
+    const pinInput = screen.getByTestId('pin-input');
+    const goButton = screen.getByText('Go');
+    await userEvent.type(pinInput, '123321');
+
+    const pinMock = jest.spyOn(hathorLib.wallet, 'isPinCorrect')
+      .mockImplementation(() => false);
+    await userEvent.click(goButton);
+    pinMock.mockRestore();
+
+    const element = screen.getByText('Invalid PIN');
+    expect(element instanceof HTMLElement).toStrictEqual(true);
+  });
+
+  it('invokes success callback when pin is correct', async () => {
+    const successCallback = jest.fn();
+    const closeCallback = jest.fn();
+    const pinText = '123321';
+
+    act(() => {
+      render(
+        <ModalPin
+          wallet={{ }}
+          onSuccess={successCallback}
+          onClose={closeCallback}
+        />,
+        container
+      )
+    });
+
+    // Get the pin input element
+    /** @type HTMLElement */
+    const pinInput = screen.getByTestId('pin-input');
+    const goButton = screen.getByText('Go');
+
+    await userEvent.type(pinInput, pinText);
+    const pinMock = jest.spyOn(hathorLib.wallet, 'isPinCorrect')
+      .mockImplementation(() => true);
+    await userEvent.click(goButton);
+    pinMock.mockRestore();
+
+    const element = screen.queryByText('Invalid PIN');
+    expect(element).toBeNull();
+
+    // Force creating the event, since the whole `modal` bootstrap class is mocked
+    $('#modalPin').trigger('hidden.bs.modal');
+    expect(successCallback).toHaveBeenCalledWith({ pin: pinText });
+    expect(closeCallback).toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/components/ModalPin.test.js
+++ b/src/__tests__/components/ModalPin.test.js
@@ -76,18 +76,23 @@ describe('pin validation', () => {
     const pinMock = jest.spyOn(hathorLib.wallet, 'isPinCorrect')
       .mockImplementation(() => false);
 
-    // Get the element
+    // Gets the input element, types the pin and clicks "Go"
     /** @type HTMLElement */
     const pinInput = screen.getByTestId('pin-input');
     const goButton = screen.getByText('Go');
     await userEvent.type(pinInput, failingPin);
     await userEvent.click(goButton);
+
+    // Validating form
     expect(pinInput.validity.patternMismatch).toStrictEqual(true);
     expect(pinInput.checkValidity()).toStrictEqual(false);
 
+    // Clears input, types again
     await userEvent.clear(pinInput);
     await userEvent.type(pinInput, passingPin);
     await userEvent.click(goButton);
+
+    // Validating form
     expect(pinInput.validity.patternMismatch).toStrictEqual(false);
     expect(pinInput.checkValidity()).toStrictEqual(true);
 
@@ -105,17 +110,19 @@ describe('pin validation', () => {
       )
     });
 
-    // Get the element
+    // Gets the input element, types the pin
     /** @type HTMLElement */
     const pinInput = screen.getByTestId('pin-input');
     const goButton = screen.getByText('Go');
     await userEvent.type(pinInput, '123321');
 
+    // Clicks "Go"
     const pinMock = jest.spyOn(hathorLib.wallet, 'isPinCorrect')
       .mockImplementation(() => false);
     await userEvent.click(goButton);
     pinMock.mockRestore();
 
+    // Validates error message
     const element = screen.getByText('Invalid PIN');
     expect(element instanceof HTMLElement).toStrictEqual(true);
   });
@@ -135,17 +142,19 @@ describe('pin validation', () => {
       )
     });
 
-    // Get the pin input element
+    // Gets the input element, types the pin
     /** @type HTMLElement */
     const pinInput = screen.getByTestId('pin-input');
     const goButton = screen.getByText('Go');
-
     await userEvent.type(pinInput, pinText);
+
+    // Clicks "Go"
     const pinMock = jest.spyOn(hathorLib.wallet, 'isPinCorrect')
       .mockImplementation(() => true);
     await userEvent.click(goButton);
     pinMock.mockRestore();
 
+    // Confirms there is no error message
     const element = screen.queryByText('Invalid PIN');
     expect(element).toBeNull();
 
@@ -185,11 +194,12 @@ describe('pin validation', () => {
       )
     });
 
-    // Get the pin input element
+    // Gets the input element, types the pin
     /** @type HTMLElement */
     const pinInput = screen.getByTestId('pin-input');
-
     await userEvent.type(pinInput, pinText);
+
+    // Validates the handleChange callback results
     expect(changePinCallback).toHaveBeenCalledTimes(6);
     expect(receivedEvents).toStrictEqual(expectedReceivedEvents);
   });

--- a/src/__tests__/components/ModalSendTx.test.js
+++ b/src/__tests__/components/ModalSendTx.test.js
@@ -1,0 +1,149 @@
+import React from 'react';
+import { unmountComponentAtNode } from 'react-dom';
+import { act, render, screen } from '@testing-library/react';
+import $ from 'jquery'
+import hathorLib from '@hathor/wallet-lib';
+import { ModalSendTx } from '../../components/ModalSendTx';
+import { SendTxHandler } from '../../components/SendTxHandler';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import helpers from '../../utils/helpers';
+
+let container = null;
+
+// This allows the calls to Bootstrap's $('#modalId').modal('show') to work.
+$.fn.modal = jest.fn();
+const MODAL_ID = '#sendTxModal';
+
+beforeEach(() => {
+  // setup a DOM element as a render target
+  container = document.createElement('div');
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  // cleanup on exiting
+  unmountComponentAtNode(container);
+  container.remove();
+  container = null;
+});
+
+
+describe('rendering tests', () => {
+  it('renders without crashing', () => {
+    render(
+      <ModalSendTx
+        pin={'123321'}
+        title={'Mock Title'}
+        prepareSendTransaction={jest.fn()}
+        onSendSuccess={jest.fn()}
+        onClose={jest.fn()}
+      />,
+      container
+    )
+  })
+
+  it('renders the title prop correctly', () => {
+    render(
+      <ModalSendTx
+        pin={'123321'}
+        title={'Mock Title'}
+        prepareSendTransaction={jest.fn()}
+        onSendSuccess={jest.fn()}
+        onClose={jest.fn()}
+      />,
+      container
+    )
+
+    // Force creating the event, since the whole `modal` bootstrap class is mocked
+    $('#modalPin').trigger('shown.bs.modal');
+    const element = screen.getByText('Mock Title');
+    expect(element instanceof HTMLElement).toStrictEqual(true);
+  })
+
+  // TODO: Test that Renders the button disabled and error message empty
+});
+
+describe('tx handling', () => {
+  it.skip('handles errors from the prepareSendTransaction prop', () => {
+    // TODO: Implement this handling
+  });
+
+  it('invokes onSendSuccess callback correctly', async () => {
+    const mockChildComponent = jest.fn();
+    jest.mock('../../components/SendTxHandler', (props) => {
+      mockChildComponent(props);
+      return <mock-child-component/>
+    })
+
+    const mockPrepareSendTransaction = () => ({
+      on: () => jest.fn(), // Necessary for the event listeners
+      run: async () => {
+        return ({ mockedTransaction: true });
+      }
+    });
+    const mockOnSuccess = jest.fn();
+    const mockOnError = jest.fn();
+
+    act(() => {
+      render(
+        <ModalSendTx
+          pin={'123321'}
+          title={'Mock Title'}
+          prepareSendTransaction={mockPrepareSendTransaction}
+          onSendSuccess={mockOnSuccess}
+          onSendError={mockOnError}
+          onClose={jest.fn()}
+        />,
+        container
+      )
+    });
+
+    // Waiting until the transaction has been "processed"
+    await helpers.delay(0);
+
+    // Simulating click ok button (by hiding the modal) and validating the onSuccess call
+    $(MODAL_ID).trigger('hidden.bs.modal');
+    expect(mockOnSuccess).toHaveBeenCalledWith({ mockedTransaction: true });
+    expect(mockOnError).not.toHaveBeenCalled();
+  });
+
+  it('invokes onSendError callback on failure', async () => {
+    const mockChildComponent = jest.fn();
+    jest.mock('../../components/SendTxHandler', (props) => {
+      mockChildComponent(props);
+      return <mock-child-component/>
+    })
+
+    const mockPrepareSendTransaction = () => ({
+      on: () => jest.fn(), // Necessary for the event listeners
+      run: async () => {
+        throw new Error('SendTransaction Error')
+      }
+    });
+    const mockOnSuccess = jest.fn();
+    const mockOnError = jest.fn();
+
+    act(() => {
+      render(
+        <ModalSendTx
+          pin={'123321'}
+          title={'Mock Title'}
+          prepareSendTransaction={mockPrepareSendTransaction}
+          onSendSuccess={mockOnSuccess}
+          onSendError={mockOnError}
+          onClose={jest.fn()}
+        />,
+        container
+      )
+    });
+
+    // Waiting until the transaction has been "processed"
+    await helpers.delay(0);
+
+    // Simulating click ok button (by hiding the modal) and validating the onSuccess call
+    $(MODAL_ID).trigger('hidden.bs.modal');
+    expect(mockOnError).toHaveBeenCalledWith('SendTransaction Error');
+    expect(mockOnSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/GlobalModal.js
+++ b/src/components/GlobalModal.js
@@ -20,6 +20,7 @@ import ModalLedgerSignToken from './ModalLedgerSignToken';
 import ModalConfirmTestnet from './ModalConfirmTestnet';
 import ModalSendTx from './ModalSendTx';
 import ModalUnregisteredTokenInfo from './ModalUnregisteredTokenInfo';
+import ModalPin from "./ModalPin";
 
 const initialState = {
   showModal: () => {},
@@ -41,6 +42,7 @@ export const MODAL_TYPES = {
   'CONFIRM_TESTNET': 'CONFIRM_TESTNET',
   'SEND_TX': 'SEND_TX',
   'UNREGISTERED_TOKEN_INFO': 'UNREGISTERED_TOKEN_INFO',
+  'PIN': 'PIN',
 };
 
 export const MODAL_COMPONENTS = {
@@ -57,6 +59,7 @@ export const MODAL_COMPONENTS = {
   [MODAL_TYPES.CONFIRM_TESTNET]: ModalConfirmTestnet,
   [MODAL_TYPES.SEND_TX]: ModalSendTx,
   [MODAL_TYPES.UNREGISTERED_TOKEN_INFO]: ModalUnregisteredTokenInfo,
+  [MODAL_TYPES.PIN]: ModalPin,
 };
 
 export const GlobalModalContext = createContext(initialState);

--- a/src/components/ModalPin.js
+++ b/src/components/ModalPin.js
@@ -11,6 +11,7 @@ import { connect } from "react-redux";
 import $ from 'jquery';
 import PinInput from './PinInput';
 import hathorLib from '@hathor/wallet-lib';
+import PropTypes from "prop-types";
 
 
 const mapStateToProps = (state) => {
@@ -23,12 +24,6 @@ const mapStateToProps = (state) => {
 /**
  * Component that shows a modal with a form to ask for the user PIN
  * and when the PIN succeeds, it invokes the callback function
- * Expected props:
- * @param props
- * @param {function} props.onSuccess Handles the success and receives a "pin" parameter
- * @param {function} [props.handleChangePin] (Optional) Handles each change on the input element
- * @param {function} props.onClose Mandatory function from the GlobalModal invocation
- *
  * @memberof Components
  */
 class ModalPin extends React.Component {
@@ -38,9 +33,6 @@ class ModalPin extends React.Component {
   state = {
     errorMessage: '',
   }
-
-  // Error message when sending
-  sendErrorMessage = '';
 
   pin = '';
 
@@ -101,39 +93,26 @@ class ModalPin extends React.Component {
     $('#modalPin').modal('hide');
   }
 
-  /**
-   * Executed when tx was sent with success
-   *
-   * @param {Object} tx Transaction data
-   */
-  onSendSuccess = (tx) => {
-    this.tx = tx;
-    this.setState({ loading: false });
-  }
-
   render() {
-    const renderBody = () => {
-      return (
-        <div>
-          <form ref="formPin" onSubmit={this.handlePin} noValidate>
-            <div className="form-group">
-              <PinInput ref="pinInput" handleChangePin={this.props.handleChangePin} />
+    const renderBody = () => (<div>
+        {this.props.bodyTop}
+        <form ref="formPin" onSubmit={this.handlePin} noValidate>
+          <div className="form-group">
+            <PinInput ref="pinInput" handleChangePin={this.props.handleChangePin}/>
+          </div>
+          <div className="row">
+            <div className="col-12 col-sm-10">
+              <p className="error-message text-danger">
+                {this.state.errorMessage}
+              </p>
             </div>
-            <div className="row">
-              <div className="col-12 col-sm-10">
-                  <p className="error-message text-danger">
-                    {this.state.errorMessage}
-                  </p>
-              </div>
-            </div>
-          </form>
-        </div>
-      );
-    }
+          </div>
+        </form>
+      </div>)
 
-    return (
-      <div>
-        <div className="modal fade" id="modalPin" tabIndex="-1" role="dialog" aria-labelledby="modalPin" aria-hidden="true">
+    return <div>
+        <div className="modal fade" id="modalPin" tabIndex="-1" role="dialog" aria-labelledby="modalPin"
+             aria-hidden="true">
           <div className="modal-dialog" role="document">
             <div className="modal-content">
               <div className="modal-header">
@@ -147,16 +126,33 @@ class ModalPin extends React.Component {
               </div>
               <div className="modal-footer">
                 <div className="d-flex flex-row">
-                  <button type="button" className="btn btn-secondary mr-3" data-dismiss="modal">{t`Cancel`}</button>
-                  <button onClick={this.handlePin} type="button" className="btn btn-hathor">{t`Go`}</button>
+                  <button type="button" className="btn btn-secondary mr-3"
+                          data-dismiss="modal">{t`Cancel`}</button>
+                  <button onClick={this.handlePin} type="button"
+                          className="btn btn-hathor">{t`Go`}</button>
                 </div>
               </div>
             </div>
           </div>
         </div>
       </div>
-    )
   }
 }
 
 export default connect(mapStateToProps)(ModalPin);
+
+
+ModalPin.propTypes = {
+  /**
+   * A React element that can optionally be rendered before the PIN input
+   */
+  bodyTop: PropTypes.element,
+  /**
+   * Callback invoked when tx is sent with success
+   */
+  onSuccess: PropTypes.func,
+  /**
+   * Callback provided by the GlobalModal helper to manage the modal lifecycle
+   */
+  onClose: PropTypes.func,
+}

--- a/src/components/ModalPin.js
+++ b/src/components/ModalPin.js
@@ -25,7 +25,7 @@ const mapStateToProps = (state) => {
  * and when the PIN succeeds, it invokes the callback function
  * @memberof Components
  */
-class ModalPin extends React.Component {
+export class ModalPin extends React.Component {
   /**
    * errorMessage {string} Message to be shown to the user in case of error in the form
    */

--- a/src/components/ModalPin.js
+++ b/src/components/ModalPin.js
@@ -17,7 +17,6 @@ import PropTypes from "prop-types";
 const mapStateToProps = (state) => {
   return {
     wallet: state.wallet,
-    useWalletService: state.useWalletService,
   };
 };
 
@@ -68,6 +67,7 @@ class ModalPin extends React.Component {
    */
   handlePin = async (e) => {
     e.preventDefault();
+
     // Invalid form, show error message and do nothing else
     if (this.refs.formPin.checkValidity() === false) {
       this.refs.formPin.classList.add('was-validated');
@@ -86,15 +86,13 @@ class ModalPin extends React.Component {
 
     // Set the PIN on the instance variable and close the modal.
     this.pin = pin;
-    // $('#modalPin').data('bs.modal')._config.backdrop = 'static';
-    // $('#modalPin').data('bs.modal')._config.keyboard = false;
 
     // Necessary callbacks will be executed at the `onHidden` modal event
     $('#modalPin').modal('hide');
   }
 
   render() {
-    const renderBody = () => (<div>
+    const renderBody = () => <div>
         {this.props.bodyTop}
         <form ref="formPin" onSubmit={this.handlePin} noValidate>
           <div className="form-group">
@@ -108,7 +106,7 @@ class ModalPin extends React.Component {
             </div>
           </div>
         </form>
-      </div>)
+      </div>
 
     return <div>
         <div className="modal fade" id="modalPin" tabIndex="-1" role="dialog" aria-labelledby="modalPin"

--- a/src/components/ModalPin.js
+++ b/src/components/ModalPin.js
@@ -7,18 +7,10 @@
 
 import React from 'react';
 import { t } from 'ttag';
-import { connect } from "react-redux";
 import $ from 'jquery';
 import PinInput from './PinInput';
 import hathorLib from '@hathor/wallet-lib';
 import PropTypes from "prop-types";
-
-
-const mapStateToProps = (state) => {
-  return {
-    wallet: state.wallet,
-  };
-};
 
 /**
  * Component that shows a modal with a form to ask for the user PIN
@@ -137,7 +129,7 @@ export class ModalPin extends React.Component {
   }
 }
 
-export default connect(mapStateToProps)(ModalPin);
+export default ModalPin;
 
 
 ModalPin.propTypes = {

--- a/src/components/ModalPin.js
+++ b/src/components/ModalPin.js
@@ -146,11 +146,15 @@ ModalPin.propTypes = {
    */
   bodyTop: PropTypes.element,
   /**
+   * An optional callback function called every time the PIN receives input
+   */
+  handleChangePin: PropTypes.func,
+  /**
    * Callback invoked when tx is sent with success
    */
-  onSuccess: PropTypes.func,
+  onSuccess: PropTypes.func.isRequired,
   /**
    * Callback provided by the GlobalModal helper to manage the modal lifecycle
    */
-  onClose: PropTypes.func,
+  onClose: PropTypes.func.isRequired,
 }

--- a/src/components/ModalSendTx.js
+++ b/src/components/ModalSendTx.js
@@ -170,29 +170,29 @@ ModalSendTx.propTypes = {
   /**
    * User PIN already validated
    */
-  pin: PropTypes.string,
+  pin: PropTypes.string.isRequired,
   /**
    * Title of the modal to be shown
    */
-  title: PropTypes.string,
+  title: PropTypes.string.isRequired,
   /**
    * A function that should prepare data before sending tx to be mined,
    * receiving the PIN as a parameter
    * @param {string} pin
    */
-  prepareSendTransaction: PropTypes.func,
+  prepareSendTransaction: PropTypes.func.isRequired,
   /**
    * Callback invoked when tx is sent with success
    */
-  onSendSuccess: PropTypes.func,
+  onSendSuccess: PropTypes.func.isRequired,
   /**
-   * Callback invoked when there is an error sending the tx
+   * Callback invoked when there is an error sending the tx (Recommended)
    */
   onSendError: PropTypes.func,
   /**
    * Callback provided by the GlobalModal helper to manage the modal lifecycle
    */
-  onClose: PropTypes.func,
+  onClose: PropTypes.func.isRequired,
 }
 
 export default connect(mapStateToProps)(ModalSendTx);

--- a/src/components/ModalSendTx.js
+++ b/src/components/ModalSendTx.js
@@ -79,9 +79,6 @@ class ModalSendTx extends React.Component {
    * @param {string} pin Pin received from the user
    */
   processTxWithPin = async (pin) => {
-    $('#sendTxModal').data('bs.modal')._config.backdrop = 'static';
-    $('#sendTxModal').data('bs.modal')._config.keyboard = false;
-
     // If we are using the wallet service facade, we should avail of the validated PIN
     // to renew the auth token.
     if (this.props.useWalletService) {
@@ -128,7 +125,15 @@ class ModalSendTx extends React.Component {
   render() {
     return (
       <div>
-        <div className="modal fade" id="sendTxModal" tabIndex="-1" role="dialog" aria-labelledby="sendTxModal" aria-hidden="true">
+        <div className="modal fade"
+             id="sendTxModal"
+             tabIndex="-1"
+             role="dialog"
+             aria-labelledby="sendTxModal"
+             aria-hidden="true"
+             data-backdrop="static"
+             data-keyboard="false"
+        >
           <div className="modal-dialog" role="document">
             <div className="modal-content">
               <div className="modal-header">

--- a/src/components/ModalSendTx.js
+++ b/src/components/ModalSendTx.js
@@ -28,7 +28,7 @@ const mapStateToProps = (state) => {
  *
  * @memberof Components
  */
-class ModalSendTx extends React.Component {
+export class ModalSendTx extends React.Component {
   /**
    * @property {boolean} loading If it's executing a sending tx request
    * @property {unknown} [preparedTransaction] The prepared transaction, if any

--- a/src/components/PinInput.js
+++ b/src/components/PinInput.js
@@ -19,7 +19,16 @@ class PinInput extends React.Component {
       <div>
         <label htmlFor="pin">Pin*</label>
         <small> (6 digits password)</small>
-        <input type="password" ref="pin" pattern="[0-9]{6}" autoComplete="off" inputMode="numeric" className="pin-input form-control" required onChange={this.props.handleChangePin} />
+        <input
+          type="password"
+          ref="pin"
+          pattern="[0-9]{6}"
+          autoComplete="off"
+          inputMode="numeric"
+          className="pin-input form-control"
+          required
+          data-testid="pin-input" // Necessary for unit tests
+          onChange={this.props.handleChangePin} />
       </div>
     )
   }

--- a/src/components/SendTxHandler.js
+++ b/src/components/SendTxHandler.js
@@ -20,7 +20,7 @@ import PropTypes from 'prop-types';
  *
  * @memberof Components
  */
-class SendTxHandler extends React.Component {
+export class SendTxHandler extends React.Component {
   // Loading message to be shown while server does not return a response
   powMessage = t`Resolving proof of work of your transaction.`
 

--- a/src/components/tokens/TokenAction.js
+++ b/src/components/tokens/TokenAction.js
@@ -95,6 +95,7 @@ class TokenAction extends React.Component {
    */
   openPinModal = () => {
     this.context.showModal(MODAL_TYPES.PIN, {
+      bodyTop: this.props.pinBodyTop,
       onSuccess: ({pin}) => {
         this.context.showModal(MODAL_TYPES.SEND_TX, {
           pin,
@@ -102,7 +103,6 @@ class TokenAction extends React.Component {
           prepareSendTransaction: this.onPrepareSendTransaction,
           onSendSuccess: this.onSendSuccess,
           onSendError: this.onSendError,
-          bodyTop: this.props.pinBodyTop,
         });
       }
     })

--- a/src/components/tokens/TokenAction.js
+++ b/src/components/tokens/TokenAction.js
@@ -94,13 +94,18 @@ class TokenAction extends React.Component {
    * Opens the PIN modal
    */
   openPinModal = () => {
-    this.context.showModal(MODAL_TYPES.SEND_TX, {
-      title: this.props.modalTitle,
-       prepareSendTransaction: this.onPrepareSendTransaction,
-       onSendSuccess: this.onSendSuccess,
-       onSendError: this.onSendError,
-       bodyTop: this.props.pinBodyTop,
-    });
+    this.context.showModal(MODAL_TYPES.PIN, {
+      onSuccess: ({pin}) => {
+        this.context.showModal(MODAL_TYPES.SEND_TX, {
+          pin,
+          title: this.props.modalTitle,
+          prepareSendTransaction: this.onPrepareSendTransaction,
+          onSendSuccess: this.onSendSuccess,
+          onSendError: this.onSendError,
+          bodyTop: this.props.pinBodyTop,
+        });
+      }
+    })
   }
 
   /**

--- a/src/screens/CreateNFT.js
+++ b/src/screens/CreateNFT.js
@@ -106,11 +106,16 @@ class CreateNFT extends React.Component {
     }
 
     this.setState({ errorMessage: '' });
-    this.context.showModal(MODAL_TYPES.SEND_TX, {
-      prepareSendTransaction: this.prepareSendTransaction,
-      onSendSuccess: this.onTokenCreateSuccess,
-      title: 'Creating NFT',
-    });
+    this.context.showModal(MODAL_TYPES.PIN, {
+      onSuccess: ({pin}) => {
+        this.context.showModal(MODAL_TYPES.SEND_TX, {
+          pin,
+          prepareSendTransaction: this.prepareSendTransaction,
+          onSendSuccess: this.onTokenCreateSuccess,
+          title: t`Creating NFT`,
+        });
+      }
+    })
   }
 
   /**
@@ -268,7 +273,7 @@ class CreateNFT extends React.Component {
     // so this must be 0.01 (the text will show 0.01%) because the amount to create for NFTs is an integer.
     // Then to create 100 units, the deposit is 0.01 HTR, to create 1,000 units the deposit is 0.1 HTR
     const htrDeposit = hathorLib.tokens.getDepositPercentage();
-    const depositAmount = hathorLib.tokens.getDepositAmount(this.state.amount); 
+    const depositAmount = hathorLib.tokens.getDepositAmount(this.state.amount);
     const nftFee = hathorLib.helpers.prettyValue(tokens.getNFTFee());
 
     return (

--- a/src/screens/CreateToken.js
+++ b/src/screens/CreateToken.js
@@ -100,11 +100,16 @@ class CreateToken extends React.Component {
     }
 
     this.setState({ errorMessage: '' });
-    this.context.showModal(MODAL_TYPES.SEND_TX, {
-      prepareSendTransaction: this.prepareSendTransaction,
-      onSendSuccess: this.onTokenCreateSuccess,
-      title: 'Creating token',
-    });
+    this.context.showModal(MODAL_TYPES.PIN, {
+      onSuccess: ({pin}) => {
+        this.context.showModal(MODAL_TYPES.SEND_TX, {
+          pin,
+          prepareSendTransaction: this.prepareSendTransaction,
+          onSendSuccess: this.onTokenCreateSuccess,
+          title: t`Creating token`,
+        });
+      }
+    })
   }
 
   /**

--- a/src/screens/SendTokens.js
+++ b/src/screens/SendTokens.js
@@ -46,7 +46,7 @@ class SendTokens extends React.Component {
 
   /**
    * Get the selected token on the TokenBar.
-   * 
+   *
    * @param {mapStateToProps} props
    * @returns {Object} Token selected
    */
@@ -344,12 +344,17 @@ class SendTokens extends React.Component {
     try {
       this.data = data;
       if (hathorLib.wallet.isSoftwareWallet()) {
-        this.context.showModal(MODAL_TYPES.SEND_TX, {
-          prepareSendTransaction: this.prepareSendTransaction,
-          onSendSuccess: this.onSendSuccess,
-          onSendError: this.onSendError,
-          title: t`Sending transaction`,
-        });
+        this.context.showModal(MODAL_TYPES.PIN, {
+          onSuccess: ({pin}) => {
+            this.context.showModal(MODAL_TYPES.SEND_TX, {
+              pin,
+              prepareSendTransaction: this.prepareSendTransaction,
+              onSendSuccess: this.onSendSuccess,
+              onSendError: this.onSendError,
+              title: t`Sending transaction`,
+            });
+          }
+        })
       } else {
         this.beforeSendLedger();
       }

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -241,6 +241,20 @@ const helpers = {
 
     return 'other';
   },
+
+  /**
+   * Generates a promise that resolves only after a specified time
+   * @param {number} [ms=1000] Time in milliseconds
+   * @return {Promise<unknown>}
+   */
+  async delay(ms = 1000) {
+    return new Promise((resolve) => {
+      setTimeout(
+        () => resolve(),
+        ms
+      )
+    })
+  }
 }
 
 export default helpers;


### PR DESCRIPTION
The PIN modal we currently have also has the logic to send transactions after receiving the user input. To make it more reusable in other contexts, a dedicated PIN modal should be created with the existing code.

### Acceptance Criteria
- Creates a `ModalPin` component dedicated only to receiving PIN input from the user
- The PIN logic should be removed from the `ModalSendTx` where it currently is
- Screens that used the `ModalSendTx` modal should continue working as expected, sending transaction and being informed of success or error

### Drawbacks
The current implementation has a seamless state change between the PIN input and the monitoring of the transaction send status. This refactor separates the logic into two modals, creating a noticeable modal change between steps.

**Failure handling**
https://user-images.githubusercontent.com/1299409/221319294-ab00b15b-69f7-4aa6-99af-e189251418aa.mp4

**Transaction success**
https://user-images.githubusercontent.com/1299409/221319333-dd075689-b19c-469f-9d44-4630c0fb394a.mp4

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
