### PR TITLE
chore: Update caniuse-lite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1326,11 +1326,6 @@
             "update-browserslist-db": "^1.0.13"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001566",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001566.tgz",
-          "integrity": "sha512-ggIhCsTxmITBAMmK8yZjEhCO5/47jKXPu6Dha/wuCS4JePVL+3uiDEBuhu2aIoT+bqTOR8L76Ip1ARL9xYsEJA=="
-        },
         "core-js-compat": {
           "version": "3.34.0",
           "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.34.0.tgz",
@@ -7988,11 +7983,6 @@
             "update-browserslist-db": "^1.0.13"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001566",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001566.tgz",
-          "integrity": "sha512-ggIhCsTxmITBAMmK8yZjEhCO5/47jKXPu6Dha/wuCS4JePVL+3uiDEBuhu2aIoT+bqTOR8L76Ip1ARL9xYsEJA=="
-        },
         "convert-source-map": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -9096,9 +9086,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001346",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001346.tgz",
-      "integrity": "sha512-q6ibZUO2t88QCIPayP/euuDREq+aMAxFE5S70PkrLh0iTDj/zEhgvJRKC2+CvXY6EWc6oQwUR48lL5vCW6jiXQ=="
+      "version": "1.0.30001570",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001570.tgz",
+      "integrity": "sha512-+3e0ASu4sw1SWaoCtvPeyXp+5PsjigkSt8OXZbF9StH5pQWbxEjLAZE3n8Aup5udop1uRiKA7a4utUk/uoSpUw=="
     },
     "capture-exit": {
       "version": "2.0.0",


### PR DESCRIPTION
This solves a warning raised on server start indicating our `caniuse` database was obsolete.

### Acceptance Criteria
- Updates [`caniuse-lite`](https://github.com/browserslist/caniuse-lite) dependency


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
