### PR TITLE
feat: filter HTR out when fetching token metadata

### DIFF
--- a/src/sagas/wallet.js
+++ b/src/sagas/wallet.js
@@ -373,7 +373,7 @@ export function* loadTokens() {
   // spawn a new "thread" to handle it.
   //
   // `spawn` is similar to `fork`, but it creates a `detached` fork
-  yield spawn(fetchTokensMetadata, registeredTokens.map(token => token.uid));
+  yield spawn(fetchTokensMetadata, registeredTokens.map(token => token.uid).filter(token => token !== htrUid));
 
   // Dispatch actions to asynchronously load the balances of each token the wallet has
   // ever interacted with. The `put` effect will just dispatch and continue, loading


### PR DESCRIPTION
### Acceptance Criteria

- Do not fetch HTR token metadata from the explorer-service.


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
