### PR TITLE
chore: Upgrades `react-paginate`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22484,11 +22484,11 @@
       "integrity": "sha512-Vdqy79zq+bpeWJqC+xjltUjuGApyoItPgL0vgVfcJHhqwU7bAMKzysfGW/ADu6i0z0JiOCRJjo+IkFNkRNbA3A=="
     },
     "react-paginate": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/react-paginate/-/react-paginate-6.5.0.tgz",
-      "integrity": "sha512-H7xSi9jyiJzgfaj+2nNhQcjZfwzJ/Mxb64V2RiyDctjZyCWojwsaGwMqhLBpQ58iAuMVtBMRQ7ECqMcUKG9QSQ==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/react-paginate/-/react-paginate-8.2.0.tgz",
+      "integrity": "sha512-sJCz1PW+9PNIjUSn919nlcRVuleN2YPoFBOvL+6TPgrH/3lwphqiSOgdrLafLdyLDxsgK+oSgviqacF4hxsDIw==",
       "requires": {
-        "prop-types": "^15.6.1"
+        "prop-types": "^15"
       }
     },
     "react-redux": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "react-copy-to-clipboard": "5.1.0",
     "react-dom": "18.2.0",
     "react-loading": "2.0.3",
-    "react-paginate": "6.5.0",
+    "react-paginate": "8.2.0",
     "react-redux": "7.2.8",
     "react-router-dom": "5.3.3",
     "react-scripts": "4.0.3",


### PR DESCRIPTION
### Acceptance Criteria
- Upgrades `react-paginate` to v8.2.0

### Notes
The [changelogs](https://github.com/AdeleD/react-paginate/blob/v8.2.0/CHANGELOG.md#-820) for this dependency indicate no breaking changes

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
