### PR TITLE
chore: Upgrades `react-router` to `v6`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3432,6 +3432,11 @@
       "resolved": "https://registry.npmjs.org/@redux-saga/types/-/types-1.2.1.tgz",
       "integrity": "sha512-1dgmkh+3so0+LlBWRhGA33ua4MYr7tUOj+a9Si28vUi0IUFNbff1T3sgpeDJI/LaC75bBYnQ0A3wXjn0OrRNBA=="
     },
+    "@remix-run/router": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.3.tgz",
+      "integrity": "sha512-Oy8rmScVrVxWZVOpEF57ovlnhpZ8CCPlnIIumVcV9nFdiSIrus99+Lw78ekXyGvVDlIsFJbSfmSovJUhCWYV3w=="
+    },
     "@rollup/plugin-node-resolve": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz",
@@ -14094,19 +14099,6 @@
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
     },
-    "history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
-      }
-    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -18155,15 +18147,6 @@
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true
     },
-    "mini-create-react-context": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz",
-      "integrity": "sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==",
-      "requires": {
-        "@babel/runtime": "^7.12.1",
-        "tiny-warning": "^1.0.3"
-      }
-    },
     "mini-css-extract-plugin": {
       "version": "0.11.3",
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.11.3.tgz",
@@ -20450,21 +20433,6 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
-    "path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-      "requires": {
-        "isarray": "0.0.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
-        }
-      }
-    },
     "path-type": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
@@ -22236,34 +22204,20 @@
       "integrity": "sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg=="
     },
     "react-router": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.3.tgz",
-      "integrity": "sha512-mzQGUvS3bM84TnbtMYR8ZjKnuPJ71IjSzR+DE6UkUqvN4czWIqEs17yLL8xkAycv4ev0AiN+IGrWu88vJs/p2w==",
+      "version": "6.22.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.22.3.tgz",
+      "integrity": "sha512-dr2eb3Mj5zK2YISHK++foM9w4eBnO23eKnZEDs7c880P6oKbrjz/Svg9+nxqtHQK+oMW4OtjZca0RqPglXxguQ==",
       "requires": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "mini-create-react-context": "^0.4.0",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "@remix-run/router": "1.15.3"
       }
     },
     "react-router-dom": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.3.tgz",
-      "integrity": "sha512-Ov0tGPMBgqmbu5CDmN++tv2HQ9HlWDuWIIqn4b88gjlAN5IHI+4ZUZRcpz9Hl0azFIwihbLDYw1OiHGRo7ZIng==",
+      "version": "6.22.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.22.3.tgz",
+      "integrity": "sha512-7ZILI7HjcE+p31oQvwbokjk6OA/bnFxrhJ19n82Ex9Ph8fNAq+Hm/7KchpMGlTgWhUxRHMMCut+vEtNpWpowKw==",
       "requires": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.3.3",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "@remix-run/router": "1.15.3",
+        "react-router": "6.22.3"
       }
     },
     "react-scripts": {
@@ -23030,11 +22984,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
-    },
-    "resolve-pathname": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -25592,16 +25541,6 @@
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
-    "tiny-invariant": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
-      "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg=="
-    },
-    "tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
-    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -26646,11 +26585,6 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
-    },
-    "value-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "react-loading": "2.0.3",
     "react-paginate": "8.2.0",
     "react-redux": "7.2.8",
-    "react-router-dom": "5.3.3",
+    "react-router-dom": "^6.22.3",
     "react-scripts": "4.0.3",
     "redux": "4.2.0",
     "redux-saga": "1.2.1",

--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,7 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import { Redirect, Route, Routes, useRouteMatch } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation, useMatch, useNavigate } from 'react-router-dom';
 import Wallet from './screens/Wallet';
 import SendTokens from './screens/SendTokens';
 import CreateToken from './screens/CreateToken';
@@ -66,13 +66,13 @@ function Root() {
     };
   });
   const dispatch = useDispatch();
-  const history = useHistory();
+  const navigate = useNavigate();
 
   // Monitors when Ledger device loses connection or the app is closed
   useEffect(() => {
     if (ledgerClosed) {
       LOCAL_STORE.lock();
-      history.push('/locked/');
+      navigate('/locked/');
     }
   }, [ledgerClosed]);
 
@@ -188,15 +188,16 @@ function Root() {
 }
 
 function LoadedWalletComponent({ children }) {
-  const match = useRouteMatch();
+  const match = useMatch('');
   // For server screen we don't need to check version
   // We also allow the server screen to be reached from the locked screen
   // In the case of an unresponsive fullnode, which would block the wallet start
-  const isServerScreen = match.path === '/server';
+  console.log(`[LoadedWalletComponent] match: `, { match });
+  const isServerScreen = match.pathname === '/server';
 
   // If was closed and is loaded we need to redirect to locked screen
   if ((!isServerScreen) && (LOCAL_STORE.wasClosed() || LOCAL_STORE.isLocked()) && (!LOCAL_STORE.isHardwareWallet())) {
-    return <Redirect to={{ pathname: '/locked/' }} />;
+    return <Navigate to={ '/locked/' } />;
   }
 
   // We allow server screen to be shown from locked screen to allow the user to
@@ -213,10 +214,10 @@ function LoadedWalletComponent({ children }) {
   // The addresses are being loaded, redirect user
   if (loadingAddresses) {
     // If wallet is still loading addresses we redirect to the loading screen
-    return <Redirect to={{
-      pathname: '/loading_addresses/',
-      state: {path: match.url}
-    }} />;
+    return <Navigate
+      to={ '/loading_addresses/' }
+      state={{path: match.pathname}}
+    />;
   }
 
   // The wallet has fully loaded: check version
@@ -234,13 +235,13 @@ function LoadedWalletComponent({ children }) {
 }
 
 function StartedComponent({children, loaded: routeRequiresWalletToBeLoaded}) {
-  const history = useHistory();
   const { loadingAddresses } = useSelector(state => ({
     loadingAddresses: state.loadingAddresses
   }));
 
   // Handling Windows pathname issues
-  const pathname = history.location.pathname;
+  const location = useLocation();
+  const pathname = location.pathname;
   if (pathname.length > 3 && pathname.slice(0, 4).toLowerCase() === '/c:/') {
     // On Windows the pathname that is being pushed into history has a prefix of '/C:'
     // So everytime I use 'push' it works, because I set the pathname
@@ -249,13 +250,13 @@ function StartedComponent({children, loaded: routeRequiresWalletToBeLoaded}) {
     // Besides that, when electron loads initially it needs to load index.html from the filesystem
     // So the first load from electron get from '/C:/' in windows. That's why we need the second 'if'
     if (pathname.length > 11 && pathname.slice(-11).toLowerCase() !== '/index.html') {
-      return <Redirect to={{pathname: pathname.slice(3)}} />;
+      return <Navigate to={pathname.slice(3)} replace />;
     }
   }
 
   // The wallet was not yet started, go to Welcome
   if (!LOCAL_STORE.wasStarted()) {
-    return <Redirect to={{pathname: '/welcome/'}}/>;
+    return <Navigate to={ '/welcome/' } replace />;
   }
 
   // The wallet is already loaded
@@ -263,10 +264,10 @@ function StartedComponent({children, loaded: routeRequiresWalletToBeLoaded}) {
     // The server screen is a special case since we allow the user to change the
     // connected server in case of unresponsiveness, this should be allowed from
     // the locked screen since the wallet would not be able to be started otherwise
-    const isServerScreen = history.location.pathname === '/server';
+    const isServerScreen = location.pathname === '/server';
     // Wallet is locked, go to locked screen
     if (LOCAL_STORE.isLocked() && !isServerScreen && !LOCAL_STORE.isHardwareWallet()) {
-      return <Redirect to={{pathname: '/locked/'}}/>;
+      return <Navigate to={ '/locked/' } replace />;
     }
 
     // Route requires the wallet to be loaded, render it
@@ -275,22 +276,20 @@ function StartedComponent({children, loaded: routeRequiresWalletToBeLoaded}) {
     }
 
     // Route does not require wallet to be loaded. Redirect to wallet "home" screen
-    return <Redirect to={{pathname: '/wallet/'}}/>;
+    return <Navigate to="/wallet/" replace />;
   }
 
   // Wallet is not loaded, but it is still loading addresses. Go to the loading screen
   if (loadingAddresses) {
-    const match = useRouteMatch();
-    return <Redirect to={{
-      pathname: '/loading_addresses/',
-      state: {path: match.url}
-    }}/>;
+    const match = useMatch('');
+    console.log(`[StartedComponent] useMatch contents: `, { match }); // TODO: We need the URL instead of pathname... Check if this works
+    return <Navigate to={ '/loading_addresses/' } state={{path: match.pathname}} />;
   }
 
   // Wallet is not loaded or loading, but it is started
   // Since the route requires the wallet to be loaded, redirect to the wallet_type screen
   if (routeRequiresWalletToBeLoaded) {
-    return <Redirect to={{pathname: '/wallet_type/'}}/>;
+    return <Navigate to={ '/wallet_type/' } />;
   }
 
   // Wallet is not loaded nor loading, and the route does not require it to be loaded.
@@ -309,7 +308,6 @@ function DefaultComponent({ children }) {
   const { isVersionAllowed } = useSelector(state => ({
     isVersionAllowed: state.isVersionAllowed,
   }));
-  const history = useHistory();
 
   const [versionIsKnown, setVersionIsKnown] = useState(false);
 
@@ -322,12 +320,13 @@ function DefaultComponent({ children }) {
     setVersionIsKnown(true);
   }, [isVersionAllowed]);
 
-  /*
-   * Prevents rendering commmon app usage screens while the wallet version is still unknown.
-   * An exception is made to the 'locked' screen, because the version request is not yet done while the user is in it.
-   * Note: `DefaultComponent` is not used on the screens that initialize new wallets, or the "Welcome" screens
-   */
-  const isLockedScreen = history.location.pathname === '/locked/';
+	/*
+	 * Prevents rendering commmon app usage screens while the wallet version is still unknown.
+	 * An exception is made to the 'locked' screen, because the version request is not yet done while the user is in it.
+	 * Note: `DefaultComponent` is not used on the screens that initialize new wallets, or the "Welcome" screens
+	 */
+  const location = useLocation();
+  const isLockedScreen = location.pathname === '/locked/';
   if (!versionIsKnown) {
     if (!isLockedScreen) {
       return null;
@@ -344,7 +343,7 @@ function DefaultComponent({ children }) {
     LOCAL_STORE.isHardwareWallet()) {
     // This will redirect the page to Wallet Type screen
     LOCAL_STORE.cleanWallet();
-    return <Redirect to={ { pathname: '/wallet_type/' } } />;
+    return <Navigate to={ '/wallet_type/' } />;
   }
 
   // Render the navigation top bar, the component and the error handling modal

--- a/src/App.js
+++ b/src/App.js
@@ -210,25 +210,12 @@ function LoadedWalletComponent({ children }) {
     loadingAddresses: state.loadingAddresses,
   }));
 
-  // Check version
-  if (isVersionAllowed === undefined) {
-    throw new Error('[LoadedWalletComponent] isVersionAllowed is undefined');
-    // return <Redirect to={{
-    //   pathname: '/loading_addresses/',
-    //   state: {path: match.url},
-    //   waitVersionCheck: true
-    // }} />;
-  }
-  if (isVersionAllowed === false) {
-    return <VersionError />;
-  }
-
   // The version has been checked and allowed
   if (loadingAddresses) {
     // If wallet is still loading addresses we redirect to the loading screen
     return <Navigate
       to={ '/loading_addresses/' }
-      state={{path: location.pathname}}
+      state={{ path: location.pathname }}
     />;
   }
 

--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,7 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import { Navigate, Route, Routes, useLocation, useMatch, useNavigate } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import Wallet from './screens/Wallet';
 import SendTokens from './screens/SendTokens';
 import CreateToken from './screens/CreateToken';
@@ -210,7 +210,7 @@ function LoadedWalletComponent({ children }) {
     loadingAddresses: state.loadingAddresses,
   }));
 
-  // The version has been checked and allowed
+  // The addresses are being loaded, redirect user
   if (loadingAddresses) {
     // If wallet is still loading addresses we redirect to the loading screen
     return <Navigate

--- a/src/App.js
+++ b/src/App.js
@@ -170,7 +170,7 @@ function Root() {
       <Route path="/wallet/passphrase" element={<StartedComponent children={ <ChoosePassphrase />} loaded={true} />} />
       <Route path="/server" element={<StartedComponent children={ <Server /> } loaded={true} />} />
       <Route path="/transaction/:id" element={<StartedComponent children={ <TransactionDetail />} loaded={true} />} />
-      <Route path="/addresses" element={<StartedComponent children={ <AddressList /> } /> } loaded={true} />
+      <Route path="/addresses" element={<StartedComponent children={ <AddressList /> } loaded={true} /> } />
       <Route path="/new_wallet" element={<StartedComponent children={ <NewWallet />} loaded={false} />} />
       <Route path="/load_wallet" element={<StartedComponent children={ <LoadWallet /> } loaded={false} /> } />
       <Route path="/wallet_type" element={<StartedComponent children={<WalletType loaded={false} />} />} />

--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,7 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import { Redirect, Route, Switch, useHistory, useRouteMatch } from 'react-router-dom';
+import { Redirect, Route, Routes, useRouteMatch } from 'react-router-dom';
 import Wallet from './screens/Wallet';
 import SendTokens from './screens/SendTokens';
 import CreateToken from './screens/CreateToken';
@@ -154,36 +154,36 @@ function Root() {
 
   // Application rendering
   return (
-    <Switch>
-      <Route exact path="/nft" children={<StartedComponent children={ <NFTList />} loaded={true} />} />
-      <Route exact path="/create_token" children={<StartedComponent children={ <CreateToken /> } loaded={true} />} />
-      <Route exact path="/create_nft" children={<StartedComponent children={ <CreateNFT />} loaded={true} />} />
-      <Route exact path="/custom_tokens" children={<StartedComponent children={ <CustomTokens /> } loaded={true} />} />
-      <Route exact path="/unknown_tokens" children={<StartedComponent children={ <UnknownTokens />} loaded={true} />} />
-      <Route exact path="/wallet/send_tokens" children={<StartedComponent children={ <SendTokens /> } loaded={true} />} />
-      <Route exact path="/wallet/atomic_swap" children={<StartedComponent children={ <ProposalList />} loaded={true} />} />
-      <Route exact path="/wallet/atomic_swap/proposal/create" children={<StartedComponent children={ <NewSwap /> } loaded={true} />} />
-      <Route exact path="/wallet/atomic_swap/proposal/import" children={<StartedComponent children={ <ImportExisting />} loaded={true} />} />
-      <Route exact path="/wallet/atomic_swap/proposal/:proposalId" children={<StartedComponent children={ <EditSwap /> } loaded={true} />} />
-      <Route exact path="/wallet" children={<StartedComponent children={ <Wallet />} loaded={true} />} />
-      <Route exact path="/settings" children={<StartedComponent children={ <Settings /> } loaded={true} />} />
-      <Route exact path="/wallet/passphrase" children={<StartedComponent children={ <ChoosePassphrase />} loaded={true} />} />
-      <Route exact path="/server" children={<StartedComponent children={ <Server /> } loaded={true} />} />
-      <Route exact path="/transaction/:id" children={<StartedComponent children={ <TransactionDetail />} loaded={true} />} />
-      <Route exact path="/addresses" children={<StartedComponent children={ <AddressList /> } loaded={true} /> } />
-      <Route exact path="/new_wallet" children={<StartedComponent children={ <NewWallet />} loaded={false} />} />
-      <Route exact path="/load_wallet" children={<StartedComponent children={ <LoadWallet /> } loaded={false} /> } />
-      <Route exact path="/wallet_type" children={<StartedComponent children={<WalletType loaded={false} />} />} />
-      <Route exact path="/software_warning" children={<StartedComponent children={ <SoftwareWalletWarning /> } loaded={false} />} />
-      <Route exact path="/signin" children={<StartedComponent children={ <Signin />} loaded={false} />} />
-      <Route exact path="/hardware_wallet" children={<StartedComponent children={ <StartHardwareWallet /> } loaded={false} />} />
-      <Route exact path="/locked" children={<DefaultComponent children={<LockedWallet />} />} />
-      <Route exact path="/welcome" children={<Welcome />} />
-      <Route exact path="/loading_addresses" children={<LoadingAddresses />} />
-      <Route exact path="/permission" children={<SentryPermission />} />
-      <Route exact path="" children={<StartedComponent children={ <Wallet />} loaded={true} />} />
-      <Route path="" children={<Page404 />} />
-    </Switch>
+    <Routes>
+      <Route path="/nft" element={<StartedComponent children={ <NFTList />} loaded={true} />} />
+      <Route path="/create_token" element={<StartedComponent children={ <CreateToken /> } loaded={true} />} />
+      <Route path="/create_nft" element={<StartedComponent children={ <CreateNFT />} loaded={true} />} />
+      <Route path="/custom_tokens" element={<StartedComponent children={ <CustomTokens /> } loaded={true} />} />
+      <Route path="/unknown_tokens" element={<StartedComponent children={ <UnknownTokens />} loaded={true} />} />
+      <Route path="/wallet/send_tokens" element={<StartedComponent children={ <SendTokens /> } loaded={true} />} />
+      <Route path="/wallet/atomic_swap" element={<StartedComponent children={ <ProposalList />} loaded={true} />} />
+      <Route path="/wallet/atomic_swap/proposal/create" element={<StartedComponent children={ <NewSwap /> } loaded={true} />} />
+      <Route path="/wallet/atomic_swap/proposal/import" element={<StartedComponent children={ <ImportExisting />} loaded={true} />} />
+      <Route path="/wallet/atomic_swap/proposal/:proposalId" element={<StartedComponent children={ <EditSwap /> } loaded={true} />} />
+      <Route path="/wallet" element={<StartedComponent children={ <Wallet />} loaded={true} />} />
+      <Route path="/settings" element={<StartedComponent children={ <Settings /> } loaded={true} />} />
+      <Route path="/wallet/passphrase" element={<StartedComponent children={ <ChoosePassphrase />} loaded={true} />} />
+      <Route path="/server" element={<StartedComponent children={ <Server /> } loaded={true} />} />
+      <Route path="/transaction/:id" element={<StartedComponent children={ <TransactionDetail />} loaded={true} />} />
+      <Route path="/addresses" element={<StartedComponent children={ <AddressList /> } /> } loaded={true} />
+      <Route path="/new_wallet" element={<StartedComponent children={ <NewWallet />} loaded={false} />} />
+      <Route path="/load_wallet" element={<StartedComponent children={ <LoadWallet /> } loaded={false} /> } />
+      <Route path="/wallet_type" element={<StartedComponent children={<WalletType loaded={false} />} />} />
+      <Route path="/software_warning" element={<StartedComponent children={ <SoftwareWalletWarning /> } loaded={false} />} />
+      <Route path="/signin" element={<StartedComponent children={ <Signin />} loaded={false} />} />
+      <Route path="/hardware_wallet" element={<StartedComponent children={ <StartHardwareWallet /> } loaded={false} />} />
+      <Route path="/locked" element={<DefaultComponent children={<LockedWallet />} />} />
+      <Route path="/welcome" element={<Welcome />} />
+      <Route path="/loading_addresses" element={<LoadingAddresses />} />
+      <Route path="/permission" element={<SentryPermission />} />
+      <Route path="" element={<StartedComponent children={ <Wallet />} loaded={true} />} />
+      <Route path="" element={<Page404 />} />
+    </Routes>
   );
 }
 

--- a/src/App.js
+++ b/src/App.js
@@ -181,19 +181,18 @@ function Root() {
       <Route path="/welcome" element={<Welcome />} />
       <Route path="/loading_addresses" element={<LoadingAddresses />} />
       <Route path="/permission" element={<SentryPermission />} />
-      <Route path="" element={<StartedComponent children={ <Wallet />} loaded={true} />} />
-      <Route path="" element={<Page404 />} />
+      <Route path="/" element={<StartedComponent children={ <Wallet />} loaded={true} />} />
+      <Route path="*" element={<Page404 />} />
     </Routes>
   );
 }
 
 function LoadedWalletComponent({ children }) {
-  const match = useMatch('');
+  const location = useLocation();
   // For server screen we don't need to check version
   // We also allow the server screen to be reached from the locked screen
   // In the case of an unresponsive fullnode, which would block the wallet start
-  console.log(`[LoadedWalletComponent] match: `, { match });
-  const isServerScreen = match.pathname === '/server';
+  const isServerScreen = location.pathname === '/server';
 
   // If was closed and is loaded we need to redirect to locked screen
   if ((!isServerScreen) && (LOCAL_STORE.wasClosed() || LOCAL_STORE.isLocked()) && (!LOCAL_STORE.isHardwareWallet())) {
@@ -211,12 +210,25 @@ function LoadedWalletComponent({ children }) {
     loadingAddresses: state.loadingAddresses,
   }));
 
-  // The addresses are being loaded, redirect user
+  // Check version
+  if (isVersionAllowed === undefined) {
+    throw new Error('[LoadedWalletComponent] isVersionAllowed is undefined');
+    // return <Redirect to={{
+    //   pathname: '/loading_addresses/',
+    //   state: {path: match.url},
+    //   waitVersionCheck: true
+    // }} />;
+  }
+  if (isVersionAllowed === false) {
+    return <VersionError />;
+  }
+
+  // The version has been checked and allowed
   if (loadingAddresses) {
     // If wallet is still loading addresses we redirect to the loading screen
     return <Navigate
       to={ '/loading_addresses/' }
-      state={{path: match.pathname}}
+      state={{path: location.pathname}}
     />;
   }
 
@@ -281,9 +293,8 @@ function StartedComponent({children, loaded: routeRequiresWalletToBeLoaded}) {
 
   // Wallet is not loaded, but it is still loading addresses. Go to the loading screen
   if (loadingAddresses) {
-    const match = useMatch('');
-    console.log(`[StartedComponent] useMatch contents: `, { match }); // TODO: We need the URL instead of pathname... Check if this works
-    return <Navigate to={ '/loading_addresses/' } state={{path: match.pathname}} />;
+    const location = useLocation();
+    return <Navigate to={ '/loading_addresses/' } state={{path: location.pathname}} />;
   }
 
   // Wallet is not loaded or loading, but it is started

--- a/src/ErrorWrapper.js
+++ b/src/ErrorWrapper.js
@@ -15,6 +15,7 @@ import 'bootstrap';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'font-awesome/css/font-awesome.min.css';
 import './index.css';
+import TokenBar from "./components/TokenBar";
 
 function ErrorBoundary(props) {
 	const { onError } = props;
@@ -36,7 +37,7 @@ function ErrorBoundary(props) {
 	)
 }
 
-function ErrorWrapper(props) {
+function ErrorWrapper() {
 	const [error, setError] = useState(null);
 
 	const onError = (newError) => {
@@ -48,16 +49,17 @@ function ErrorWrapper(props) {
 	}
 
 	return (
+		<>
+		<TokenBar />
 		<div className="components-wrapper">
 			<ErrorBoundary
-				{...props}
 				onError={onError}
 			/>
 			<ModalUnhandledError
-				{...props}
 				resetError={() => onError(null)}
 			/>
 		</div>
+		</>
 	)
 }
 

--- a/src/ErrorWrapper.js
+++ b/src/ErrorWrapper.js
@@ -6,7 +6,7 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import $ from 'jquery';
 import App from './App';
 import ModalUnhandledError, { UNHANDLED_ERROR_MODAL_ID_SELECTOR } from './components/ModalUnhandledError';
@@ -18,7 +18,6 @@ import './index.css';
 
 function ErrorBoundary(props) {
 	const { onError } = props;
-	const history = useHistory();
 
 	const handleErrorEvent = (event) => {
 		onError(event.error);
@@ -33,7 +32,7 @@ function ErrorBoundary(props) {
 	}, []);
 
 	return (
-		<App history={history} />
+		<App />
 	)
 }
 

--- a/src/components/BackButton.js
+++ b/src/components/BackButton.js
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { t } from 'ttag';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 
 /**
@@ -16,7 +16,7 @@ import { useHistory } from 'react-router-dom';
  * @memberof Components
  */
 function BackButton() {
-  const history = useHistory();
+  const navigate = useNavigate();
 
   /**
    * Called when link is clicked and goes back one page
@@ -25,7 +25,7 @@ function BackButton() {
    */
   const goBack = (e) => {
     e.preventDefault();
-    history.goBack();
+    navigate(-1);
   }
 
   return (

--- a/src/components/ModalBackupWords.js
+++ b/src/components/ModalBackupWords.js
@@ -113,7 +113,9 @@ class ModalBackupWords extends React.Component {
         this.props.updateWords(words);
         this.setState({ passwordSuccess: true, errorMessage: '' });
       } catch (err) {
-        if (err && err.errorCode === hathorLib.ErrorMessages.DECRYPTION_ERROR) {
+        // XXX: The `ErrorMessages.ErrorMessages` property from the lib needs fixing.
+        if (err.errorCode === hathorLib.ErrorMessages.ErrorMessages.DECRYPTION_ERROR
+          || err.errorCode === hathorLib.ErrorMessages.ErrorMessages.INVALID_PASSWD) {
           // If the password is invalid it will throw a DecryptionError
           this.setState({ errorMessage: t`Invalid password` });
         }

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -46,19 +46,19 @@ function Navigation() {
         <div className="collapse navbar-collapse" id="navbarSupportedContent">
           <ul className="navbar-nav mr-auto">
             <li className="nav-item">
-              <NavLink to="/wallet/" exact className="nav-link" activeClassName="active" activeStyle={{ fontWeight: 'bold' }}>{t`Wallet`}</NavLink>
+              <NavLink to="/wallet/" className="nav-link">{t`Wallet`}</NavLink>
             </li>
             <li className="nav-item">
-              <NavLink to="/wallet/send_tokens/" exact className="nav-link" activeClassName="active" activeStyle={{ fontWeight: 'bold' }}>{t`Send tokens`}</NavLink>
+              <NavLink to="/wallet/send_tokens/" className="nav-link">{t`Send tokens`}</NavLink>
             </li>
             <li className="nav-item">
-              <NavLink to="/custom_tokens/" exact className="nav-link" activeClassName="active" activeStyle={{ fontWeight: 'bold' }}>{t`Custom tokens`}</NavLink>
+              <NavLink to="/custom_tokens/" className="nav-link">{t`Custom tokens`}</NavLink>
             </li>
             <li className="nav-item">
-              <NavLink to="/nft/" exact className="nav-link" activeClassName="active" activeStyle={{ fontWeight: 'bold' }}>{t`NFTs`}</NavLink>
+              <NavLink to="/nft/" className="nav-link">{t`NFTs`}</NavLink>
             </li>
             {useAtomicSwap && <li className="nav-item">
-              <NavLink to="/wallet/atomic_swap/" exact className="nav-link" activeClassName="active" activeStyle={{ fontWeight: 'bold' }}>{t`Atomic Swap`}</NavLink>
+              <NavLink to="/wallet/atomic_swap/" className="nav-link">{t`Atomic Swap`}</NavLink>
             </li>}
             <li className="nav-item">
               <a className="nav-link" href="true" onClick={goToExplorer}>{t`Public Explorer`}</a>

--- a/src/components/RequestError.js
+++ b/src/components/RequestError.js
@@ -26,7 +26,7 @@ const MODAL_DOM_ID = '#requestErrorModal';
  * @memberof Components
  */
 function RequestErrorModal() {
-	const navigate = useNavigate();
+  const navigate = useNavigate();
   const dispatch = useDispatch();
   const { lastFailedRequest, requestErrorStatusCode } = useSelector(state => ({
     lastFailedRequest: state.lastFailedRequest,

--- a/src/components/RequestError.js
+++ b/src/components/RequestError.js
@@ -12,7 +12,7 @@ import createRequestInstance from '../api/axiosInstance';
 import SpanFmt from './SpanFmt';
 import { useDispatch, useSelector } from 'react-redux';
 import hathorLib from '@hathor/wallet-lib';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 /**
  * DOM Identifier for the modal
@@ -26,7 +26,7 @@ const MODAL_DOM_ID = '#requestErrorModal';
  * @memberof Components
  */
 function RequestErrorModal() {
-  const history = useHistory();
+	const navigate = useNavigate();
   const dispatch = useDispatch();
   const { lastFailedRequest, requestErrorStatusCode } = useSelector(state => ({
     lastFailedRequest: state.lastFailedRequest,
@@ -42,7 +42,7 @@ function RequestErrorModal() {
    */
   const handleChangeServer = () => {
     $(MODAL_DOM_ID).modal('hide');
-    history.push('/server/');
+    navigate('/server/');
   }
 
   /**

--- a/src/components/TokenBar.js
+++ b/src/components/TokenBar.js
@@ -14,7 +14,7 @@ import helpers from '../utils/helpers';
 import wallet from "../utils/wallet";
 import Loading from '../components/Loading';
 import { TOKEN_DOWNLOAD_STATUS } from '../sagas/tokens';
-import { useHistory, useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import LOCAL_STORE from '../storage';
 
 // Routes that should display the TokenBar
@@ -26,7 +26,7 @@ const ROUTE_WHITELIST = [
 export default function TokenBar () {
   const [opened, setOpened] = useState(false);
   const dispatch = useDispatch();
-  const history = useHistory();
+  const navigate = useNavigate();
   const location = useLocation();
 
   // These are all tokens that are currently registered on the wallet
@@ -76,14 +76,14 @@ export default function TokenBar () {
    */
   const lockWallet = () => {
     LOCAL_STORE.lock();
-    history.push('/locked/');
+    navigate('/locked/');
   };
 
   /**
    * Called when user clicks to go to settings, then redirects to settings screen
    */
   const goToSettings = () => {
-    history.push('/settings/');
+    navigate('/settings/');
   };
 
   /**
@@ -119,7 +119,7 @@ export default function TokenBar () {
    * Called when user clicks in the unknown tokens number, then redirects to unknown tokens screen
    */
   const unknownClicked = () => {
-    history.push('/unknown_tokens/');
+    navigate('/unknown_tokens/');
   };
 
   const renderLoading = () => (

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,6 @@ import { createRoot } from 'react-dom/client';
 import ErrorWrapper from './ErrorWrapper';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import { GlobalModal } from './components/GlobalModal';
-import TokenBar from './components/TokenBar';
 
 import 'bootstrap';
 import 'bootstrap/dist/css/bootstrap.min.css';
@@ -22,8 +21,7 @@ import store from "./store/index";
 import { Provider } from "react-redux";
 
 const routerInstance = createBrowserRouter([
-  { element: <TokenBar /> },
-  { element: <ErrorWrapper /> },
+  { path: '*', element: <ErrorWrapper /> },
 ])
 
 const container = document.getElementById('root');

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ import './i18nInit';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import ErrorWrapper from './ErrorWrapper';
-import { BrowserRouter as Router } from 'react-router-dom';
+import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import { GlobalModal } from './components/GlobalModal';
 import TokenBar from './components/TokenBar';
 
@@ -21,15 +21,17 @@ import './index.css';
 import store from "./store/index";
 import { Provider } from "react-redux";
 
+const routerInstance = createBrowserRouter([
+  { element: <TokenBar /> },
+  { element: <ErrorWrapper /> },
+])
+
 const container = document.getElementById('root');
 const root = createRoot(container);
 root.render(
   <Provider store={store}>
     <GlobalModal>
-      <Router>
-        <TokenBar />
-        <ErrorWrapper />
-      </Router>
+      <RouterProvider router={routerInstance} />
     </GlobalModal>
   </Provider>
 );

--- a/src/index.module.scss
+++ b/src/index.module.scss
@@ -315,6 +315,10 @@ svg.svg-wrapper {
   width: 70px;
 }
 
+.navbar-nav a.nav-link.active {
+  font-weight: bold;
+}
+
 @media (max-width: 992px) {
   .navbar-nav li.nav-item {
     padding: 0rem 1rem;

--- a/src/sagas/atomicSwap.js
+++ b/src/sagas/atomicSwap.js
@@ -165,7 +165,7 @@ function* createProposalOnBackend(action) {
 
         // Navigating to the Edit Swap screen with this proposal
         const routerHistory = yield select((state) => state.routerHistory);
-        routerHistory.replace(`/wallet/atomic_swap/proposal/${proposalId}`);
+        routerHistory(`/wallet/atomic_swap/proposal/${proposalId}`, { replace: true });
     } catch (e) {
         yield put(lastFailedRequest({ message: e.message }));
     }

--- a/src/sagas/wallet.js
+++ b/src/sagas/wallet.js
@@ -193,7 +193,7 @@ export function* startWallet(action) {
         /**
          * Lock screen will call `resolve` with the pin screen after validation
          */
-        routerHistory.push('/locked/');
+        routerHistory('/locked/');
         dispatch(lockWalletForResult(resolve));
       }),
       passphrase,
@@ -280,7 +280,7 @@ export function* startWallet(action) {
       console.error(e);
       // Return to locked screen when the wallet fails to start
       LOCAL_STORE.lock();
-      routerHistory.push('/');
+      routerHistory('/');
       return
     }
   }
@@ -299,7 +299,7 @@ export function* startWallet(action) {
   }
 
   // Wallet start called, we need to show the loading addresses screen
-  routerHistory.replace('/loading_addresses');
+  routerHistory('/loading_addresses', { replace: true });
 
   // Wallet might be already ready at this point
   if (!wallet.isReady()) {
@@ -333,7 +333,7 @@ export function* startWallet(action) {
 
   LOCAL_STORE.unlock();
 
-  routerHistory.replace('/wallet/');
+  routerHistory('/wallet/', { replace: true });
 
   yield put(loadingAddresses(false));
 
@@ -541,7 +541,7 @@ export function* handleNewTx(action) {
         return;
       }
 
-      routerHistory.push(`/transaction/${tx.tx_id}/`);
+      routerHistory(`/transaction/${tx.tx_id}/`);
     }
   }
 }
@@ -703,7 +703,7 @@ export function* walletReloading() {
 
     // Load success, we can send the user back to the wallet screen
     yield put(loadWalletSuccess(allTokens, registeredTokens, currentAddress));
-    routerHistory.replace('/wallet/');
+    routerHistory('/wallet/', { replace: true });
     yield put(loadingAddresses(false));
   } catch (e) {
     yield put(startWalletFailed());
@@ -735,7 +735,7 @@ export function* onWalletReset() {
   yield put(walletResetSuccess());
 
   if (routerHistory) {
-    routerHistory.push('/welcome');
+    routerHistory('/welcome');
   }
 }
 

--- a/src/screens/ChoosePassphrase.js
+++ b/src/screens/ChoosePassphrase.js
@@ -13,7 +13,7 @@ import walletUtils from '../utils/wallet';
 import BackButton from '../components/BackButton';
 import { useSelector } from 'react-redux';
 import { GlobalModalContext, MODAL_TYPES } from '../components/GlobalModal';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 /**
  * Screen used to choose a passphrase for your wallet
@@ -30,7 +30,7 @@ function ChoosePassphrase() {
   const pinRef = useRef();
   const blankPassphraseRef = useRef();
   const passphraseWrapperRef = useRef();
-  const history =  useHistory();
+  const navigate =  useNavigate();
 
   /** errorMessage {string} Message to show when error happens on the form */
   const [errorMessage, setErrorMessage] = useState('');
@@ -44,8 +44,8 @@ function ChoosePassphrase() {
    */
   const handlePassphrase = async () => {
     modalContext.hideModal();
-    await walletUtils.addPassphrase(wallet, passphraseRef.current.value, pinRef.current.value, passwordRef.current.value, history)
-    history.push('/wallet/');
+    await walletUtils.addPassphrase(wallet, passphraseRef.current.value, pinRef.current.value, passwordRef.current.value, navigate)
+    navigate('/wallet/');
   }
 
   /**

--- a/src/screens/CreateNFT.js
+++ b/src/screens/CreateNFT.js
@@ -22,7 +22,7 @@ import { str2jsx } from '../utils/i18n';
 import { NFT_DATA_MAX_SIZE, NFT_GUIDE_URL, NFT_STANDARD_RFC_URL } from '../constants';
 import InputNumber from '../components/InputNumber';
 import { GlobalModalContext, MODAL_TYPES } from '../components/GlobalModal';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 
 /**
@@ -33,7 +33,7 @@ import { useHistory } from 'react-router-dom';
 function CreateNFT() {
 
   const globalModalContext = useContext(GlobalModalContext);
-  const history = useHistory();
+  const navigate = useNavigate();
   const dispatch = useDispatch();
 
   const addressDivRef = useRef();
@@ -211,7 +211,7 @@ function CreateNFT() {
    */
   const alertButtonClick = () => {
     globalModalContext.hideModal();
-    history.push('/wallet/');
+    navigate('/wallet/');
   }
 
   /**

--- a/src/screens/CreateToken.js
+++ b/src/screens/CreateToken.js
@@ -22,7 +22,7 @@ import { TOKEN_DEPOSIT_RFC_URL } from '../constants';
 import InputNumber from '../components/InputNumber';
 import { GlobalModalContext, MODAL_TYPES } from '../components/GlobalModal';
 import { str2jsx } from '../utils/i18n';
-import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 /**
  * Create a new token
@@ -38,7 +38,7 @@ function CreateToken() {
   }));
 
   const dispatch = useDispatch();
-  const history = useHistory();
+  const navigate = useNavigate();
   const globalModalContext = useContext(GlobalModalContext);
 
   const addressWrapperRef = useRef(null);
@@ -185,7 +185,7 @@ function CreateToken() {
    */
   const alertButtonClick = () => {
     globalModalContext.hideModal();
-    history.push('/wallet/');
+    navigate('/wallet/');
   }
 
   /**

--- a/src/screens/CustomTokens.js
+++ b/src/screens/CustomTokens.js
@@ -15,7 +15,7 @@ import { NFT_ENABLED } from '../constants';
 import { GlobalModalContext, MODAL_TYPES } from '../components/GlobalModal';
 import { useSelector } from 'react-redux';
 import LOCAL_STORE from '../storage';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 /**
  * Initial screen of custom tokens
@@ -25,7 +25,7 @@ import { useHistory } from 'react-router-dom';
 function CustomTokens() {
   const context = useContext(GlobalModalContext);
   const alertSuccessRef = useRef(null);
-  const history = useHistory();
+  const navigate = useNavigate();
   const { tokensBalance } = useSelector(state => ({  tokensBalance: state.tokensBalance }));
 
   /**
@@ -53,7 +53,7 @@ function CustomTokens() {
     if (LOCAL_STORE.isHardwareWallet()) {
       context.showModal(MODAL_TYPES.ALERT_NOT_SUPPORTED);
     } else {
-      history.push('/create_token/');
+      navigate('/create_token/');
     }
   }
 
@@ -64,7 +64,7 @@ function CustomTokens() {
     if (LOCAL_STORE.isHardwareWallet()) {
       context.showModal(MODAL_TYPES.ALERT_NOT_SUPPORTED);
     } else {
-      history.push('/create_nft/');
+      navigate('/create_nft/');
     }
   }
 

--- a/src/screens/LoadWallet.js
+++ b/src/screens/LoadWallet.js
@@ -14,7 +14,7 @@ import ChoosePin from '../components/ChoosePin';
 import logo from '../assets/images/hathor-logo.png';
 import { updatePassword, updatePin } from '../actions/index';
 import { useDispatch, useSelector } from 'react-redux';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import hathorLib from '@hathor/wallet-lib';
 import InitialImages from '../components/InitialImages';
 import LOCAL_STORE from '../storage';
@@ -42,7 +42,7 @@ function LoadWallet() {
   const wordsInputRef = useRef();
   const dispatch = useDispatch();
   const { pin, password } = useSelector((state) => ({ pin: state.pin, password: state.password }));
-  const history = useHistory();
+  const navigate = useNavigate();
 
   /**
    * Method called when user clicks the 'Import' button
@@ -78,7 +78,7 @@ function LoadWallet() {
   const pinSuccess = () => {
     LOCAL_STORE.unlock();
     // First we clean what can still be there of a last wallet
-    wallet.generateWallet(words, '', pin, password, history);
+    wallet.generateWallet(words, '', pin, password, navigate);
     LOCAL_STORE.markBackupDone();
     LOCAL_STORE.open(); // Mark this wallet as open, so that it does not appear locked after loading
     // Clean pin and password from redux
@@ -141,7 +141,7 @@ function LoadWallet() {
         <p className={`mb-4 ${getWordsCountClassName()}`}>{`${wordsCount}/24 words`}</p>
         {errorMessage && <p className="mb-4 text-danger">{errorMessage}</p>}
         <div className="d-flex justify-content-between flex-row w-100">
-          <button onClick={() => history.goBack()} type="button" className="btn btn-secondary">{t`Back`}</button>
+          <button onClick={() => navigate(-1)} type="button" className="btn btn-secondary">{t`Back`}</button>
           <button onClick={importClick} type="button" className="btn btn-hathor">{t`Import data`}</button>
         </div>
       </div>

--- a/src/screens/LoadingAddresses.js
+++ b/src/screens/LoadingAddresses.js
@@ -6,7 +6,7 @@
  */
 
 import React, { useState, useEffect, useRef } from 'react';
-import { Redirect, useLocation } from 'react-router-dom';
+import { Navigate, Redirect, useLocation } from 'react-router-dom';
 import ReactLoading from 'react-loading';
 import { t } from 'ttag';
 import { useDispatch, useSelector } from 'react-redux';
@@ -37,6 +37,7 @@ function LoadingAddresses() {
 
   const dispatch = useDispatch();
   const location = useLocation();
+  console.log(`[LoadingAddresses] Location: `, {location});
   const { addressesFound, transactionsFound, loadingAddresses } = useSelector(state => ({
     addressesFound: state.loadedData.addresses,
     transactionsFound: state.loadedData.transactions,
@@ -74,9 +75,9 @@ function LoadingAddresses() {
     // was reloaded on the loading_addresses screen. This may happen during development
     // because of the auto reload
     if (!location.state) {
-      return <Redirect to='/wallet/' />;
+      return <Navigate to={ '/wallet/' } />;
     }
-    return <Redirect to={{ pathname: location.state.path }} />;
+    return <Navigate to={ location.state.path } />;
   }
 
   return (

--- a/src/screens/LoadingAddresses.js
+++ b/src/screens/LoadingAddresses.js
@@ -37,7 +37,6 @@ function LoadingAddresses() {
 
   const dispatch = useDispatch();
   const location = useLocation();
-  console.log(`[LoadingAddresses] Location: `, {location});
   const { addressesFound, transactionsFound, loadingAddresses } = useSelector(state => ({
     addressesFound: state.loadedData.addresses,
     transactionsFound: state.loadedData.transactions,

--- a/src/screens/LockedWallet.js
+++ b/src/screens/LockedWallet.js
@@ -6,7 +6,7 @@
  */
 
 import React, { useState, useEffect, useRef, useContext } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { t } from 'ttag';
 import { useSelector, useDispatch } from "react-redux";
 import wallet from '../utils/wallet';
@@ -34,7 +34,7 @@ function LockedWallet() {
   const context = useContext(GlobalModalContext);
   const lockWalletPromise = useSelector(state => state.lockWalletPromise);
   const dispatch = useDispatch();
-  const history = useHistory();
+  const navigate = useNavigate();
 
   useEffect(() => {
     pinRef.current.focus();
@@ -77,13 +77,13 @@ function LockedWallet() {
     if (lockWalletPromise) {
       dispatch(resolveLockWalletPromise(pin));
       // return to the last screen
-      history.goBack();
+      navigate(-1);
       return;
     }
 
     setLoading(true);
 
-    dispatch(startWalletRequested({ pin, routerHistory: history }));
+    dispatch(startWalletRequested({ pin, routerHistory: navigate }));
   }
 
   /**
@@ -92,7 +92,7 @@ function LockedWallet() {
   const handleReset = () => {
     context.hideModal();
     dispatch(walletReset());
-    history.push('/welcome/');
+    navigate('/welcome/');
   }
 
   /**

--- a/src/screens/NewWallet.js
+++ b/src/screens/NewWallet.js
@@ -7,7 +7,7 @@
 
 import React, { useRef, useState, useContext, useEffect } from 'react';
 import { t } from 'ttag'
-import { useHistory } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom';
 import wallet from '../utils/wallet';
 import logo from '../assets/images/hathor-logo.png';
 import ChoosePassword from '../components/ChoosePassword';
@@ -32,7 +32,7 @@ import LOCAL_STORE from '../storage';
  * @memberof Screens
  */
 function NewWallet() {
-  const history = useHistory();
+  const navigate = useNavigate();
   const context = useContext(GlobalModalContext);
   const dispatch = useDispatch();
 
@@ -104,10 +104,10 @@ function NewWallet() {
    */
   const pinSuccess = () => {
     // Generate addresses and load data
-    LOCAL_STORE.unlock();
-    wallet.generateWallet(words, '', pin, password, history);
-    // Mark this wallet as open, so that it does not appear locked after loading
-    LOCAL_STORE.open();
+		LOCAL_STORE.unlock();
+		wallet.generateWallet(words, '', pin, password, navigate);
+		// Mark this wallet as open, so that it does not appear locked after loading
+		LOCAL_STORE.open();
     // Clean pin, password and words from redux
     dispatch(updatePassword(null));
     dispatch(updatePin(null));
@@ -148,7 +148,7 @@ function NewWallet() {
           </div>
         </form>
         <div className="d-flex justify-content-between flex-row w-100">
-          <button onClick={history.goBack} type="button" className="btn btn-secondary">{t`Back`}</button>
+          <button onClick={() => navigate(-1)} type="button" className="btn btn-secondary">{t`Back`}</button>
           <button onClick={create} type="button" className="btn btn-hathor">{t`Create my words`}</button>
         </div>
       </div>

--- a/src/screens/NewWallet.js
+++ b/src/screens/NewWallet.js
@@ -104,10 +104,10 @@ function NewWallet() {
    */
   const pinSuccess = () => {
     // Generate addresses and load data
-		LOCAL_STORE.unlock();
-		wallet.generateWallet(words, '', pin, password, navigate);
-		// Mark this wallet as open, so that it does not appear locked after loading
-		LOCAL_STORE.open();
+    LOCAL_STORE.unlock();
+    wallet.generateWallet(words, '', pin, password, navigate);
+    // Mark this wallet as open, so that it does not appear locked after loading
+    LOCAL_STORE.open();
     // Clean pin, password and words from redux
     dispatch(updatePassword(null));
     dispatch(updatePin(null));

--- a/src/screens/SendTokens.js
+++ b/src/screens/SendTokens.js
@@ -20,7 +20,7 @@ import { IPC_RENDERER, LEDGER_TX_CUSTOM_TOKEN_LIMIT, colors } from '../constants
 import ReactLoading from 'react-loading';
 import { GlobalModalContext, MODAL_TYPES } from '../components/GlobalModal';
 import LOCAL_STORE from '../storage';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 /** @typedef {0|1} LEDGER_MODAL_STATE */
 const LEDGER_MODAL_STATE = {
@@ -38,7 +38,7 @@ function SendTokens() {
   const globalModalContext = useContext(GlobalModalContext);
 
   const dispatch = useDispatch();
-  const history = useHistory();
+  const navigate = useNavigate();
 
   // Redux state
   const { selectedToken, tokens, wallet, metadataLoaded, useWalletService } = useSelector(
@@ -231,7 +231,7 @@ function SendTokens() {
 
     // Must update the shared address, in case we have used one for the change
     dispatch(walletRefreshSharedAddress());
-    history.push('/wallet/');
+    navigate('/wallet/');
   }
 
   /**

--- a/src/screens/SentryPermission.js
+++ b/src/screens/SentryPermission.js
@@ -6,7 +6,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { t } from 'ttag';
 import wallet from '../utils/wallet';
 import logo from '../assets/images/hathor-logo.png';
@@ -19,7 +19,7 @@ import InitialImages from '../components/InitialImages';
  * @memberof Screens
  */
 function SentryPermission() {
-  const history = useHistory();
+  const navigate = useNavigate();
 
   /** @type {boolean} If user has already a permission saved in the wallet */
   const [savedPermission, setSavedPermission] = useState(null);
@@ -47,9 +47,9 @@ function SentryPermission() {
     // If state permission is null, user is still starting the wallet
     // Otherwise, user is changing it in the settings
     if (savedPermission === null) {
-      history.push('/wallet_type/');
+      navigate('/wallet_type/');
     } else {
-      history.goBack();
+      navigate(-1);
     }
   }
 

--- a/src/screens/Server.js
+++ b/src/screens/Server.js
@@ -21,7 +21,7 @@ import {
 import { useDispatch, useSelector } from 'react-redux';
 import { GlobalModalContext, MODAL_TYPES } from '../components/GlobalModal';
 import LOCAL_STORE from '../storage';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { isVersionAllowedUpdate, selectToken } from "../actions";
 
 
@@ -32,7 +32,7 @@ import { isVersionAllowedUpdate, selectToken } from "../actions";
  */
 function Server() {
   const context = useContext(GlobalModalContext);
-  const history = useHistory();
+	const navigate = useNavigate();
   const dispatch  = useDispatch();
 
   /* newServer {boolean} If user selected checkbox that he wants to set a new server */
@@ -265,8 +265,8 @@ function Server() {
       // We don't have PIN on hardware wallet
       const pin = isHardwareWallet ? null : pinRef.current.value;
       try {
-        await walletUtils.changeServer(wallet, pin, history, networkChanged);
-        history.push('/wallet/');
+        await walletUtils.changeServer(wallet, pin, navigate, networkChanged);
+        navigate('/wallet/');
       } catch (err) {
         setLoading(false);
         setErrorMessage(err.message);

--- a/src/screens/Settings.js
+++ b/src/screens/Settings.js
@@ -10,7 +10,7 @@ import { t } from 'ttag';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import wallet from '../utils/wallet';
 import helpers from '../utils/helpers';
-import { Link, useHistory } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import HathorAlert from '../components/HathorAlert';
 import SpanFmt from '../components/SpanFmt';
 import BackButton from '../components/BackButton';
@@ -32,7 +32,7 @@ function Settings() {
   const context = useContext(GlobalModalContext);
   const alertCopiedRef = useRef();
   const dispatch = useDispatch();
-  const history = useHistory();
+  const navigate = useNavigate();
 
   /** isNotificationOne {boolean} state to update if notification is turned on or off */
   const [isNotificationOn, setIsNotificationOn] = useState(null);
@@ -68,7 +68,7 @@ function Settings() {
   const handleReset = () => {
     context.hideModal();
     dispatch(walletReset());
-    history.push('/welcome/');
+    navigate('/welcome/');
   }
 
   /**
@@ -98,7 +98,7 @@ function Settings() {
         )
       });
     } else {
-      history.push('/wallet/passphrase/');
+      navigate('/wallet/passphrase/');
     }
   }
 
@@ -135,7 +135,7 @@ function Settings() {
    * When user clicks Change Server button we redirect to Change Server screen
    */
   const changeServer = () => {
-    history.push('/server/');
+    navigate('/server/');
   }
 
   /**

--- a/src/screens/Signin.js
+++ b/src/screens/Signin.js
@@ -10,7 +10,7 @@ import { t } from 'ttag'
 
 import logo from '../assets/images/hathor-logo.png';
 import InitialImages from '../components/InitialImages';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 
 /**
@@ -19,20 +19,20 @@ import { useHistory } from 'react-router-dom';
  * @memberof Screens
  */
 function Signin() {
-  const history = useHistory();
+  const navigate = useNavigate();
 
   /**
    * Go to the new wallet screen
    */
   const goToNewWallet = () => {
-    history.push('/new_wallet/');
+    navigate('/new_wallet/');
   }
 
   /**
    * Go to the load wallet screen
    */
   const goToLoadWallet = () => {
-    history.push('/load_wallet/');
+    navigate('/load_wallet/');
   }
 
   return (
@@ -42,7 +42,7 @@ function Signin() {
           <img className="hathor-logo" src={logo} alt="" />
           <p className="mt-4 mb-4">{t`You can start a new wallet or import data from a wallet that already exists.`}</p>
           <div className="d-flex align-items-center flex-row justify-content-between w-100 mt-4">
-            <button onClick={history.goBack} type="button" className="btn btn-secondary">{t`Back`}</button>
+            <button onClick={() => navigate(-1)} type="button" className="btn btn-secondary">{t`Back`}</button>
             <button onClick={goToNewWallet} type="button" className="btn btn-hathor mr-3">{t`New wallet`}</button>
             <button onClick={goToLoadWallet} type="button" className="btn btn-hathor">{t`Import wallet`}</button>
           </div>

--- a/src/screens/SoftwareWalletWarning.js
+++ b/src/screens/SoftwareWalletWarning.js
@@ -11,7 +11,7 @@ import { t } from 'ttag';
 import logo from '../assets/images/hathor-logo.png';
 import SoftwareWalletWarningMessage from '../components/SoftwareWalletWarningMessage';
 import InitialImages from '../components/InitialImages';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 
 /**
@@ -25,13 +25,13 @@ function SoftwareWalletWarning() {
    */
   const [formValidated, setFormValidated] = useState(false);
 
-  const history = useHistory();
+  const navigate = useNavigate();
   const confirmFormRef = useRef(null);
 
   const create = () => {
     let isValid = confirmFormRef.current.checkValidity();
     if (isValid) {
-      history.push('/signin/');
+      navigate('/signin/');
     } else {
       setFormValidated(true);
     }
@@ -52,7 +52,7 @@ function SoftwareWalletWarning() {
                 </div>
               </form>
               <div className="d-flex justify-content-between flex-row w-100">
-                <button onClick={history.goBack} type="button" className="btn btn-secondary">{t`Back`}</button>
+                <button onClick={() => navigate(-1)} type="button" className="btn btn-secondary">{t`Back`}</button>
                 <button onClick={create} type="button" className="btn btn-hathor">{t`Continue`}</button>
               </div>
             </div>

--- a/src/screens/StartHardwareWallet.js
+++ b/src/screens/StartHardwareWallet.js
@@ -8,7 +8,7 @@
 import React, { useState, useEffect } from 'react';
 import { t } from 'ttag'
 import { useDispatch } from 'react-redux';
-import { useHistory } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom';
 
 import logo from '../assets/images/hathor-logo.png';
 import ledger from '../utils/ledger';
@@ -29,7 +29,7 @@ const attemptInterval = 3000;
  * @memberof Screens
  */
 function StartHardwareWallet() {
-  const history = useHistory();
+  const navigate = useNavigate();
   const dispatch = useDispatch();
 
   // Attempt parameters when trying to connect to ledger
@@ -107,7 +107,7 @@ function StartHardwareWallet() {
         passphrase: '',
         pin: null,
         password: '',
-        routerHistory: history,
+        routerHistory: navigate,
         xpub,
         hardware: true,
       }));
@@ -179,7 +179,7 @@ function StartHardwareWallet() {
         <p className="mt-4 mb-2 text-center"><strong>{renderTextTitle()}</strong></p>
         <p className="mt-4 mb-4">{renderText()}</p>
         <div className="d-flex align-items-center flex-column w-100 mt-5">
-          <button onClick={history.goBack} type="button" className="btn btn-secondary">{t`Back`}</button>
+          <button onClick={() => navigate(-1)} type="button" className="btn btn-secondary">{t`Back`}</button>
         </div>
       </div>
     )

--- a/src/screens/TransactionDetail.js
+++ b/src/screens/TransactionDetail.js
@@ -15,7 +15,7 @@ import hathorLib from '@hathor/wallet-lib';
 import { colors } from '../constants';
 import helpers from '../utils/helpers';
 import path from 'path';
-import { useHistory, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 /**
  * Shows the detail of a transaction or block
@@ -24,7 +24,7 @@ import { useHistory, useParams } from 'react-router-dom';
  */
 function TransactionDetail() {
   const wallet = useSelector((state) => state.wallet);
-  const history = useHistory();
+  const navigate = useNavigate();
   const { id: txId } = useParams();
 
   /* transaction {Object} Loaded transaction */
@@ -145,7 +145,7 @@ function TransactionDetail() {
             showRaw={true}
             showConflicts={true}
             showGraphs={true}
-            history={history} />
+            history={navigate} />
         ) : (
           <p className="text-danger">
             {isTxNotFound ? (

--- a/src/screens/VersionError.js
+++ b/src/screens/VersionError.js
@@ -12,7 +12,7 @@ import version from '../utils/version';
 import logo from '../assets/images/hathor-white-logo.png';
 import Version from '../components/Version';
 import hathorLib from '@hathor/wallet-lib';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 
 /**
@@ -21,7 +21,7 @@ import { useHistory } from 'react-router-dom';
  * @memberof Screens
  */
 function VersionError() {
-  const history = useHistory();
+  const navigate = useNavigate();
 
   /**
    * Called when user clicks to Try Again, then check the API version again
@@ -34,7 +34,7 @@ function VersionError() {
    * Called when user clicks to Change Server, then redirects to change server screen
    */
   const changeServer = () => {
-    history.push('/server/');
+    navigate('/server/');
   };
   const min_api_version = hathorLib.constants.MIN_API_VERSION;
 

--- a/src/screens/Wallet.js
+++ b/src/screens/Wallet.js
@@ -28,7 +28,7 @@ import { TOKEN_DOWNLOAD_STATUS } from '../sagas/tokens';
 import { GlobalModalContext, MODAL_TYPES } from '../components/GlobalModal';
 import { tokenFetchBalanceRequested, tokenFetchHistoryRequested, updateWords, } from '../actions/index';
 import LOCAL_STORE from '../storage';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 
 /**
@@ -83,7 +83,7 @@ function Wallet() {
   const unregisterModalRef = useRef(null);
 
   // Navigation and actions
-  const history = useHistory();
+  const navigate = useNavigate();
   const dispatch = useDispatch();
 
   // Initialize the screen on mount
@@ -274,10 +274,10 @@ function Wallet() {
   }
 
   /**
-   * @deprecated This should be replaced by usage of `useHistory` inside the child component
+   * @deprecated This should be replaced by usage of `navigate()` inside the child component
    */
   const goToAllAddresses = () => {
-    history.push('/addresses/');
+    navigate('/addresses/');
   }
 
   /**

--- a/src/screens/WalletType.js
+++ b/src/screens/WalletType.js
@@ -17,7 +17,7 @@ import { str2jsx } from '../utils/i18n';
 import { useDispatch, useSelector } from 'react-redux';
 import { updateLedgerClosed } from '../actions/index';
 import LOCAL_STORE from '../storage';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { LEDGER_GUIDE_URL } from '../constants';
 import helpers from '../utils/helpers';
 
@@ -27,7 +27,7 @@ import helpers from '../utils/helpers';
  * @memberof Screens
  */
 function WalletType() {
-  const history = useHistory();
+  const navigate = useNavigate();
   const dispatch = useDispatch();
   const ledgerClosed = useSelector((state) => state.ledgerWasClosed);
 
@@ -45,14 +45,14 @@ function WalletType() {
    */
   const goToSoftwareWallet = () => {
     LOCAL_STORE.setHardwareWallet(false);
-    history.push('/software_warning/');
+    navigate('/software_warning/');
   }
 
   /**
    * Go to hardware wallet start screen
    */
   const goToHardwareWallet = () => {
-    history.push('/hardware_wallet/');
+    navigate('/hardware_wallet/');
   }
 
   /**

--- a/src/screens/WalletVersionError.js
+++ b/src/screens/WalletVersionError.js
@@ -14,7 +14,7 @@ import { updateWords, walletReset } from '../actions/index';
 import { useDispatch } from "react-redux";
 import { GlobalModalContext, MODAL_TYPES } from '../components/GlobalModal';
 import LOCAL_STORE from '../storage';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 
 /**
@@ -26,7 +26,7 @@ import { useHistory } from 'react-router-dom';
 function WalletVersionError() {
   const context = useContext(GlobalModalContext);
   const dispatch = useDispatch();
-  const history = useHistory();
+  const navigate = useNavigate();
   const alertSuccessRef = useRef();
 
   /**
@@ -59,7 +59,7 @@ function WalletVersionError() {
   const handleReset = () => {
     context.hideModal();
     dispatch(walletReset());
-    history.push('/welcome/');
+    navigate('/welcome/');
   }
 
   /**

--- a/src/screens/Welcome.js
+++ b/src/screens/Welcome.js
@@ -6,7 +6,7 @@
  */
 
 import React, { useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { t } from 'ttag'
 
 import SpanFmt from '../components/SpanFmt';
@@ -30,7 +30,7 @@ function Welcome() {
    */
   const [formValidated, setFormValidated] = useState(false);
 
-  const history = useHistory();
+  const navigate = useNavigate();
   const agreeForm = React.createRef();
 
   /**
@@ -43,7 +43,7 @@ function Welcome() {
       LOCAL_STORE.markWalletAsStarted();
       // For the mainnet sentry will be disabled by default and the user can change this on Settings
       wallet.disallowSentry();
-      history.push('/wallet_type/');
+      navigate('/wallet_type/');
     }
   };
 

--- a/src/screens/atomic-swap/ImportExisting.js
+++ b/src/screens/atomic-swap/ImportExisting.js
@@ -8,7 +8,7 @@ import BackButton from "../../components/BackButton";
 import { t } from "ttag";
 import Loading from "../../components/Loading";
 import React, { useEffect, useState } from "react";
-import { useHistory } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 import { importProposal, proposalFetchRequested } from "../../actions";
 import {
@@ -25,11 +25,11 @@ export default function ImportExisting(props) {
 
     // Global interactions
     const allProposals = useSelector(state => state.proposals);
-    const history = useHistory();
+    const navigate = useNavigate();
     const dispatch = useDispatch();
 
     const navigateToProposal = (pId) => {
-        history.replace(`/wallet/atomic_swap/proposal/${pId}`);
+        navigate(`/wallet/atomic_swap/proposal/${pId}`, { replace: true });
     }
 
     const importClickHandler = () => {

--- a/src/screens/atomic-swap/ProposalList.js
+++ b/src/screens/atomic-swap/ProposalList.js
@@ -9,7 +9,7 @@ import BackButton from "../../components/BackButton";
 import { t } from "ttag";
 import React, { useContext, useEffect } from 'react';
 import { useDispatch, useSelector } from "react-redux";
-import { useHistory } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import Loading from "../../components/Loading";
 import { proposalFetchRequested, proposalRemoved } from "../../actions";
 import {
@@ -20,7 +20,7 @@ import walletUtil from "../../utils/wallet";
 import { GlobalModalContext, MODAL_TYPES } from '../../components/GlobalModal';
 
 export default function ProposalList (props) {
-    const history = useHistory();
+    const navigate = useNavigate();
     const dispatch = useDispatch();
     const modalContext = useContext(GlobalModalContext);
 
@@ -28,15 +28,15 @@ export default function ProposalList (props) {
     const proposals = useSelector(state => state.proposals)
 
     const navigateToProposal = (pId) => {
-        history.push(`/wallet/atomic_swap/proposal/${pId}`)
+        navigate(`/wallet/atomic_swap/proposal/${pId}`)
     }
 
     const navigateToNewProposal = () => {
-        history.push(`/wallet/atomic_swap/proposal/create`)
+        navigate(`/wallet/atomic_swap/proposal/create`)
     }
 
     const importExistingProposal = () => {
-        history.push(`/wallet/atomic_swap/proposal/import`)
+        navigate(`/wallet/atomic_swap/proposal/import`)
     }
 
     /**


### PR DESCRIPTION
This PR upgrades the React Router from version `5.x` to `v6`. Below are the guides followed to implement the necessary adaptations:
- [Migration guide](https://reactrouter.com/en/main/upgrading/v5) from v5 to v6
- [Additional explanations](https://gist.github.com/mjackson/d54b40a094277b7afdd6b81f51a0393f) on how to compose routes in this new structure ( mainly implemented on #502 )

### Acceptance Criteria
- Upgrades the React Router to the latest stable version v6

### Notes
- It's still not recommended to store the full navigation object to use on Sagas ([link](https://github.com/remix-run/react-router/issues/9422#issuecomment-1486960784)), but changing this approach on our code is beyond the scope of this PR ( [additional reading](https://frontendwithhasan.com/articles/react-router-upgrade#navigating-outside-of-routers-context) )
- Most of the file changes were due to renaming all instances of `useHistory` to `useNavigate` on the screens. These changes are concentrated on the https://github.com/HathorNetwork/hathor-wallet/pull/555/commits/c99a74f0ca5ab9655278b5286b22192763c18e1d commit for easier reviewing

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
