### PR TITLE
chore: add libusb1 to flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,7 @@
           packages = with pkgs; [
             nixpkgs-fmt
             nodejs-14_x
+            libusb1
           ];
         };
     });


### PR DESCRIPTION
## Motivation

`libusb1` is now a dependency for one of the libraries the wallet-desktop uses, we should have it in the dev environment

### Acceptance Criteria
- [ ] The dev shell should include `libusb1` 


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
