### PR TITLE
chore: Removes `typescript`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26590,12 +26590,6 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
-      "dev": true
-    },
     "typescript-compare": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/typescript-compare/-/typescript-compare-0.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -98,8 +98,7 @@
     "jsdoc": "3.6.10",
     "nodemon": "2.0.16",
     "sass": "1.52.2",
-    "ttag-cli": "1.9.4",
-    "typescript": "3.9.10"
+    "ttag-cli": "1.9.4"
   },
   "build": {
     "appId": "network.hathor.macos.wallet",


### PR DESCRIPTION
Even though we want to use typescript on this application some day, it's currently unused and can be safely removed during this dependencies upgrade process. It was first added as a dev dependency on #32 

The application without this dependency was tested successfully in:
- Development environment
- The build artifacts
- The distributable binaries for Linux

### Acceptance Criteria
- Removes the `typescript` dependency


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
