### PR TITLE
Chore: Update `unleash-proxy-client`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3375,14 +3375,6 @@
         }
       }
     },
-    "@react-native-async-storage/async-storage": {
-      "version": "1.17.6",
-      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.17.6.tgz",
-      "integrity": "sha512-XXnoheQI3vQTQmjphdXNLTmtiKZeRqvI8kPQ25X5Eae7nZjdYEEGN+0z8N2qyelbUIQwKgmW0aagJk56q7DyNg==",
-      "requires": {
-        "merge-options": "^3.0.4"
-      }
-    },
     "@redux-saga/core": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@redux-saga/core/-/core-1.2.1.tgz",
@@ -18316,21 +18308,6 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
     },
-    "merge-options": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
-      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
-      "requires": {
-        "is-plain-obj": "^2.1.0"
-      },
-      "dependencies": {
-        "is-plain-obj": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
-        }
-      }
-    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -26752,19 +26729,18 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unleash-proxy-client": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/unleash-proxy-client/-/unleash-proxy-client-1.11.0.tgz",
-      "integrity": "sha512-z5qwSo0i2G+nKS3WeKhfVxDAED8CmlrfoXtUz1AOsCmhZ81GvkHFvvhMAWKdqGKyk86qojcEeA5c5adWX2HYjg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/unleash-proxy-client/-/unleash-proxy-client-3.2.0.tgz",
+      "integrity": "sha512-y9iCRCytxQCej6HlXecGu63ul1Wz6xklXOs+vuaPbqtj4NDGT6IThUvP3h7m5pW+IIxR99hnkVS1FICt1FT3yQ==",
       "requires": {
-        "@react-native-async-storage/async-storage": "^1.15.17",
         "tiny-emitter": "^2.1.0",
-        "uuid": "^8.3.2"
+        "uuid": "^9.0.1"
       },
       "dependencies": {
         "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "redux-saga": "1.2.1",
     "redux-thunk": "2.4.1",
     "ttag": "1.7.24",
-    "unleash-proxy-client": "1.11.0",
+    "unleash-proxy-client": "3.2.0",
     "viz.js": "2.1.2"
   },
   "main": "public/electron.js",


### PR DESCRIPTION
This upgrade removes some obsolete indirect dependencies that were interfering with an upgrade to Node.js `v20`

### Acceptance Criteria
- Upgrades [`unleash-proxy-client`](https://github.com/Unleash/unleash-proxy-client-js) to the latest stable version `3.2.0`

### Breaking changes
On `v2.0.2` [release](https://github.com/Unleash/unleash-proxy-client-js/releases/tag/v2.0.2-beta-0) it was announced that this lib will no longer support natively `react native async storage`. This native support was precisely what was breaking our migration, so it is a welcome change for this repository.

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
