### PR TITLE
Refactor: Removes `unleash` from Redux store

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -471,14 +471,6 @@ export const setFeatureToggles = (toggles) => ({
   payload: toggles,
 });
 
-/**
- * unleashClient {UnleashClient} The unleash client to store
- */
-export const setUnleashClient = (unleashClient) => ({
-  type: types.SET_UNLEASH_CLIENT,
-  payload: unleashClient,
-});
-
 export const walletResetSuccess = () => ({
   type: types.WALLET_RESET_SUCCESS,
 });

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -44,7 +44,6 @@ export const types = {
   WALLET_RELOAD_DATA: 'WALLET_RELOAD_DATA',
   WALLET_CHANGE_STATE: 'WALLET_CHANGE_STATE',
   WALLET_RESET: 'WALLET_RESET',
-  WALLET_RESET_SUCCESS: 'WALLET_RESET_SUCCESS',
   WALLET_REFRESH_SHARED_ADDRESS: 'WALLET_REFRESH_SHARED_ADDRESS',
   SET_SERVER_INFO: 'SET_SERVER_INFO',
   SET_NAVIGATE_TO: 'SET_NAVIGATE_TO',
@@ -469,10 +468,6 @@ export const featureToggleInitialized = () => ({
 export const setFeatureToggles = (toggles) => ({
   type: types.SET_FEATURE_TOGGLES,
   payload: toggles,
-});
-
-export const walletResetSuccess = () => ({
-  type: types.WALLET_RESET_SUCCESS,
 });
 
 export const walletReset = () => ({

--- a/src/modules/unleash.js
+++ b/src/modules/unleash.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+let unleashClient = null;
+
+export function setUnleashClient(_unleashClient) {
+	unleashClient = _unleashClient;
+}
+
+export function getUnleashClient() {
+	return unleashClient;
+}

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -132,7 +132,6 @@ const initialState = {
       status: TOKEN_DOWNLOAD_STATUS.READY
     }
   },
-  unleashClient: null,
   featureTogglesInitialized: false,
   featureToggles: {
     ...FEATURE_TOGGLE_DEFAULTS,
@@ -349,12 +348,11 @@ const onUpdateLoadedData = (state, action) => ({
 });
 
 const onCleanData = (state) => {
+  // Keep the unleashClient as it should continue running
   return Object.assign({}, initialState, {
     isVersionAllowed: state.isVersionAllowed,
     loadingAddresses: state.loadingAddresses,
     ledgerWasClosed: state.ledgerWasClosed,
-    // Keep the unleashClient as it should continue running
-    unleashClient: state.unleashClient,
     featureTogglesInitialized: state.featureTogglesInitialized,
   });
 };
@@ -987,19 +985,10 @@ const onSetFeatureToggles = (state, { payload }) => ({
   featureToggles: payload,
 });
 
-/**
- * @param {Object} action.payload The unleash client to store
- */
-const onSetUnleashClient = (state, { payload }) => ({
-  ...state,
-  unleashClient: payload,
-});
-
-const onWalletResetSuccess = (state) => ({
-  ...state,
+const onWalletResetSuccess = (state) => {
   // Keep the unleashClient as it should continue running
-  unleashClient: state.unleashClient,
-});
+  return state;
+};
 
 export const onUpdateTxHistory = (state, action) => {
   const { tx, tokenId, balance } = action.payload;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -264,8 +264,6 @@ const rootReducer = (state = initialState, action) => {
       return onSetFeatureToggles(state, action);
     case types.FEATURE_TOGGLE_INITIALIZED:
       return onFeatureToggleInitialized(state);
-    case types.WALLET_RESET_SUCCESS:
-      return onWalletResetSuccess(state);
     case types.UPDATE_TX_HISTORY:
       return onUpdateTxHistory(state, action);
     case types.WALLET_CHANGE_STATE:
@@ -984,11 +982,6 @@ const onSetFeatureToggles = (state, { payload }) => ({
   ...state,
   featureToggles: payload,
 });
-
-const onWalletResetSuccess = (state) => {
-  // Keep the unleashClient as it should continue running
-  return state;
-};
 
 export const onUpdateTxHistory = (state, action) => {
   const { tx, tokenId, balance } = action.payload;

--- a/src/sagas/featureToggle.js
+++ b/src/sagas/featureToggle.js
@@ -29,7 +29,6 @@ import helpers from '../utils/helpers';
 import { VERSION } from '../constants';
 
 import {
-  setUnleashClient,
   setFeatureToggles,
   featureToggleInitialized,
 } from '../actions';
@@ -39,6 +38,7 @@ import {
   UNLEASH_POLLING_INTERVAL,
   FEATURE_TOGGLE_DEFAULTS,
 } from '../constants';
+import { getUnleashClient, setUnleashClient } from "../modules/unleash";
 
 const CONNECT_TIMEOUT = 10000;
 const MAX_RETRIES = 5;
@@ -46,11 +46,11 @@ const MAX_RETRIES = 5;
 export function* handleInitFailed(currentRetry) {
   if (currentRetry >= MAX_RETRIES) {
     console.error('Max retries reached while trying to create the unleash-proxy client.');
-    const unleashClient = yield select((state) => state.unleashClient);
+    const unleashClient = getUnleashClient();
 
     if (unleashClient) {
       unleashClient.close();
-      yield put(setUnleashClient(null));
+      setUnleashClient(null);
     }
 
     // Even if unleash failed, we should allow the app to continue as it
@@ -68,7 +68,7 @@ export function* fetchTogglesRoutine() {
     // Wait first so we don't double-check on initialization
     yield delay(UNLEASH_POLLING_INTERVAL);
 
-    const unleashClient = yield select((state) => state.unleashClient);
+    const unleashClient = getUnleashClient();
 
     try {
       yield call(() => unleashClient.fetchToggles());
@@ -105,7 +105,7 @@ export function* monitorFeatureFlags(currentRetry = 0) {
   try {
     console.log('starting unleash with', options);
     yield call(() => unleashClient.updateContext(options));
-    yield put(setUnleashClient(unleashClient));
+    setUnleashClient(unleashClient);
 
     // Listeners should be set before unleashClient.start so we don't miss
     // updates
@@ -142,7 +142,7 @@ export function* monitorFeatureFlags(currentRetry = 0) {
     console.error('Error initializing unleash');
     unleashClient.stop();
 
-    yield put(setUnleashClient(null));
+    setUnleashClient(null);
 
     // Wait 500ms before retrying
     yield delay(500);
@@ -209,7 +209,7 @@ function mapFeatureToggles(toggles) {
 }
 
 export function* handleToggleUpdate() {
-  const unleashClient = yield select((state) => state.unleashClient);
+  const unleashClient = getUnleashClient();
   const featureTogglesInitialized = yield select((state) => state.featureTogglesInitialized);
 
   if (!unleashClient || !featureTogglesInitialized) {

--- a/src/sagas/wallet.js
+++ b/src/sagas/wallet.js
@@ -56,7 +56,6 @@ import {
   setEnableAtomicSwap,
   proposalListUpdated,
   proposalFetchRequested,
-  walletResetSuccess,
   reloadWalletRequested,
   changeWalletState,
   updateTxHistory,
@@ -736,8 +735,6 @@ export function* onWalletReset() {
   if (wallet) {
     yield call([wallet.storage, wallet.storage.cleanStorage], true, true);
   }
-
-  yield put(walletResetSuccess());
 
   yield put(setNavigateTo('/welcome'));
 }


### PR DESCRIPTION
The next version of Redux throws an error by default whenever there are non-serializable objects in its Store ( more about this on [this article](https://www.bam.tech/article/the-redux-best-practice-do-not-put-non-serializable-values-in-state-or-actions-explained) ). This PR is one in a series of PRs that aim to refactor all of those instances before the upgrade.

The `unleash` Redux property is currently initialized at the start of the application and used as a monitoring tool for dynamic feature activation. The proposed _singleton_ solution is similar to the one on #580 , which was recently merged.

### Acceptance Criteria
- Create an `unleash` singleton javascript module, apart from the Redux store
- Refactor all the calls from this store property to use the singleton directly
- Remove unused code after this change


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
