### PR TITLE
chore: Upgrades `redux`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@hathor/wallet-lib": "1.0.4",
         "@ledgerhq/hw-transport-node-hid": "6.28.1",
+        "@reduxjs/toolkit": "^2.1.0",
         "@sentry/electron": "3.0.7",
         "babel-polyfill": "6.26.0",
         "bootstrap": "4.6.1",
@@ -31,7 +32,6 @@
         "react-redux": "7.2.8",
         "react-router-dom": "^6.22.3",
         "react-scripts": "4.0.3",
-        "redux": "4.2.0",
         "redux-saga": "1.2.1",
         "redux-thunk": "2.4.1",
         "ttag": "1.8.6",
@@ -3395,6 +3395,51 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@redux-saga/types/-/types-1.2.1.tgz",
       "integrity": "sha512-1dgmkh+3so0+LlBWRhGA33ua4MYr7tUOj+a9Si28vUi0IUFNbff1T3sgpeDJI/LaC75bBYnQ0A3wXjn0OrRNBA=="
+    },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.2.3.tgz",
+      "integrity": "sha512-76dll9EnJXg4EVcI5YNxZA/9hSAmZsFqzMmNRHvIlzw2WS/twfcVX3ysYrWGJMClwEmChQFC4yRq74tn6fdzRA==",
+      "dependencies": {
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
     },
     "node_modules/@remix-run/router": {
       "version": "1.15.3",
@@ -21778,6 +21823,11 @@
       "dependencies": {
         "lodash": "^4.17.21"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.0.tgz",
+      "integrity": "sha512-aw7jcGLDpSgNDyWBQLv2cedml85qd95/iszJjN988zX1t7AVRJi19d9kto5+W7oCfQ94gyo40dVbT6g2k4/kXg=="
     },
     "node_modules/resolve": {
       "version": "1.22.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@hathor/wallet-lib": "1.0.4",
         "@ledgerhq/hw-transport-node-hid": "6.28.1",
-        "@reduxjs/toolkit": "^2.1.0",
+        "@reduxjs/toolkit": "2.2.3",
         "@sentry/electron": "3.0.7",
         "babel-polyfill": "6.26.0",
         "bootstrap": "4.6.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@hathor/wallet-lib": "1.0.4",
     "@ledgerhq/hw-transport-node-hid": "6.28.1",
-    "@reduxjs/toolkit": "^2.1.0",
+    "@reduxjs/toolkit": "2.2.3",
     "@sentry/electron": "3.0.7",
     "babel-polyfill": "6.26.0",
     "bootstrap": "4.6.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@hathor/wallet-lib": "1.0.4",
     "@ledgerhq/hw-transport-node-hid": "6.28.1",
+    "@reduxjs/toolkit": "^2.1.0",
     "@sentry/electron": "3.0.7",
     "babel-polyfill": "6.26.0",
     "bootstrap": "4.6.1",
@@ -51,7 +52,6 @@
     "react-redux": "7.2.8",
     "react-router-dom": "^6.22.3",
     "react-scripts": "4.0.3",
-    "redux": "4.2.0",
     "redux-saga": "1.2.1",
     "redux-thunk": "2.4.1",
     "ttag": "1.8.6",

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { configureStore } from "@reduxjs/toolkit";
+import { configureStore } from '@reduxjs/toolkit';
 import thunk from 'redux-thunk';
 import createSagaMiddleware from 'redux-saga';
 import rootReducer from '../reducers/index';

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { createStore, applyMiddleware } from "redux";
+import { configureStore } from "@reduxjs/toolkit";
 import thunk from 'redux-thunk';
 import createSagaMiddleware from 'redux-saga';
 import rootReducer from '../reducers/index';
@@ -15,7 +15,10 @@ import rootSagas from '../sagas';
 const saga = createSagaMiddleware();
 const middlewares = [saga, thunk];
 
-const store = createStore(rootReducer, applyMiddleware(...middlewares));
+const store = configureStore({
+  reducer: rootReducer,
+  middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(middlewares)
+});
 
 saga.run(rootSagas);
 


### PR DESCRIPTION
This PR upgrades the Redux version of this application from `v4` to `v5`, but instead of keeping it a direct rependency, replaces it with `redux-toolkit` that indirectly uses `redux`. This is [the strongly recommended](https://redux.js.org/style-guide/#use-redux-toolkit-for-writing-redux-logic) approach by the current Redux docs.

This is the first step needed for the broader refactoring of the redux code proposed by #507 , aiming to bring this code to more up to date best practices for Redux.

### Acceptance Criteria
- Upgrades the `Redux` dependency


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
