### PR TITLE
feat: Scroll to top on `LockedWallet`

### DIFF
--- a/src/screens/LockedWallet.js
+++ b/src/screens/LockedWallet.js
@@ -38,6 +38,7 @@ function LockedWallet() {
 
   useEffect(() => {
     pinRef.current.focus();
+    window.scrollTo(0, 0); // Ensures the user interface is correct when loading this screen
     wallet.updateSentryState(); // Update Sentry when user started wallet now
   }, []);
 


### PR DESCRIPTION
If the wallet is locked while the screen is scrolled down, the `LockedScreen` is also loaded scrolled, hiding its visual elements. This PR fixes this.

### Acceptance Criteria
- Everytime the `LockedScreen` is loaded, all elements should be visible


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
