### PR TITLE
fix: Network name inconsistency

### DIFF
--- a/src/sagas/wallet.js
+++ b/src/sagas/wallet.js
@@ -124,7 +124,6 @@ export function* startWallet(action) {
     }
   }
 
-  const network = config.getNetwork();
   const storage = LOCAL_STORE.getStorage();
 
   // We are offline, the connection object is yet to be created
@@ -146,6 +145,13 @@ export function* startWallet(action) {
   // If we've lost redux data, we could not properly stop the wallet object
   // then we don't know if we've cleaned up the wallet data in the storage
   yield storage.cleanStorage(true, true);
+
+  // Set the server and network as saved on localStorage
+  // If the localStorage is empty, fetch data directly from the lib config
+  const networkName = LOCAL_STORE.getNetwork() || config.getNetwork().name;
+  const serverUrl = LOCAL_STORE.getServer() || config.getServerUrl();
+  config.setServerUrl(serverUrl);
+  LOCAL_STORE.setServers(serverUrl);
 
   let wallet, connection;
   if (useWalletService) {
@@ -196,15 +202,9 @@ export function* startWallet(action) {
     wallet = new HathorWalletServiceWallet(walletConfig);
     connection = wallet.conn;
   } else {
-    // Set the server and network as saved on localStorage
-    // If the localStorage is empty, fetch data directly from the lib config
-    const serverUrl = LOCAL_STORE.getServer() || config.getServerUrl();
-    config.setServerUrl(serverUrl);
-    LOCAL_STORE.setServers(serverUrl);
-
     connection = new Connection({
-      network: network.name,
-      servers: [config.getServerUrl()],
+      network: networkName,
+      servers: [serverUrl],
     });
 
     const beforeReloadCallback = () => {
@@ -250,16 +250,16 @@ export function* startWallet(action) {
     console.log('[+] Start wallet.', serverInfo);
 
     let version;
-    let networkName = network.name;
+    let serverNetworkName = networkName;
 
     if (serverInfo) {
       version = serverInfo.version;
-      networkName = serverInfo.network && serverInfo.network.split('-')[0];
+      serverNetworkName = serverInfo.network && serverInfo.network.split('-')[0];
     }
 
     yield put(setServerInfo({
       version,
-      network: networkName,
+      network: serverNetworkName,
     }));
   } catch(e) {
     if (useWalletService) {
@@ -285,7 +285,7 @@ export function* startWallet(action) {
 
   if (enableAtomicSwap) {
     // Set urls for the Atomic Swap Service. If we have it on storage, use it, otherwise use defaults
-    initializeSwapServiceBaseUrlForWallet(network.name)
+    initializeSwapServiceBaseUrlForWallet(networkName)
     // Initialize listened proposals list
     const listenedProposals = walletUtils.getListenedProposals();
     yield put(proposalListUpdated(listenedProposals));

--- a/src/sagas/wallet.js
+++ b/src/sagas/wallet.js
@@ -151,7 +151,9 @@ export function* startWallet(action) {
   const networkName = LOCAL_STORE.getNetwork() || config.getNetwork().name;
   const serverUrl = LOCAL_STORE.getServer() || config.getServerUrl();
   config.setServerUrl(serverUrl);
+  config.setNetwork(networkName);
   LOCAL_STORE.setServers(serverUrl);
+  LOCAL_STORE.setNetwork(networkName);
 
   let wallet, connection;
   if (useWalletService) {


### PR DESCRIPTION
This is a complement of #537 : , it fixed all tested cases for software wallets. However when testing hardware wallets on `testnet` some new errors appeared. This PR fixes them.

The cause is that the _network name_ was never updated on local store for a hardware wallet.

### Acceptance Criteria
- The application should run a hardware wallet successfully on `testnet`
- After closing and opening the application again, the application should not throw any errors and continue on `testnet`


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
