### PR TITLE
chore: Upgrades `sentry`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3486,67 +3486,159 @@
         }
       }
     },
-    "@sentry/browser": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.30.0.tgz",
-      "integrity": "sha512-rOb58ZNVJWh1VuMuBG1mL9r54nZqKeaIlwSlvzJfc89vyfd7n6tQ1UXMN383QBz/MS5H5z44Hy5eE+7pCrYAfw==",
+    "@sentry-internal/feedback": {
+      "version": "7.99.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.99.0.tgz",
+      "integrity": "sha512-exIO1o+bE0MW4z30FxC0cYzJ4ZHSMlDPMHCBDPzU+MWGQc/fb8s58QUrx5Dnm6HTh9G3H+YlroCxIo9u0GSwGQ==",
       "dev": true,
       "requires": {
-        "@sentry/core": "5.30.0",
-        "@sentry/types": "5.30.0",
-        "@sentry/utils": "5.30.0",
-        "tslib": "^1.9.3"
+        "@sentry/core": "7.99.0",
+        "@sentry/types": "7.99.0",
+        "@sentry/utils": "7.99.0"
       },
       "dependencies": {
         "@sentry/core": {
-          "version": "5.30.0",
-          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.30.0.tgz",
-          "integrity": "sha512-TmfrII8w1PQZSZgPpUESqjB+jC6MvZJZdLtE/0hZ+SrnKhW3x5WlYLvTXZpcWePYBku7rl2wn1RZu6uT0qCTeg==",
+          "version": "7.99.0",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.99.0.tgz",
+          "integrity": "sha512-vOAtzcAXEUtS/oW7wi3wMkZ3hsb5Ch96gKyrrj/mXdOp2zrcwdNV6N9/pawq2E9P/7Pw8AXw4CeDZztZrjQLuA==",
           "dev": true,
           "requires": {
-            "@sentry/hub": "5.30.0",
-            "@sentry/minimal": "5.30.0",
-            "@sentry/types": "5.30.0",
-            "@sentry/utils": "5.30.0",
-            "tslib": "^1.9.3"
-          }
-        },
-        "@sentry/hub": {
-          "version": "5.30.0",
-          "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.30.0.tgz",
-          "integrity": "sha512-2tYrGnzb1gKz2EkMDQcfLrDTvmGcQPuWxLnJKXJvYTQDGLlEvi2tWz1VIHjunmOvJrB5aIQLhm+dcMRwFZDCqQ==",
-          "dev": true,
-          "requires": {
-            "@sentry/types": "5.30.0",
-            "@sentry/utils": "5.30.0",
-            "tslib": "^1.9.3"
-          }
-        },
-        "@sentry/minimal": {
-          "version": "5.30.0",
-          "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.30.0.tgz",
-          "integrity": "sha512-BwWb/owZKtkDX+Sc4zCSTNcvZUq7YcH3uAVlmh/gtR9rmUvbzAA3ewLuB3myi4wWRAMEtny6+J/FN/x+2wn9Xw==",
-          "dev": true,
-          "requires": {
-            "@sentry/hub": "5.30.0",
-            "@sentry/types": "5.30.0",
-            "tslib": "^1.9.3"
+            "@sentry/types": "7.99.0",
+            "@sentry/utils": "7.99.0"
           }
         },
         "@sentry/types": {
-          "version": "5.30.0",
-          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.30.0.tgz",
-          "integrity": "sha512-R8xOqlSTZ+htqrfteCWU5Nk0CDN5ApUTvrlvBuiH1DyP6czDZ4ktbZB0hAgBlVcK0U+qpD3ag3Tqqpa5Q67rPw==",
+          "version": "7.99.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.99.0.tgz",
+          "integrity": "sha512-94qwOw4w40sAs5mCmzcGyj8ZUu/KhnWnuMZARRq96k+SjRW/tHFAOlIdnFSrt3BLPvSOK7R3bVAskZQ0N4FTmA==",
           "dev": true
         },
         "@sentry/utils": {
-          "version": "5.30.0",
-          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.30.0.tgz",
-          "integrity": "sha512-zaYmoH0NWWtvnJjC9/CBseXMtKHm/tm40sz3YfJRxeQjyzRqNQPgivpd9R/oDJCYj999mzdW382p/qi2ypjLww==",
+          "version": "7.99.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.99.0.tgz",
+          "integrity": "sha512-cYZy5WNTkWs5GgggGnjfGqC44CWir0pAv4GVVSx0fsup4D4pMKBJPrtub15f9uC+QkUf3vVkqwpBqeFxtmJQTQ==",
           "dev": true,
           "requires": {
-            "@sentry/types": "5.30.0",
-            "tslib": "^1.9.3"
+            "@sentry/types": "7.99.0"
+          }
+        }
+      }
+    },
+    "@sentry-internal/replay-canvas": {
+      "version": "7.99.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.99.0.tgz",
+      "integrity": "sha512-PoIkfusToDq0snfl2M6HJx/1KJYtXxYhQplrn11kYadO04SdG0XGXf4h7wBTMEQ7LDEAtQyvsOu4nEQtTO3YjQ==",
+      "dev": true,
+      "requires": {
+        "@sentry/core": "7.99.0",
+        "@sentry/replay": "7.99.0",
+        "@sentry/types": "7.99.0",
+        "@sentry/utils": "7.99.0"
+      },
+      "dependencies": {
+        "@sentry/core": {
+          "version": "7.99.0",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.99.0.tgz",
+          "integrity": "sha512-vOAtzcAXEUtS/oW7wi3wMkZ3hsb5Ch96gKyrrj/mXdOp2zrcwdNV6N9/pawq2E9P/7Pw8AXw4CeDZztZrjQLuA==",
+          "dev": true,
+          "requires": {
+            "@sentry/types": "7.99.0",
+            "@sentry/utils": "7.99.0"
+          }
+        },
+        "@sentry/types": {
+          "version": "7.99.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.99.0.tgz",
+          "integrity": "sha512-94qwOw4w40sAs5mCmzcGyj8ZUu/KhnWnuMZARRq96k+SjRW/tHFAOlIdnFSrt3BLPvSOK7R3bVAskZQ0N4FTmA==",
+          "dev": true
+        },
+        "@sentry/utils": {
+          "version": "7.99.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.99.0.tgz",
+          "integrity": "sha512-cYZy5WNTkWs5GgggGnjfGqC44CWir0pAv4GVVSx0fsup4D4pMKBJPrtub15f9uC+QkUf3vVkqwpBqeFxtmJQTQ==",
+          "dev": true,
+          "requires": {
+            "@sentry/types": "7.99.0"
+          }
+        }
+      }
+    },
+    "@sentry-internal/tracing": {
+      "version": "7.99.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.99.0.tgz",
+      "integrity": "sha512-z3JQhHjoM1KdM20qrHwRClKJrNLr2CcKtCluq7xevLtXHJWNAQQbafnWD+Aoj85EWXBzKt9yJMv2ltcXJ+at+w==",
+      "dev": true,
+      "requires": {
+        "@sentry/core": "7.99.0",
+        "@sentry/types": "7.99.0",
+        "@sentry/utils": "7.99.0"
+      },
+      "dependencies": {
+        "@sentry/core": {
+          "version": "7.99.0",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.99.0.tgz",
+          "integrity": "sha512-vOAtzcAXEUtS/oW7wi3wMkZ3hsb5Ch96gKyrrj/mXdOp2zrcwdNV6N9/pawq2E9P/7Pw8AXw4CeDZztZrjQLuA==",
+          "dev": true,
+          "requires": {
+            "@sentry/types": "7.99.0",
+            "@sentry/utils": "7.99.0"
+          }
+        },
+        "@sentry/types": {
+          "version": "7.99.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.99.0.tgz",
+          "integrity": "sha512-94qwOw4w40sAs5mCmzcGyj8ZUu/KhnWnuMZARRq96k+SjRW/tHFAOlIdnFSrt3BLPvSOK7R3bVAskZQ0N4FTmA==",
+          "dev": true
+        },
+        "@sentry/utils": {
+          "version": "7.99.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.99.0.tgz",
+          "integrity": "sha512-cYZy5WNTkWs5GgggGnjfGqC44CWir0pAv4GVVSx0fsup4D4pMKBJPrtub15f9uC+QkUf3vVkqwpBqeFxtmJQTQ==",
+          "dev": true,
+          "requires": {
+            "@sentry/types": "7.99.0"
+          }
+        }
+      }
+    },
+    "@sentry/browser": {
+      "version": "7.99.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.99.0.tgz",
+      "integrity": "sha512-bgfoUv3wkwwLgN5YUOe0ibB3y268ZCnamZh6nLFqnY/UBKC1+FXWFdvzVON/XKUm62LF8wlpCybOf08ebNj2yg==",
+      "dev": true,
+      "requires": {
+        "@sentry-internal/feedback": "7.99.0",
+        "@sentry-internal/replay-canvas": "7.99.0",
+        "@sentry-internal/tracing": "7.99.0",
+        "@sentry/core": "7.99.0",
+        "@sentry/replay": "7.99.0",
+        "@sentry/types": "7.99.0",
+        "@sentry/utils": "7.99.0"
+      },
+      "dependencies": {
+        "@sentry/core": {
+          "version": "7.99.0",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.99.0.tgz",
+          "integrity": "sha512-vOAtzcAXEUtS/oW7wi3wMkZ3hsb5Ch96gKyrrj/mXdOp2zrcwdNV6N9/pawq2E9P/7Pw8AXw4CeDZztZrjQLuA==",
+          "dev": true,
+          "requires": {
+            "@sentry/types": "7.99.0",
+            "@sentry/utils": "7.99.0"
+          }
+        },
+        "@sentry/types": {
+          "version": "7.99.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.99.0.tgz",
+          "integrity": "sha512-94qwOw4w40sAs5mCmzcGyj8ZUu/KhnWnuMZARRq96k+SjRW/tHFAOlIdnFSrt3BLPvSOK7R3bVAskZQ0N4FTmA==",
+          "dev": true
+        },
+        "@sentry/utils": {
+          "version": "7.99.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.99.0.tgz",
+          "integrity": "sha512-cYZy5WNTkWs5GgggGnjfGqC44CWir0pAv4GVVSx0fsup4D4pMKBJPrtub15f9uC+QkUf3vVkqwpBqeFxtmJQTQ==",
+          "dev": true,
+          "requires": {
+            "@sentry/types": "7.99.0"
           }
         }
       }
@@ -3661,6 +3753,45 @@
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
         "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/replay": {
+      "version": "7.99.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.99.0.tgz",
+      "integrity": "sha512-gyN/I2WpQrLAZDT+rScB/0jnFL2knEVBo8U8/OVt8gNP20Pq8T/rDZKO/TG0cBfvULDUbJj2P4CJryn2p/O2rA==",
+      "dev": true,
+      "requires": {
+        "@sentry-internal/tracing": "7.99.0",
+        "@sentry/core": "7.99.0",
+        "@sentry/types": "7.99.0",
+        "@sentry/utils": "7.99.0"
+      },
+      "dependencies": {
+        "@sentry/core": {
+          "version": "7.99.0",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.99.0.tgz",
+          "integrity": "sha512-vOAtzcAXEUtS/oW7wi3wMkZ3hsb5Ch96gKyrrj/mXdOp2zrcwdNV6N9/pawq2E9P/7Pw8AXw4CeDZztZrjQLuA==",
+          "dev": true,
+          "requires": {
+            "@sentry/types": "7.99.0",
+            "@sentry/utils": "7.99.0"
+          }
+        },
+        "@sentry/types": {
+          "version": "7.99.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.99.0.tgz",
+          "integrity": "sha512-94qwOw4w40sAs5mCmzcGyj8ZUu/KhnWnuMZARRq96k+SjRW/tHFAOlIdnFSrt3BLPvSOK7R3bVAskZQ0N4FTmA==",
+          "dev": true
+        },
+        "@sentry/utils": {
+          "version": "7.99.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.99.0.tgz",
+          "integrity": "sha512-cYZy5WNTkWs5GgggGnjfGqC44CWir0pAv4GVVSx0fsup4D4pMKBJPrtub15f9uC+QkUf3vVkqwpBqeFxtmJQTQ==",
+          "dev": true,
+          "requires": {
+            "@sentry/types": "7.99.0"
+          }
+        }
       }
     },
     "@sentry/types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3644,15 +3644,20 @@
       }
     },
     "@sentry/cli": {
-      "version": "1.74.4",
-      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-1.74.4.tgz",
-      "integrity": "sha512-BMfzYiedbModsNBJlKeBOLVYUtwSi99LJ8gxxE4Bp5N8hyjNIN0WVrozAVZ27mqzAuy6151Za3dpmOLO86YlGw==",
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.27.0.tgz",
+      "integrity": "sha512-pc0opd71W8lGhYvmB1keQtJkarxzCS9f9ErKYv6TfXOOX6drvwkyA6vD/6xEnpzyvqGAuGRU4T4sEeLD3irwUQ==",
       "dev": true,
       "requires": {
+        "@sentry/cli-darwin": "2.27.0",
+        "@sentry/cli-linux-arm": "2.27.0",
+        "@sentry/cli-linux-arm64": "2.27.0",
+        "@sentry/cli-linux-i686": "2.27.0",
+        "@sentry/cli-linux-x64": "2.27.0",
+        "@sentry/cli-win32-i686": "2.27.0",
+        "@sentry/cli-win32-x64": "2.27.0",
         "https-proxy-agent": "^5.0.0",
-        "mkdirp": "^0.5.5",
         "node-fetch": "^2.6.7",
-        "npmlog": "^4.1.2",
         "progress": "^2.0.3",
         "proxy-from-env": "^1.1.0",
         "which": "^2.0.2"
@@ -3668,6 +3673,55 @@
           }
         }
       }
+    },
+    "@sentry/cli-darwin": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.27.0.tgz",
+      "integrity": "sha512-/DOZlN5rK19g7YP2OaVNauQhUrRfJ88RDr6qURFiqdxYHDc3isPFGHZJmeZBTwOnDDepyZb4XLaOyfwvAOxHig==",
+      "dev": true,
+      "optional": true
+    },
+    "@sentry/cli-linux-arm": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.27.0.tgz",
+      "integrity": "sha512-JmMQ9zgFhkZUEN5WIYuJisu4Jif/ThRHDjbsbXBRbUkkgRn88hgUfg299djMvlZZxjpl3K9AEua+1TIUeQd0Sg==",
+      "dev": true,
+      "optional": true
+    },
+    "@sentry/cli-linux-arm64": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.27.0.tgz",
+      "integrity": "sha512-f+zuB9XGfB8pNamNgSDhqsavuLuzi6saZxbr3uQf30bA5AESI5hspOd1zPcidOORCVZxiPzQe3+T7avBI1XLuw==",
+      "dev": true,
+      "optional": true
+    },
+    "@sentry/cli-linux-i686": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.27.0.tgz",
+      "integrity": "sha512-/4eyz7jnYp20mZqNtpvCEBkxFW0nEjEZRo2BiASQ5/7K8CmoJRe1vhpDA0WOfzi1zTFIfpdE1/RZm2CjHS6DHQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@sentry/cli-linux-x64": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.27.0.tgz",
+      "integrity": "sha512-ptu7wXecnYssihzHlxEOaqbFHWmNEfbepBKGXTdWK2kC+D51+7yHsR9xRdThwVID1bisFgjAveKmBQjmKuXjHQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@sentry/cli-win32-i686": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.27.0.tgz",
+      "integrity": "sha512-Db4/xmdE5qV4Aq7Yc8vRw22Y46JJdGMdsMsl5jIf0GVSQPgO23O/2uTiDGpPOdeq91K9EtvpH1zQfDLIfLMaXw==",
+      "dev": true,
+      "optional": true
+    },
+    "@sentry/cli-win32-x64": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.27.0.tgz",
+      "integrity": "sha512-q7y/BH4iGfs0TD5PXh2Q8oqnTbOIufoT1NWJcKqvZcOiqCLK3PNUiq7xUeX1PMTrFYAh3Bm6EekOnMavqvbGmg==",
+      "dev": true,
+      "optional": true
     },
     "@sentry/core": {
       "version": "6.19.2",
@@ -5577,16 +5631,6 @@
       "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
       "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
       "dev": true
-    },
-    "are-we-there-yet": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
-      "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
-      "dev": true,
-      "requires": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
-      }
     },
     "argparse": {
       "version": "1.0.10",
@@ -9423,12 +9467,6 @@
         "q": "^1.1.2"
       }
     },
-    "code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
-      "dev": true
-    },
     "collect-v8-coverage": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
@@ -9614,12 +9652,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
       "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA=="
-    },
-    "console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
-      "dev": true
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -13605,22 +13637,6 @@
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
     },
-    "gauge": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha512-14x4kjc6lkD3ltw589k0NrPD6cCNTD6CWoVUNpB85+DrtONoZn+Rug6xZU5RvSC4+TZPxA5AnBibQYAvZn41Hg==",
-      "dev": true,
-      "requires": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
-      }
-    },
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -13948,12 +13964,6 @@
       "requires": {
         "has-symbols": "^1.0.2"
       }
-    },
-    "has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-      "dev": true
     },
     "has-value": {
       "version": "1.0.0",
@@ -14917,15 +14927,6 @@
       "integrity": "sha512-0by5vtUJs8iFQb5TYUHHPudOR+qXYIMKtiUzvLIZITZUjknFmziyBJuLhVRc+Ds0dREFlskDNJKYIdIzu/9pfw==",
       "requires": {
         "call-bind": "^1.0.2"
-      }
-    },
-    "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "^1.0.0"
       }
     },
     "is-generator-fn": {
@@ -18692,18 +18693,6 @@
         "path-key": "^2.0.0"
       }
     },
-    "npmlog": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-      "dev": true,
-      "requires": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
-      }
-    },
     "nth-check": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
@@ -18716,12 +18705,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
       "integrity": "sha512-Y1wZESM7VUThYY+4W+X4ySH2maqcA+p7UR+w8VWNWVAd6lwuXXWz/w/Cz43J/dI2I+PS6wD5N+bJUF+gjWvIqg=="
-    },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
-      "dev": true
     },
     "nwsapi": {
       "version": "2.2.7",
@@ -24520,17 +24503,6 @@
       "resolved": "https://registry.npmjs.org/string-natural-compare/-/string-natural-compare-3.0.1.tgz",
       "integrity": "sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw=="
     },
-    "string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "dev": true,
-      "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      }
-    },
     "string.prototype.matchall": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.10.tgz",
@@ -27853,15 +27825,6 @@
         "gopd": "^1.0.1",
         "has-tostringtag": "^1.0.0",
         "is-typed-array": "^1.1.10"
-      }
-    },
-    "wide-align": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-      "dev": true,
-      "requires": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
     "word-wrap": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   },
   "devDependencies": {
     "@sentry/browser": "7.99.0",
-    "@sentry/cli": "1.74.4",
+    "@sentry/cli": "2.27.0",
     "@testing-library/cypress": "8.0.7",
     "@testing-library/jest-dom": "6.1.5",
     "@testing-library/react": "14.1.2",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "generate-doc": "npx jsdoc -c jsdoc.json -r src/. README.md || exit 0"
   },
   "devDependencies": {
-    "@sentry/browser": "5.30.0",
+    "@sentry/browser": "7.99.0",
     "@sentry/cli": "1.74.4",
     "@testing-library/cypress": "8.0.7",
     "@testing-library/jest-dom": "6.1.5",


### PR DESCRIPTION
### Acceptance Criteria
- Upgrades `@sentry/browser` to the latest stable `v7.99.0`
- Upgrades `@sentry/cli` to the latest stable `v2.27.0`

### Notes
**Browser** update from 5.30.0 to 7.99.0
- [v6](https://github.com/getsentry/sentry-javascript/releases/tag/6.0.0) has no breaking changes
- [v7](https://github.com/getsentry/sentry-javascript/releases/tag/7.0.0) has some, but do not affect this application usage

**Cli** update from 1.74.4 to 2.27.0
- [v2](https://github.com/getsentry/sentry-cli/releases/tag/2.0.0) has some breaking changes, but none related to our usage on `/upload_source_maps.sh`

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
