### PR TITLE
Refactor: Navigation root for Router v5

### DIFF
--- a/src/ErrorWrapper.js
+++ b/src/ErrorWrapper.js
@@ -5,9 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Route } from 'react-router-dom';
-import wallet from './utils/wallet';
 import $ from 'jquery';
 import App from './App';
 import ModalUnhandledError from './components/ModalUnhandledError';
@@ -17,60 +16,47 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 import 'font-awesome/css/font-awesome.min.css';
 import './index.css';
 
-class ErrorBoundary extends React.Component {
+function ErrorBoundary({ onError }) {
+	const handleErrorEvent = (event) => {
+		onError(event.error);
+	}
 
-  state = { hasUiError: false, }
+	// Handling errors on the window level
+	useEffect(() => {
+		window.addEventListener('error', handleErrorEvent);
+		return () => {
+			window.removeEventListener('error', handleErrorEvent);
+		};
+	}, []);
 
-  handleErrorEvent = (event) => {
-    this.props.onError(event.error, false, {})
-  }
-
-  componentDidMount() {
-    window.addEventListener('error', this.handleErrorEvent)
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener('error', this.handleErrorEvent)
-  }
-
-  static getDerivedStateFromError(error) {
-    return { hasUiError: true };
-  }
-
-  componentDidCatch(error, info) {
-    this.props.onError(error, true)
-    wallet.sentryWithScope(error, info);
-  }
-
-  // Remove corrupted UI subtree to prevent error corrupt higher components
-  render() {
-    if (!this.props.error && this.state.hasUiError) {
-      this.setState({ hasUiError: false })
-    }
-
-    return this.state.hasUiError ? null : <Route path="/" component={App} />
-  }
+	return (
+		<Route path="/" children={<App/>}/>
+	)
 }
 
-class ErrorWrapper extends React.Component {
-  state = { error: null, renderError: null, info: null }
+function ErrorWrapper(props) {
+	const [error, setError] = useState(null);
 
-  onError = (error, renderError, info) => {
-    // Don't propagate error messages listened more than once
-    if (error !== this.state.error) {
-      this.setState({ error, renderError, info })
-      $('#unhandledErrorModal').modal('show')
-    }
-  }
+	const onError = (newError) => {
+		// Don't propagate error messages listened more than once
+		if (newError !== error) {
+			setError(error);
+			$('#unhandledErrorModal').modal('show');
+		}
+	}
 
-  render() {
-    const renderApp = (props) => <ErrorBoundary {...props} onError={this.onError} error={this.state.error} info={this.state.info} />
-    const renderModal = (props) => <ModalUnhandledError {...props} {...this.state} resetError={() => this.onError(null)} />
-    return <div className="components-wrapper">
-      <Route path="/" render={renderApp} />
-      <Route path="/" render={renderModal} />
-    </div>
-  }
+	return (
+		<div className="components-wrapper">
+			<ErrorBoundary
+				{...props}
+				onError={onError}
+			/>
+			<ModalUnhandledError
+				{...props}
+				resetError={() => onError(null)}
+			/>
+		</div>
+	)
 }
 
 export default ErrorWrapper;

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ root.render(
     <GlobalModal>
       <Router>
         <TokenBar />
-        <Route path="/" component={ErrorWrapper} />
+        <ErrorWrapper />
       </Router>
     </GlobalModal>
   </Provider>

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@
 
 import './i18nInit';
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import ErrorWrapper from './ErrorWrapper';
 import { BrowserRouter as Router, Route } from 'react-router-dom';
 import { GlobalModal } from './components/GlobalModal';
@@ -21,7 +21,9 @@ import './index.css';
 import store from "./store/index";
 import { Provider } from "react-redux";
 
-ReactDOM.render(
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(
   <Provider store={store}>
     <GlobalModal>
       <Router>
@@ -29,6 +31,5 @@ ReactDOM.render(
         <Route path="/" component={ErrorWrapper} />
       </Router>
     </GlobalModal>
-  </Provider>,
-  document.getElementById('root')
+  </Provider>
 );

--- a/src/screens/LoadWallet.js
+++ b/src/screens/LoadWallet.js
@@ -95,6 +95,7 @@ class LoadWallet extends React.Component {
     // First we clean what can still be there of a last wallet
     wallet.generateWallet(this.state.words, '', pin, password, this.props.history);
     LOCAL_STORE.markBackupDone();
+    LOCAL_STORE.open(); // Mark this wallet as open, so that is does not appear locked after loading
     // Clean pin and password from redux
     this.props.updatePassword(null);
     this.props.updatePin(null);

--- a/src/screens/LoadWallet.js
+++ b/src/screens/LoadWallet.js
@@ -95,7 +95,7 @@ class LoadWallet extends React.Component {
     // First we clean what can still be there of a last wallet
     wallet.generateWallet(this.state.words, '', pin, password, this.props.history);
     LOCAL_STORE.markBackupDone();
-    LOCAL_STORE.open(); // Mark this wallet as open, so that is does not appear locked after loading
+    LOCAL_STORE.open(); // Mark this wallet as open, so that it does not appear locked after loading
     // Clean pin and password from redux
     this.props.updatePassword(null);
     this.props.updatePin(null);


### PR DESCRIPTION
In the process to update React Router to v6, it is first necessary to make the current implementation of v5 fully integrated with react hooks. ( see: [official docs](https://reactrouter.com/en/main/upgrading/v5#upgrade-to-react-router-v51) )

### Acceptance Criteria
- Refactor the Router `root` element for React to use React v18
- Refactor the `ErrorWrapper` to be a _functional component_ and use hooks
- Refactor the `ErrorWrapper` to be a direct child of the root router


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
