### PR TITLE
feat: register HTR on start saga

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hathor-wallet",
-  "version": "0.26.0",
+  "version": "0.27.0-rc1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "productName": "Hathor Wallet",
   "description": "Light wallet for Hathor Network",
   "author": "Hathor Labs <contact@hathor.network> (https://hathor.network/)",
-  "version": "0.26.0",
+  "version": "0.27.0-rc1",
   "private": true,
   "dependencies": {
     "@hathor/wallet-lib": "^1.0.0-rc8",

--- a/public/electron.js
+++ b/public/electron.js
@@ -35,7 +35,7 @@ if (process.platform === 'darwin') {
 }
 
 const appName = 'Hathor Wallet';
-const walletVersion = '0.26.0';
+const walletVersion = '0.27.0-rc1';
 
 const debugMode = (
   process.argv.indexOf('--unsafe-mode') >= 0 &&

--- a/src/App.js
+++ b/src/App.js
@@ -160,13 +160,14 @@ class Root extends React.Component {
  * Validate if version is allowed for the loaded wallet
  */
 const returnLoadedWalletComponent = (Component, props) => {
+  // For server screen we don't need to check version
+  const isServerScreen = props.match.path === '/server';
+
   // If was closed and is loaded we need to redirect to locked screen
-  if (LOCAL_STORE.wasClosed() || LOCAL_STORE.isLocked()) {
+  if ((!isServerScreen) && (LOCAL_STORE.wasClosed() || LOCAL_STORE.isLocked())) {
     return <Redirect to={{ pathname: '/locked/' }} />;
   }
 
-  // For server screen we don't need to check version
-  const isServerScreen = props.match.path === '/server';
   const reduxState = store.getState();
 
   // Check version
@@ -228,13 +229,14 @@ const returnStartedRoute = (Component, props, rest) => {
   // The wallet is already loaded
   const routeRequiresWalletToBeLoaded = rest.loaded;
   if (LOCAL_STORE.getWalletId()) {
+    const isServerScreen = props.match.path === '/server';
     // Wallet is locked, go to locked screen
-    if (LOCAL_STORE.isLocked()) {
+    if (LOCAL_STORE.isLocked() && !isServerScreen) {
       return <Redirect to={{pathname: '/locked/'}}/>;
     }
 
     // Route requires the wallet to be loaded, render it
-    if (routeRequiresWalletToBeLoaded) {
+    if (routeRequiresWalletToBeLoaded || isServerScreen) {
       return returnLoadedWalletComponent(Component, props);
     }
 

--- a/src/App.js
+++ b/src/App.js
@@ -161,6 +161,8 @@ class Root extends React.Component {
  */
 const returnLoadedWalletComponent = (Component, props) => {
   // For server screen we don't need to check version
+  // We also allow the server screen to be reached from the locked screen
+  // In the case of an unresponsive fullnode, which would block the wallet start
   const isServerScreen = props.match.path === '/server';
 
   // If was closed and is loaded we need to redirect to locked screen
@@ -229,6 +231,9 @@ const returnStartedRoute = (Component, props, rest) => {
   // The wallet is already loaded
   const routeRequiresWalletToBeLoaded = rest.loaded;
   if (LOCAL_STORE.getWalletId()) {
+    // The server screen is a special case since we allow the user to change the
+    // connected server in case of unresponsiveness, this should be allowed from
+    // the locked screen since the wallet would not be able to be started otherwise
     const isServerScreen = props.match.path === '/server';
     // Wallet is locked, go to locked screen
     if (LOCAL_STORE.isLocked() && !isServerScreen) {

--- a/src/App.js
+++ b/src/App.js
@@ -34,6 +34,7 @@ import WalletVersionError from './screens/WalletVersionError';
 import LoadWalletFailed from './screens/LoadWalletFailed';
 import version from './utils/version';
 import tokens from './utils/tokens';
+import storageUtils from './utils/storage';
 import { connect } from 'react-redux';
 import RequestErrorModal from './components/RequestError';
 import store from './store/index';
@@ -215,6 +216,9 @@ const returnStartedRoute = (Component, props, rest) => {
       return <Redirect to={{pathname: pathname.slice(3)}} />;
     }
   }
+
+  // Detect a previous instalation and migrate before continuing
+  storageUtils.migratePreviousLocalStorage();
 
   // The wallet was not yet started, go to Welcome
   if (!LOCAL_STORE.wasStarted()) {

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -51,6 +51,7 @@ export const types = {
   FEATURE_TOGGLE_INITIALIZED: 'FEATURE_TOGGLE_INITIALIZED',
   SET_FEATURE_TOGGLES: 'SET_FEATURE_TOGGLES',
   SET_UNLEASH_CLIENT: 'SET_UNLEASH_CLIENT',
+  MARK_TX_RECEIVED: 'MARK_TX_RECEIVED',
 };
 
 /**
@@ -154,7 +155,7 @@ export const resetWallet = () => ({ type: 'reset_wallet' });
  * tokens {Array} array of token uids the the wallet has
  * currentAddress {Object} The current unused address
  */
-export const loadWalletSuccess = (tokens, currentAddress) => ({ type: 'load_wallet_success', payload: { tokens, currentAddress } });
+export const loadWalletSuccess = (tokens, registeredTokens, currentAddress) => ({ type: 'load_wallet_success', payload: { tokens, registeredTokens, currentAddress } });
 
 /**
  * tx {Object} the new transaction
@@ -481,4 +482,9 @@ export const walletResetSuccess = () => ({
 
 export const walletReset = () => ({
   type: types.WALLET_RESET,
+});
+
+export const markTxReceived = (txId) => ({
+  type: types.MARK_TX_RECEIVED,
+  payload: txId,
 });

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -42,6 +42,7 @@ export const types = {
   WALLET_STATE_READY: 'WALLET_STATE_READY',
   WALLET_STATE_ERROR: 'WALLET_STATE_ERROR',
   WALLET_RELOAD_DATA: 'WALLET_RELOAD_DATA',
+  WALLET_CHANGE_STATE: 'WALLET_CHANGE_STATE',
   WALLET_RESET: 'WALLET_RESET',
   WALLET_RESET_SUCCESS: 'WALLET_RESET_SUCCESS',
   WALLET_REFRESH_SHARED_ADDRESS: 'WALLET_REFRESH_SHARED_ADDRESS',
@@ -51,7 +52,7 @@ export const types = {
   FEATURE_TOGGLE_INITIALIZED: 'FEATURE_TOGGLE_INITIALIZED',
   SET_FEATURE_TOGGLES: 'SET_FEATURE_TOGGLES',
   SET_UNLEASH_CLIENT: 'SET_UNLEASH_CLIENT',
-  MARK_TX_RECEIVED: 'MARK_TX_RECEIVED',
+  UPDATE_TX_HISTORY: 'UPDATE_TX_HISTORY',
 };
 
 /**
@@ -485,11 +486,23 @@ export const walletReset = () => ({
 });
 
 /**
- * Action to mark the txId as received by the wallet in this session.
- * @param {string} txId id of the tx to mark as received.
+ * Action to update the token history with this tx.
+ * @param {Object} tx New transaction to update in the token history.
+ * @param {string} tokenId token to update the history.
+ * @param {number} balance transaction balance of the token on the wallet.
  * @returns {Object} action to mark tx as received.
  */
-export const markTxReceived = (txId) => ({
-  type: types.MARK_TX_RECEIVED,
-  payload: txId,
+export const updateTxHistory = (tx, tokenId, balance) => ({
+  type: types.UPDATE_TX_HISTORY,
+  payload: { tx, tokenId, balance },
+});
+
+/**
+ * Action to set the wallet state and allow the UI to react to a state change.
+ * @param {number} newState state from the enum included on HathorWallet
+ * @returns {Object}
+ */
+export const changeWalletState = (newState) => ({
+  type: types.WALLET_CHANGE_STATE,
+  payload: newState,
 });

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -484,6 +484,11 @@ export const walletReset = () => ({
   type: types.WALLET_RESET,
 });
 
+/**
+ * Action to mark the txId as received by the wallet in this session.
+ * @param {string} txId id of the tx to mark as received.
+ * @returns {Object} action to mark tx as received.
+ */
 export const markTxReceived = (txId) => ({
   type: types.MARK_TX_RECEIVED,
   payload: txId,

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -490,7 +490,7 @@ export const walletReset = () => ({
  * @param {Object} tx New transaction to update in the token history.
  * @param {string} tokenId token to update the history.
  * @param {number} balance transaction balance of the token on the wallet.
- * @returns {Object} action to mark tx as received.
+ * @returns {Object} action to update the history of the token with the tx.
  */
 export const updateTxHistory = (tx, tokenId, balance) => ({
   type: types.UPDATE_TX_HISTORY,

--- a/src/components/ModalUnregisteredTokenInfo.js
+++ b/src/components/ModalUnregisteredTokenInfo.js
@@ -12,7 +12,12 @@ import tokens from '../utils/tokens';
 import SpanFmt from './SpanFmt';
 import TokenGeneralInfo from '../components/TokenGeneralInfo';
 import hathorLib from '@hathor/wallet-lib';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+
+const mapStateToProps = (state) => {
+  return { storage: state.wallet.storage };
+};
 
 /**
  * Component that shows a modal with information about an unregistered token
@@ -62,7 +67,7 @@ class ModalUnregisteredTokenInfo extends React.Component {
       );
 
       try {
-        const tokenData = await hathorLib.tokensUtils.validateTokenToAddByConfigurationString(configurationString, this.props.wallet.storage);
+        const tokenData = await hathorLib.tokensUtils.validateTokenToAddByConfigurationString(configurationString, this.props.storage);
         await tokens.addToken(tokenData.uid, tokenData.name, tokenData.symbol);
         $('#unregisteredTokenInfoModal').modal('hide');
         this.props.tokenRegistered(this.props.token);
@@ -153,4 +158,4 @@ ModalUnregisteredTokenInfo.propTypes = {
   totalSupply: PropTypes.number,
 };
 
-export default ModalUnregisteredTokenInfo;
+export default connect(mapStateToProps)(ModalUnregisteredTokenInfo);

--- a/src/constants.js
+++ b/src/constants.js
@@ -20,7 +20,7 @@ export const WALLET_HISTORY_COUNT = 10;
 /**
  * Wallet version
  */
-export const VERSION = '0.26.0';
+export const VERSION = '0.27.0-rc1';
 
 /**
  * Before this version the data in localStorage from the wallet is not compatible

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -133,6 +133,11 @@ const initialState = {
     ...FEATURE_TOGGLE_DEFAULTS,
   },
 
+  /**
+   * A set of tx ids received during this session.
+   * This will be used to prevent sending a notification for the same tx twice.
+   * @type {Set<string>}
+   */
   receivedTxs: new Set(),
 };
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -132,6 +132,8 @@ const initialState = {
   featureToggles: {
     ...FEATURE_TOGGLE_DEFAULTS,
   },
+
+  receivedTxs: new Set(),
 };
 
 const rootReducer = (state = initialState, action) => {
@@ -266,6 +268,8 @@ const rootReducer = (state = initialState, action) => {
       return onFeatureToggleInitialized(state);
     case types.WALLET_RESET_SUCCESS:
       return onWalletResetSuccess(state);
+    case types.MARK_TX_RECEIVED:
+      return onMarkTxReceived(state, action);
     default:
       return state;
   }
@@ -336,7 +340,7 @@ const isAllAuthority = (tx) => {
 const onLoadWalletSuccess = (state, action) => {
   // Update the version of the wallet that the data was loaded
   LOCAL_STORE.setWalletVersion(VERSION);
-  const { tokens, currentAddress } = action.payload;
+  const { tokens, registeredTokens, currentAddress } = action.payload;
   const allTokens = new Set(tokens);
 
   return {
@@ -345,6 +349,7 @@ const onLoadWalletSuccess = (state, action) => {
     lastSharedAddress: currentAddress.address,
     lastSharedIndex: currentAddress.index,
     allTokens,
+    tokens: registeredTokens,
   };
 };
 
@@ -1014,5 +1019,11 @@ const onWalletResetSuccess = (state) => ({
   unleashClient: state.unleashClient,
 });
 
+export const onMarkTxReceived = (state, action) => {
+  const txId = action.payload;
+  state.receivedTxs.add(txId);
+
+  return state;
+};
 
 export default rootReducer;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1038,14 +1038,7 @@ export const onUpdateTxHistory = (state, action) => {
 
   for (const [index, histTx] of tokenHistory.data.entries()) {
     if (histTx.tx_id === tx.tx_id) {
-      tokenHistory.data[index] = {
-        tx_id: tx.tx_id,
-        timestamp: tx.timestamp,
-        tokenUid: tokenId,
-        is_voided: Boolean(tx.is_voided),
-        version: tx.version,
-        balance,
-      };
+      tokenHistory.data[index] = getTxHistoryFromWSTx(tx, tokenId, balance);
       break;
     }
   }

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -308,7 +308,7 @@ const getTxHistoryFromWSTx = (tx, tokenUid, tokenTxBalance) => {
     balance: tokenTxBalance,
     is_voided: tx.is_voided,
     version: tx.version,
-    isAllAuthority: isAllAuthority(tx),
+    // isAllAuthority: isAllAuthority(tx),
   }
 };
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -597,6 +597,7 @@ export const onTokenFetchBalanceRequested = (state, action) => {
  */
 export const onTokenFetchBalanceSuccess = (state, action) => {
   const { tokenId, data } = action;
+  const oldState = get(state.tokensBalance, tokenId, {});
 
   return {
     ...state,
@@ -606,6 +607,7 @@ export const onTokenFetchBalanceSuccess = (state, action) => {
         status: TOKEN_DOWNLOAD_STATUS.READY,
         updatedAt: new Date().getTime(),
         data,
+        oldStatus: oldState.status,
       },
     },
   };
@@ -616,6 +618,7 @@ export const onTokenFetchBalanceSuccess = (state, action) => {
  */
 export const onTokenFetchBalanceFailed = (state, action) => {
   const { tokenId } = action;
+  const oldState = get(state.tokensBalance, tokenId, {});
 
   return {
     ...state,
@@ -623,6 +626,7 @@ export const onTokenFetchBalanceFailed = (state, action) => {
       ...state.tokensBalance,
       [tokenId]: {
         status: TOKEN_DOWNLOAD_STATUS.FAILED,
+        oldStatus: oldState.status,
       },
     },
   };
@@ -634,6 +638,7 @@ export const onTokenFetchBalanceFailed = (state, action) => {
  */
 export const onTokenFetchHistorySuccess = (state, action) => {
   const { tokenId, data } = action;
+  const oldState = get(state.tokensHistory, tokenId, {});
 
   return {
     ...state,
@@ -643,6 +648,7 @@ export const onTokenFetchHistorySuccess = (state, action) => {
         status: TOKEN_DOWNLOAD_STATUS.READY,
         updatedAt: new Date().getTime(),
         data,
+        oldStatus: oldState.status,
       },
     },
   };
@@ -653,6 +659,7 @@ export const onTokenFetchHistorySuccess = (state, action) => {
  */
 export const onTokenFetchHistoryFailed = (state, action) => {
   const { tokenId } = action;
+  const oldState = get(state.tokensHistory, tokenId, {});
 
   return {
     ...state,
@@ -661,6 +668,7 @@ export const onTokenFetchHistoryFailed = (state, action) => {
       [tokenId]: {
         status: TOKEN_DOWNLOAD_STATUS.FAILED,
         data: [],
+        oldStatus: oldState.status,
       },
     },
   };

--- a/src/sagas/helpers.js
+++ b/src/sagas/helpers.js
@@ -107,17 +107,6 @@ export function errorHandler(saga, failureAction) {
   };
 }
 
-/**
- * Get registered tokens from the wallet instance.
- * @param {HathorWallet} wallet
- * @param {boolean} excludeDefaultToken If we should exclude the default token.
- * @returns {string[]}
- */
-export async function getRegisteredTokensUids(wallet, excludeDefaultToken = false) {
-  const tokenConfigArr = await tokensUtils.getRegisteredTokens(wallet, excludeDefaultToken);
-  return tokenConfigArr.map(token => token.uid);
-}
-
 export function* dispatchLedgerTokenSignatureVerification(wallet) {
   const isHardware = yield wallet.storage.isHardwareWallet();
   if (!isHardware) {

--- a/src/sagas/wallet.js
+++ b/src/sagas/wallet.js
@@ -295,6 +295,8 @@ export function* startWallet(action) {
     }
   }
 
+  yield call([wallet.storage, wallet.storage.registerToken(hathorLibConstants.HATHOR_TOKEN_CONFIG)]);
+
   if (hardware) {
     // This will verify all ledger trusted tokens to check their validity
     yield fork(dispatchLedgerTokenSignatureVerification, wallet);
@@ -346,7 +348,7 @@ export function* loadTokens() {
 
   // Fetch all tokens, including the ones that are not registered yet
   const allTokens = yield call([wallet, wallet.getTokens]);
-  const registeredTokens = yield getRegisteredTokensUids(wallet, true);
+  const registeredTokens = yield getRegisteredTokensUids(wallet, false);
 
   // We don't need to wait for the metadatas response, so we can just
   // spawn a new "thread" to handle it.

--- a/src/sagas/wallet.js
+++ b/src/sagas/wallet.js
@@ -539,14 +539,12 @@ export function* handleUpdateTx(action) {
   }
 
   // reload token history of affected tokens
-  // We always reload the history and balance
+  // We always reload balance but only reload the tx being updated on history.
   const affectedTokens = yield call(handleTx, wallet, tx);
   const stateTokens = yield select((state) => state.tokens);
   const registeredTokens = stateTokens.map((token) => token.uid);
   const txbalance = yield call([wallet, wallet.getTxBalance], tx);
 
-  // We should download the **balance** and **history** for every token involved
-  // in the transaction
   for (const tokenUid of affectedTokens) {
     if (registeredTokens.indexOf(tokenUid) === -1) {
       continue;

--- a/src/screens/LockedWallet.js
+++ b/src/screens/LockedWallet.js
@@ -80,6 +80,8 @@ class LockedWallet extends React.Component {
       }
 
       await LOCAL_STORE.handleDataMigration(pin);
+      // We block the wallet from being showed if it was locked or closed.
+      // So we need to mark it as opened for the UI to proceed.
       LOCAL_STORE.open();
 
       // LockedWallet screen was called for a result, so we should resolve the promise with the PIN after

--- a/src/screens/LockedWallet.js
+++ b/src/screens/LockedWallet.js
@@ -80,6 +80,7 @@ class LockedWallet extends React.Component {
       }
 
       await LOCAL_STORE.handleDataMigration(pin);
+      LOCAL_STORE.open();
 
       // LockedWallet screen was called for a result, so we should resolve the promise with the PIN after
       // it is validated.

--- a/src/screens/Wallet.js
+++ b/src/screens/Wallet.js
@@ -50,6 +50,7 @@ const mapStateToProps = (state) => {
     tokenMetadata: state.tokenMetadata || {},
     tokens: state.tokens,
     wallet: state.wallet,
+    walletState: state.walletState,
     useWalletService: state.useWalletService,
   };
 };
@@ -338,12 +339,10 @@ class Wallet extends React.Component {
     const token = this.props.tokens.find((token) => token.uid === this.props.selectedToken);
     const tokenHistory = get(this.props.tokensHistory, this.props.selectedToken, {
       status: TOKEN_DOWNLOAD_STATUS.LOADING,
-      oldStatus: undefined,
       data: [],
     });
     const tokenBalance = get(this.props.tokensBalance, this.props.selectedToken, {
       status: TOKEN_DOWNLOAD_STATUS.LOADING,
-      oldStatus: undefined,
       data: {
         available: 0,
         locked: 0,
@@ -462,12 +461,11 @@ class Wallet extends React.Component {
     const renderUnlockedWallet = () => {
       let template;
       /**
-       * If an oldStatus of either balance or history should be undefined this
-       * means that this is the first time we are loading it, so it should show
-       * the loading message.
+       * We only show the loading message if we are syncing the entire history
+       * This will happen on the first history load and if we lose connection
+       * to the fullnode.
        */
-      if (tokenHistory.oldStatus === undefined
-          || tokenBalance.oldStatus === undefined) {
+      if (this.props.walletState === hathorLib.HathorWallet.SYNCING) {
         template = (
           <div className='token-wrapper d-flex flex-column align-items-center justify-content-center mb-3'>
             <ReactLoading

--- a/src/screens/Wallet.js
+++ b/src/screens/Wallet.js
@@ -338,10 +338,12 @@ class Wallet extends React.Component {
     const token = this.props.tokens.find((token) => token.uid === this.props.selectedToken);
     const tokenHistory = get(this.props.tokensHistory, this.props.selectedToken, {
       status: TOKEN_DOWNLOAD_STATUS.LOADING,
+      oldStatus: undefined,
       data: [],
     });
     const tokenBalance = get(this.props.tokensBalance, this.props.selectedToken, {
       status: TOKEN_DOWNLOAD_STATUS.LOADING,
+      oldStatus: undefined,
       data: {
         available: 0,
         locked: 0,
@@ -459,8 +461,13 @@ class Wallet extends React.Component {
 
     const renderUnlockedWallet = () => {
       let template;
-      if (tokenHistory.status === TOKEN_DOWNLOAD_STATUS.LOADING
-          || tokenBalance.status === TOKEN_DOWNLOAD_STATUS.LOADING) {
+      /**
+       * If an oldStatus of either balance or history should be undefined this
+       * means that this is the first time we are loading it, so it should show
+       * the loading message.
+       */
+      if (tokenHistory.oldStatus === undefined
+          || tokenBalance.oldStatus === undefined) {
         template = (
           <div className='token-wrapper d-flex flex-column align-items-center justify-content-center mb-3'>
             <ReactLoading

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -8,47 +8,56 @@
 import LOCAL_STORE, { STARTED_KEY, LOCKED_KEY, CLOSED_KEY, IS_BACKUP_DONE_KEY, IS_HARDWARE_KEY } from '../storage';
 
 const storageUtils = {
+  /**
+   * Migrate the localStorage from a previous version to the current version.
+   *
+   * The current state should not be affected if we run this method more than
+   * once. Like a user closing and opening the wallet again before inputing his
+   * pin.
+   */
   migratePreviousLocalStorage() {
-    const accessData = LOCAL_STORE.getItem('wallet:accessData');
-
-    if (!accessData) {
-      return;
+    const oldStorageKeys = {
+      OLD_STARTED_KEY: 'wallet:started',
+      OLD_LOCKED_KEY: 'wallet:locked',
+      OLD_CLOSED_KEY: 'wallet:closed',
+      OLD_BACKUP_KEY: 'wallet:backup',
+      OLD_TYPE_KEY: 'wallet:type',
     }
 
-    if (LOCAL_STORE.getItem('wallet:started')) {
+    if (LOCAL_STORE.getItem(oldStorageKeys.OLD_STARTED_KEY)) {
       LOCAL_STORE.setItem(
         STARTED_KEY,
-        LOCAL_STORE.getItem('wallet:started'),
+        LOCAL_STORE.getItem(oldStorageKeys.OLD_STARTED_KEY),
       );
-      LOCAL_STORE.removeItem('wallet:started');
+      LOCAL_STORE.removeItem(oldStorageKeys.OLD_STARTED_KEY);
     }
-    if (LOCAL_STORE.getItem('wallet:locked')) {
+    if (LOCAL_STORE.getItem(oldStorageKeys.OLD_LOCKED_KEY)) {
       LOCAL_STORE.setItem(
         LOCKED_KEY,
-        LOCAL_STORE.getItem('wallet:locked'),
+        LOCAL_STORE.getItem(oldStorageKeys.OLD_LOCKED_KEY),
       );
-      LOCAL_STORE.removeItem('wallet:locked');
+      LOCAL_STORE.removeItem(oldStorageKeys.OLD_LOCKED_KEY);
     }
-    if (LOCAL_STORE.getItem('wallet:closed')) {
+    if (LOCAL_STORE.getItem(oldStorageKeys.OLD_CLOSED_KEY)) {
       LOCAL_STORE.setItem(
         CLOSED_KEY,
-        LOCAL_STORE.getItem('wallet:closed'),
+        LOCAL_STORE.getItem(oldStorageKeys.OLD_CLOSED_KEY),
       );
-      LOCAL_STORE.removeItem('wallet:closed');
+      LOCAL_STORE.removeItem(oldStorageKeys.OLD_CLOSED_KEY);
     }
-    if (LOCAL_STORE.getItem('wallet:backup')) {
+    if (LOCAL_STORE.getItem(oldStorageKeys.OLD_BACKUP_KEY)) {
       LOCAL_STORE.setItem(
         IS_BACKUP_DONE_KEY,
-        LOCAL_STORE.getItem('wallet:backup'),
+        LOCAL_STORE.getItem(oldStorageKeys.OLD_BACKUP_KEY),
       );
-      LOCAL_STORE.removeItem('wallet:backup');
+      LOCAL_STORE.removeItem(oldStorageKeys.OLD_BACKUP_KEY);
     }
-    if (LOCAL_STORE.getItem('wallet:type')) {
+    if (LOCAL_STORE.getItem(oldStorageKeys.OLD_TYPE_KEY)) {
       LOCAL_STORE.setItem(
         IS_HARDWARE_KEY,
-        LOCAL_STORE.getItem('wallet:type') === 'hardware',
+        LOCAL_STORE.getItem(oldStorageKeys.OLD_TYPE_KEY) === 'hardware',
       );
-      LOCAL_STORE.removeItem('wallet:type');
+      LOCAL_STORE.removeItem(oldStorageKeys.OLD_TYPE_KEY);
     }
   }
 };

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -9,7 +9,7 @@ import LOCAL_STORE, { STARTED_KEY, LOCKED_KEY, CLOSED_KEY, IS_BACKUP_DONE_KEY, I
 
 const storageUtils = {
   migratePreviousLocalStorage() {
-    const accessData = localStorage.getItem('wallet:accessData');
+    const accessData = LOCAL_STORE.getItem('wallet:accessData');
 
     if (!accessData) {
       return;
@@ -20,30 +20,35 @@ const storageUtils = {
         STARTED_KEY,
         LOCAL_STORE.getItem('wallet:started'),
       );
+      LOCAL_STORE.removeItem('wallet:started');
     }
     if (LOCAL_STORE.getItem('wallet:locked')) {
       LOCAL_STORE.setItem(
         LOCKED_KEY,
         LOCAL_STORE.getItem('wallet:locked'),
       );
+      LOCAL_STORE.removeItem('wallet:locked');
     }
     if (LOCAL_STORE.getItem('wallet:closed')) {
       LOCAL_STORE.setItem(
         CLOSED_KEY,
         LOCAL_STORE.getItem('wallet:closed'),
       );
+      LOCAL_STORE.removeItem('wallet:closed');
     }
     if (LOCAL_STORE.getItem('wallet:backup')) {
       LOCAL_STORE.setItem(
         IS_BACKUP_DONE_KEY,
         LOCAL_STORE.getItem('wallet:backup'),
       );
+      LOCAL_STORE.removeItem('wallet:backup');
     }
     if (LOCAL_STORE.getItem('wallet:type')) {
       LOCAL_STORE.setItem(
         IS_HARDWARE_KEY,
         LOCAL_STORE.getItem('wallet:type') === 'hardware',
       );
+      LOCAL_STORE.removeItem('wallet:type');
     }
   }
 };

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import LOCAL_STORE, { STARTED_KEY, LOCKED_KEY, CLOSED_KEY, IS_BACKUP_DONE_KEY, IS_HARDWARE_KEY } from '../storage';
+
+const storageUtils = {
+  migratePreviousLocalStorage() {
+    const accessData = localStorage.getItem('wallet:accessData');
+
+    if (!accessData) {
+      return;
+    }
+
+    if (LOCAL_STORE.getItem('wallet:started')) {
+      LOCAL_STORE.setItem(
+        STARTED_KEY,
+        LOCAL_STORE.getItem('wallet:started'),
+      );
+    }
+    if (LOCAL_STORE.getItem('wallet:locked')) {
+      LOCAL_STORE.setItem(
+        LOCKED_KEY,
+        LOCAL_STORE.getItem('wallet:locked'),
+      );
+    }
+    if (LOCAL_STORE.getItem('wallet:closed')) {
+      LOCAL_STORE.setItem(
+        CLOSED_KEY,
+        LOCAL_STORE.getItem('wallet:closed'),
+      );
+    }
+    if (LOCAL_STORE.getItem('wallet:backup')) {
+      LOCAL_STORE.setItem(
+        IS_BACKUP_DONE_KEY,
+        LOCAL_STORE.getItem('wallet:backup'),
+      );
+    }
+    if (LOCAL_STORE.getItem('wallet:type')) {
+      LOCAL_STORE.setItem(
+        IS_HARDWARE_KEY,
+        LOCAL_STORE.getItem('wallet:type') === 'hardware',
+      );
+    }
+  }
+};
+
+export default storageUtils;


### PR DESCRIPTION
### Acceptance Criteria
- Include HTR in the registered tokens
- Update registered tokens when starting a wallet
- When first starting the wallet we should migrate the localStorage to the new keys, so we can start from the same point that the wallet would start on the previous version./
- mark the wallet as opened when we open the wallet
- Pass the storage as prop to ModalUnregisteredTokenInfo, so it can unregister the token.
- bump the version to 0.27.0-rc1


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
