### PR TITLE
Refactor: State tokens to a serializable array

### DIFF
--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -72,7 +72,11 @@ const initialState = {
   tokens: [hathorLib.constants.HATHOR_TOKEN_CONFIG],
   // Token selected (by default is HATHOR)
   selectedToken: hathorLib.constants.HATHOR_TOKEN_CONFIG.uid,
-  // List of all tokens seen in transactions
+  /**
+   * List of all tokens seen in transactions
+   * @type {Record<string, string>}
+   * @example { 00: "00", abc123: "abc123" }
+   */
   allTokens: {},
   // If is in the proccess of loading addresses transactions from the full node
   // When the request to load addresses fails this variable can continue true
@@ -287,13 +291,20 @@ const getTxHistoryFromWSTx = (tx, tokenUid, tokenTxBalance) => {
 
 /**
  * Got wallet history. Update wallet data on redux
+ * @param {string[]} action.payload.tokens
+ * @param {string} action.payload.currentAddress
+ * @param {{uid:string, name:string, symbol:string}[]} action.payload.registeredTokens
  */
 const onLoadWalletSuccess = (state, action) => {
   // Update the version of the wallet that the data was loaded
   LOCAL_STORE.setWalletVersion(VERSION);
   const { tokens, registeredTokens, currentAddress } = action.payload;
-  const allTokens = new Set(tokens);
 
+  // Convert the tokens list to a new Set to ensure there are no duplicated tokens
+  const allTokens = new Set();
+  for (const key in tokens) {
+    allTokens.add(tokens[key]);
+  }
   return {
     ...state,
     loadingAddresses: false,
@@ -511,12 +522,18 @@ export const resetSelectedTokenIfNeeded = (state, action) => {
   return state;
 };
 
-/*
+/**
  * Used when registering or creating tokens to update the wallet token list.
-*/
+ * @param {Record<string,string>} state.allTokens - Current list of allTokens
+ * @param {string} action.payload.uid - UID of token to add
+ */
 export const onNewTokens = (state, action) => {
+  // Convert `allTokens` to a Set to prevent duplicates
+  const allTokensSet = new Set();
+  for (const token of Object.keys(state.allTokens)) {
+    allTokensSet.add(token);
+  }
   // Add new created token to the all tokens set
-  const allTokensSet = new Set(state.allTokens);
   allTokensSet.add(action.payload.uid);
 
   return {

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -73,7 +73,7 @@ const initialState = {
   // Token selected (by default is HATHOR)
   selectedToken: hathorLib.constants.HATHOR_TOKEN_CONFIG.uid,
   // List of all tokens seen in transactions
-  allTokens: new Set(),
+  allTokens: {},
   // If is in the proccess of loading addresses transactions from the full node
   // When the request to load addresses fails this variable can continue true
   loadingAddresses: false,
@@ -299,7 +299,7 @@ const onLoadWalletSuccess = (state, action) => {
     loadingAddresses: false,
     lastSharedAddress: currentAddress.address,
     lastSharedIndex: currentAddress.index,
-    allTokens,
+    allTokens: helpersUtils.convertSetToObject(allTokens),
     tokens: registeredTokens,
   };
 };
@@ -516,12 +516,14 @@ export const resetSelectedTokenIfNeeded = (state, action) => {
 */
 export const onNewTokens = (state, action) => {
   // Add new created token to the all tokens set
-  state.allTokens.add(action.payload.uid);
+  const allTokensSet = new Set(state.allTokens);
+  allTokensSet.add(action.payload.uid);
 
   return {
     ...state,
     selectedToken: action.payload.uid,
     tokens: action.payload.tokens,
+    allTokensSet: helpersUtils.convertSetToObject(allTokensSet),
   };
 };
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1016,20 +1016,23 @@ export const onUpdateTxHistory = (state, action) => {
     return state;
   }
 
+  const newTokenHistoryData = [...tokenHistory.data];
   for (const [index, histTx] of tokenHistory.data.entries()) {
     if (histTx.tx_id === tx.tx_id) {
-      tokenHistory.data[index] = getTxHistoryFromWSTx(tx, tokenId, balance);
+      newTokenHistoryData[index] = getTxHistoryFromWSTx(tx, tokenId, balance);
       break;
     }
   }
+  const newTokenHistory = {
+    ...tokenHistory,
+    data: newTokenHistoryData,
+  };
 
   return {
     ...state,
     tokensHistory: {
       ...state.tokensHistory,
-      [tokenId]: {
-        ...tokenHistory,
-      }
+      [tokenId]: newTokenHistory,
     },
   };
 };

--- a/src/sagas/wallet.js
+++ b/src/sagas/wallet.js
@@ -380,7 +380,7 @@ export function* loadTokens() {
   //
   // Note: We need to download the balance of all the tokens from the wallet so we can
   // hide zero-balance tokens
-  for (const token of allTokens) {
+  for (const token of Object.values(allTokens)) {
     yield put(tokenFetchBalanceRequested(token));
   }
 
@@ -674,7 +674,7 @@ export function* walletReloading() {
 
     // We might have lost transactions during the reload, so we must invalidate the
     // token histories:
-    for (const tokenUid of allTokens) {
+    for (const tokenUid of Object.values(allTokens)) {
       if (tokenUid === hathorLibConstants.HATHOR_TOKEN_CONFIG.uid) {
         continue;
       }

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -375,6 +375,21 @@ const helpers = {
    */
   plural(qty, singleWord, pluralWord) {
     return qty === 1 ? singleWord : pluralWord;
+  },
+
+  /**
+   * Converts a javascript `Set` instance to a serializable object, which can be stored in redux
+   * @param {Set} set
+   * @returns {Record<string, unknown>}
+   */
+  convertSetToObject(set) {
+    let obj = {};
+
+    for (const item of set) {
+      obj[item] = item;
+    }
+
+    return obj;
   }
 }
 

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -229,7 +229,7 @@ const wallet = {
     const unknownTokens = [];
 
     // Iterating tokens to filter unregistered ones
-    for (const tokenUid of allTokens) {
+    for (const tokenUid of Object.values(allTokens)) {
       // If it is already registered, skip it.
       if (registeredTokens.find((x) => x.uid === tokenUid)) {
         continue;


### PR DESCRIPTION
The next version of Redux throws an error by default whenever there are non-serializable objects in its Store ( more about this on [this article](https://www.bam.tech/article/the-redux-best-practice-do-not-put-non-serializable-values-in-state-or-actions-explained) ). This PR is one in a series of PRs that aim to refactor all of those instances before the upgrade.

### Acceptance Criteria
- Tokens state on Redux must be serializable


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
