### PR TITLE
Feat/show authority operations

### DIFF
--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -13,6 +13,7 @@ import { TOKEN_DOWNLOAD_STATUS } from '../sagas/tokens';
 import { WALLET_STATUS } from '../sagas/wallet';
 import { PROPOSAL_DOWNLOAD_STATUS } from '../utils/atomicSwap';
 import { HATHOR_TOKEN_CONFIG } from "@hathor/wallet-lib/lib/constants";
+import helpersUtils from '../utils/helpers';
 import LOCAL_STORE from '../storage';
 
 /**
@@ -308,32 +309,10 @@ const getTxHistoryFromWSTx = (tx, tokenUid, tokenTxBalance) => {
     balance: tokenTxBalance,
     is_voided: tx.is_voided,
     version: tx.version,
-    // isAllAuthority: isAllAuthority(tx),
+    isAllAuthority: helpersUtils.isAllAuthority(tx),
   }
 };
 
-/**
- * Check if the tx has only inputs and outputs that are authorities
- *
- * @param {Object} tx Transaction data
- *
- * @return {boolean} If the tx has only authority
- */
-const isAllAuthority = (tx) => {
-  for (let txin of tx.inputs) {
-    if (!hathorLib.transactionUtils.isAuthorityOutput(txin)) {
-      return false;
-    }
-  }
-
-  for (let txout of tx.outputs) {
-    if (!hathorLib.transactionUtils.isAuthorityOutput(txout)) {
-      return false;
-    }
-  }
-
-  return true;
-}
 
 /**
  * Got wallet history. Update wallet data on redux

--- a/src/sagas/tokens.js
+++ b/src/sagas/tokens.js
@@ -201,8 +201,8 @@ function* fetchTokenHistory(action) {
       return;
     }
 
-    const response = yield call(wallet.getTxHistory.bind(wallet), { token_id: tokenId });
-    const data = response.map((txHistory) => helpers.mapTokenHistory(txHistory, tokenId));
+    const response = yield call([wallet, wallet.getTxHistory], { token_id: tokenId });
+    const data = yield call([helpers, helpers.mapTokenHistory], wallet, response, tokenId);
 
     yield put(tokenFetchHistorySuccess(tokenId, data));
   } catch (e) {

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -157,7 +157,7 @@ const wallet = {
    */
   async fetchMoreHistory(wallet, token, history) {
     const newHistory = await wallet.getTxHistory({ token_id: token, skip: history.length, count: WALLET_HISTORY_COUNT });
-    const newHistoryObjects = newHistory.map((element) => helpers.mapTokenHistory(element, token));
+    const newHistoryObjects = await helpers.mapTokenHistory(wallet, newHistory, token);
 
     if (newHistoryObjects.length) {
       store.dispatch(updateTokenHistory(token, newHistoryObjects));


### PR DESCRIPTION
### Motivation

Authority operations should show on the history list as "Authority" and not as transactions with zero balance.

The image below was taken from wallet version 0.26.0
![before](https://github.com/HathorNetwork/hathor-wallet/assets/15909384/5dfd5d2f-671b-4eb8-ba20-907fc1d29219)

This is how this PR will show a similar operation
![after](https://github.com/HathorNetwork/hathor-wallet/assets/15909384/22580a7f-d1ff-41d5-8a80-ca8f33e218b6)

### Acceptance Criteria
- Correctly map the history tx to a redux tx
- Show txs with only authority operations as "Authority" on the wallet screen


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
