### PR TITLE
Chore: Update `qrcode`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22168,19 +22168,10 @@
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw=="
     },
-    "qr.js": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
-      "integrity": "sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ=="
-    },
     "qrcode.react": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-0.9.3.tgz",
-      "integrity": "sha512-gGd30Ez7cmrKxyN2M3nueaNLk/f9J7NDRgaD5fVgxGpPLsYGWMn9UQ+XnDpv95cfszTQTdaf4QGLNMf3xU0hmw==",
-      "requires": {
-        "prop-types": "^15.6.0",
-        "qr.js": "0.0.0"
-      }
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-3.1.0.tgz",
+      "integrity": "sha512-oyF+Urr3oAMUG/OiOuONL3HXM+53wvuH3mtIWQrYmsXoAq0DkvZp2RYUWFSMFtbdOpuS++9v+WAkzNVkMlNW6Q=="
     },
     "qs": {
       "version": "6.5.3",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "patch-package": "6.4.7",
     "popper.js": "1.16.1",
     "prop-types": "15.8.1",
-    "qrcode.react": "0.9.3",
+    "qrcode.react": "3.1.0",
     "react": "18.2.0",
     "react-copy-to-clipboard": "5.1.0",
     "react-dom": "18.2.0",


### PR DESCRIPTION
### Acceptance Criteria
- Updates the QRCode library

### Notes
There were [no breaking changes](https://github.com/zpao/qrcode.react/releases/tag/v3.0.0) on the upgrade from `0.9.3` to `3.1.0`. The `qr.js` sub-dependency was also removed.

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
