### PR TITLE
fix: Ledger modal not updating on SendTokens

### DIFF
--- a/src/screens/Wallet.js
+++ b/src/screens/Wallet.js
@@ -269,6 +269,7 @@ function Wallet() {
     context.showModal(MODAL_TYPES.LEDGER_SIGN_TOKEN, {
       token,
       modalId: 'signTokenDataModal',
+      cb: (newValue) => console.log(`New token signature state: ${newValue}`)
     })
   }
 

--- a/src/screens/Wallet.js
+++ b/src/screens/Wallet.js
@@ -269,7 +269,7 @@ function Wallet() {
     context.showModal(MODAL_TYPES.LEDGER_SIGN_TOKEN, {
       token,
       modalId: 'signTokenDataModal',
-      cb: (newValue) => console.log(`New token signature state: ${newValue}`)
+      cb: () => () => {} // XXX: cb is a mandatory parameter for this modal
     })
   }
 


### PR DESCRIPTION
The ledger modal was deciding its rendering state based on a component state that was not being updated correctly after the refactor on #483 .

The code was changed to decide the rendering based on function parameters instead of component states, so that the correct context is always provided directly. Also, the `txData` local variable was completely removed and re-calculated whenever necessary to reduce component complexity.

Because this transaction data parameter needed to be handled in the Ledger event handlers, a workflow that is different from the one of the component rendering, the `sendTransaction` variable was moved outside the component. 

### Acceptance Criteria
- The Ledger modal should work on the full transaction send flow
- Minor function name refactorings should make their responsibilities clearer

### Alternate solution: declarative modal exhibition
Another solution for this event handling would be to make the Ledger modal more declarative: its exhibition would be requested by `setState()` calls and `useEffect()` functions would monitor those states to decide when to exhibit the modal and which parameters to pass to it.

This would increase the amount of code changed, modify the business logic of the component and would not improve readability too much. So this solution was discarded for now.

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
