### PR TITLE
fix: show untrust all tokens option

### DIFF
--- a/src/screens/Settings.js
+++ b/src/screens/Settings.js
@@ -315,7 +315,7 @@ class Settings extends React.Component {
   render() {
     const serverURL = this.props.useWalletService ? hathorLib.config.getWalletServiceBaseUrl() : hathorLib.config.getServerUrl();
     const wsServerURL = this.props.useWalletService ? hathorLib.config.getWalletServiceBaseWsUrl() : '';
-    const ledgerCustomTokens = (!LOCAL_STORE.isHardwareWallet()) && version.isLedgerCustomTokenAllowed();
+    const ledgerCustomTokens = LOCAL_STORE.isHardwareWallet() && version.isLedgerCustomTokenAllowed();
     const uniqueIdentifier = helpers.getUniqueId();
 
     return (


### PR DESCRIPTION
### Acceptance Criteria
- To show the 'Untrust All Tokens' button we must have `LOCAL_STORE.isHardwareWallet()` as `true`, because it means that the ledger is in use.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
