### PR TITLE
refactor: centralizes version number on package

### DIFF
--- a/public/constants.js
+++ b/public/constants.js
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+const { version } = require('../package.json');
+
 const ledgerVersionMagicString = 'HTR';
 const ledgerVersionMagicStringBuffer = [
   ledgerVersionMagicString.charCodeAt(0),
@@ -15,4 +17,5 @@ const ledgerVersionMagicStringBuffer = [
 module.exports = {
   SENTRY_DSN: process.env.SENTRY_DSN || 'https://69c067d1587c465cac836eaf25467ce1@sentry.io/1410476',
   ledgerVersionMagicStringBuffer,
+  versionNumber: version
 }

--- a/public/electron.js
+++ b/public/electron.js
@@ -16,7 +16,7 @@ const { instance: Ledger } = require('./ledger');
 
 Sentry.init({
   dsn: constants.SENTRY_DSN,
-  release: process.env.npm_package_version
+  release: constants.versionNumber
 })
 
 let tray = null
@@ -35,7 +35,6 @@ if (process.platform === 'darwin') {
 }
 
 const appName = 'Hathor Wallet';
-const walletVersion = '0.28.0';
 
 const debugMode = (
   process.argv.indexOf('--unsafe-mode') >= 0 &&
@@ -71,7 +70,7 @@ function createWindow () {
     msgCheckEvent = e;
   });
   // Adding wallet version to user agent, so we can get in all request headers
-  mainWindow.webContents.setUserAgent(mainWindow.webContents.getUserAgent() + ' HathorWallet/' + walletVersion);
+  mainWindow.webContents.setUserAgent(mainWindow.webContents.getUserAgent() + ' HathorWallet/' + constants.versionNumber);
 
   mainWindow.once('ready-to-show', () => {
     mainWindow.show()
@@ -180,7 +179,7 @@ if (process.platform === 'darwin') {
   // Set "About" options only on macOS
   app.setAboutPanelOptions({
     'applicationName': appName,
-    'applicationVersion': walletVersion,
+    'applicationVersion': constants.versionNumber,
     'version': '',
   });
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -12,6 +12,7 @@
 
 import { t } from 'ttag';
 import scssColors from './index.module.scss';
+import { version } from '../package.json';
 
 /**
  * Quantity of elements to show in the wallet history
@@ -21,7 +22,7 @@ export const WALLET_HISTORY_COUNT = 10;
 /**
  * Wallet version
  */
-export const VERSION = '0.28.0';
+export const VERSION = version;
 
 /**
  * Before this version the data in localStorage from the wallet is not compatible


### PR DESCRIPTION
Currently our version bump process has to change two files with hardcoded version numbers. This can be simplified by obtaining the most up-to-date version number from the `package.json`.

### Acceptance Criteria
- All code paths that require the version number should fetch it from the `package.json` directly

### Notes
This refactor was tested with the application being run from:
- The source code
- The built/packed code on the developer machine, without signing

A more thorough test from the signed packages will have to be made during the release candidate QA process to ensure the final packaged electron app will work correctly.


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
