### PR TITLE
chore: Upgrades `caniuse-lite`

### DIFF
--- a/locale/texts.pot
+++ b/locale/texts.pot
@@ -684,7 +684,7 @@ msgstr ""
 msgid "**Real-time server:** You are connected to ${ wsServerURL }"
 msgstr ""
 
-#: src/components/RequestError.js:181
+#: src/components/RequestError.js:162
 #: src/screens/Settings.js:334
 msgid "Change server"
 msgstr ""
@@ -1721,7 +1721,7 @@ msgstr ""
 msgid "Both fields must be equal"
 msgstr ""
 
-#: src/components/RequestError.js:99
+#: src/components/RequestError.js:94
 msgid ""
 "There was an error fetching your transactions from the server.\n"
 "This might be caused by some reasons: (i) the server may be fully loaded, "
@@ -1730,46 +1730,46 @@ msgid ""
 "We advise you to wait a few seconds and retry your request."
 msgstr ""
 
-#: src/components/RequestError.js:102
+#: src/components/RequestError.js:97
 msgid ""
 "Rate limit exceeded. Sorry about that. You should wait a few seconds and "
 "try again. What do you want to do?"
 msgstr ""
 
-#: src/components/RequestError.js:104
+#: src/components/RequestError.js:99
 msgid "Your request failed to reach the server. What do you want to do?"
 msgstr ""
 
-#: src/components/RequestError.js:116
+#: src/components/RequestError.js:111
 msgid "URL:"
 msgstr ""
 
-#: src/components/RequestError.js:117
+#: src/components/RequestError.js:112
 msgid "Method:"
 msgstr ""
 
-#: src/components/RequestError.js:118
+#: src/components/RequestError.js:113
 msgid "Response status code:"
 msgstr ""
 
-#: src/components/RequestError.js:168
+#: src/components/RequestError.js:149
 msgid "Request failed"
 msgstr ""
 
-#: src/components/RequestError.js:175
+#: src/components/RequestError.js:156
 #, javascript-format
 msgid "You are connected to **${ serverURL }**"
 msgstr ""
 
-#: src/components/RequestError.js:176
+#: src/components/RequestError.js:157
 msgid "Show advanced data"
 msgstr ""
 
-#: src/components/RequestError.js:177
+#: src/components/RequestError.js:158
 msgid "Hide advanced data"
 msgstr ""
 
-#: src/components/RequestError.js:182
+#: src/components/RequestError.js:163
 msgid "Retry request"
 msgstr ""
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1326,11 +1326,6 @@
             "update-browserslist-db": "^1.0.13"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001566",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001566.tgz",
-          "integrity": "sha512-ggIhCsTxmITBAMmK8yZjEhCO5/47jKXPu6Dha/wuCS4JePVL+3uiDEBuhu2aIoT+bqTOR8L76Ip1ARL9xYsEJA=="
-        },
         "core-js-compat": {
           "version": "3.34.0",
           "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.34.0.tgz",
@@ -7980,11 +7975,6 @@
             "update-browserslist-db": "^1.0.13"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001566",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001566.tgz",
-          "integrity": "sha512-ggIhCsTxmITBAMmK8yZjEhCO5/47jKXPu6Dha/wuCS4JePVL+3uiDEBuhu2aIoT+bqTOR8L76Ip1ARL9xYsEJA=="
-        },
         "convert-source-map": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -9088,9 +9078,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001346",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001346.tgz",
-      "integrity": "sha512-q6ibZUO2t88QCIPayP/euuDREq+aMAxFE5S70PkrLh0iTDj/zEhgvJRKC2+CvXY6EWc6oQwUR48lL5vCW6jiXQ=="
+      "version": "1.0.30001570",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001570.tgz",
+      "integrity": "sha512-+3e0ASu4sw1SWaoCtvPeyXp+5PsjigkSt8OXZbF9StH5pQWbxEjLAZE3n8Aup5udop1uRiKA7a4utUk/uoSpUw=="
     },
     "capture-exit": {
       "version": "2.0.0",


### PR DESCRIPTION
This solves a warning raised on server start indicating our `caniuse` database was obsolete.

### Acceptance Criteria
- Updates [`caniuse-lite`](https://github.com/browserslist/caniuse-lite) dependency

### Notes
Currently this breaks the CI because of some issue with the translation files. This is still pending a solution, as the `update_pot` command does not solve the problem.

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
