### PR TITLE
chore: stop e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,15 +18,18 @@ jobs:
         node-version: [14.x]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        # https://github.com/actions/checkout/releases/tag/v4.0.0
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
       - name: Setup nodejs
-        uses: actions/setup-node@v2
+        # https://github.com/actions/setup-node/releases/tag/v3.8.1
+        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d
         with:
           node-version: ${{ matrix.node-version }}
       # Install NPM dependencies, cache them correctly
       # and run all Cypress tests
       - name: Cypress run
-        uses: cypress-io/github-action@v5
+        # https://github.com/cypress-io/github-action/releases/tag/v6.5.0
+        uses: cypress-io/github-action@59810ebfa5a5ac6fcfdcfdf036d1cd4d083a88f2
         with:
           start: npm start
           wait-on: 'http://localhost:3000'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,15 +1,15 @@
 name: End-to-end tests
-on:
-  push:
-    branches:
-      - master
-      - dev
-    tags:
-      - v*
-  pull_request:
-    branches:
-      - dev
-      - master
+# on:
+#   push:
+#     branches:
+#       - master
+#       - dev
+#     tags:
+#       - v*
+#   pull_request:
+#     branches:
+#       - dev
+#       - master
 jobs:
   cypress-run:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
### Acceptance Criteria
- Stop running e2e tests until they are fixed
- Upgrade e2e actions versions

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
