### PR TITLE
chore: Upgrades `ttag`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26141,12 +26141,19 @@
       }
     },
     "ttag": {
-      "version": "1.7.24",
-      "resolved": "https://registry.npmjs.org/ttag/-/ttag-1.7.24.tgz",
-      "integrity": "sha512-8H/0dS6VYqBXzVBCo8f4s48TMIkC9UrALfMkXsaNWqKo3P3UQzfE1KZXlBkrhZho2A1iJuxUgGzHSgQvkZwGmg==",
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/ttag/-/ttag-1.8.6.tgz",
+      "integrity": "sha512-GwSFsRnthBz+VazcbvoBXcuiorMBEPrHdN3aJHZiTQiuCC1l0fZR0jp405SZ4BCHjvH+qWtVzmSwU6iSvbiSLg==",
       "requires": {
-        "dedent": "^0.7.0",
+        "dedent": "1.5.1",
         "plural-forms": "^0.5.3"
+      },
+      "dependencies": {
+        "dedent": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
+          "integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg=="
+        }
       }
     },
     "ttag-cli": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "redux": "4.2.0",
     "redux-saga": "1.2.1",
     "redux-thunk": "2.4.1",
-    "ttag": "1.7.24",
+    "ttag": "1.8.6",
     "unleash-proxy-client": "3.2.0",
     "viz.js": "2.1.2"
   },


### PR DESCRIPTION
### Acceptance Criteria
- Upgrades `ttag` to v1.8.6

### Notes
- There are no release notes since 2017 [on the repo's GitHub](https://github.com/ttag-org/ttag/releases)
- There are also no change logs [on their official site](https://ttag.js.org/docs/changelog.html) since 2019
- [The commits themselves](https://github.com/ttag-org/ttag/commits/v1.8.6/) indicate no suspicious activity: and only valid patches and fixes and a refactor to TypeScript


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
