### PR TITLE
refactor: Removes pin and password from Redux

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -95,16 +95,6 @@ export const networkUpdate = data => ({ type: 'network_update', payload: data })
 export const lastFailedRequest = data => ({ type: 'last_failed_request', payload: data });
 
 /**
- * Save written password in Redux (it's always cleaned after the use)
- */
-export const updatePassword = data => ({ type: 'update_password', payload: data });
-
-/**
- * Save written pin in Redux (it's always cleaned after the use)
- */
-export const updatePin = data => ({ type: 'update_pin', payload: data });
-
-/**
  * Save words in Redux (it's always cleaned after the use)
  */
 export const updateWords = data => ({ type: 'update_words', payload: data });

--- a/src/components/ChoosePassword.js
+++ b/src/components/ChoosePassword.js
@@ -5,52 +5,55 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { t } from 'ttag'
 
 import PinPasswordWrapper from '../components/PinPasswordWrapper'
-import { updatePassword } from '../actions/index';
-import { connect } from 'react-redux';
 import { PASSWORD_PATTERN } from '../constants';
 
 
-const mapDispatchToProps = dispatch => {
-  return {
-    updatePassword: data => dispatch(updatePassword(data)),
-  };
-};
-
-
 /**
- * Component to choose a password  
+ * Component to choose a password
  * Shows two password fields with required pattern and validations
  *
  * @memberof Components
  */
-class ChoosePassword extends React.Component {
+function ChoosePassword({ success, back }) {
+  const [password, setPassword] = useState('');
+
   /**
    * Called when input password changes the value
    *
-   * @param {string} New value in input
+   * @param {string} value value in input
    */
-  handleChange = (value) => {
-    this.props.updatePassword(value);
+  const handleChange = (value) => {
+    setPassword(value);
   }
 
-  render() {
-    const renderMessage = () => {
-      return (
-        <div className="mt-4 mb-4">
-          <p>{t`Please, choose a password to encrypt your sensitive data while using the wallet.`}</p>
-          <p className="mt-3">{t`Your password must have at least 8 characters and at least one lower case character, one upper case character, one number, and one special character.`}</p>
-        </div>
-      );
-    }
+  const handleSuccess = () => {
+    success(password);
+  }
 
+  const renderMessage = () => {
     return (
-      <PinPasswordWrapper message={renderMessage()} success={this.props.success} back={this.props.back} handleChange={this.handleChange} field={t`Password`} button={t`Next`} pattern={PASSWORD_PATTERN} />
-    )
+      <div className="mt-4 mb-4">
+        <p>{t`Please, choose a password to encrypt your sensitive data while using the wallet.`}</p>
+        <p className="mt-3">{t`Your password must have at least 8 characters and at least one lower case character, one upper case character, one number, and one special character.`}</p>
+      </div>
+    );
   }
+
+  return (
+    <PinPasswordWrapper
+      message={renderMessage()}
+      success={handleSuccess}
+      back={back}
+      handleChange={handleChange}
+      field={t`Password`}
+      button={t`Next`}
+      pattern={PASSWORD_PATTERN}
+    />
+  )
 }
 
-export default connect(null, mapDispatchToProps)(ChoosePassword);
+export default ChoosePassword;

--- a/src/components/ChoosePin.js
+++ b/src/components/ChoosePin.js
@@ -5,46 +5,48 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { t } from 'ttag'
 
 import PinPasswordWrapper from '../components/PinPasswordWrapper'
-import { updatePin } from '../actions/index';
-import { connect } from "react-redux";
-
-
-const mapDispatchToProps = dispatch => {
-  return {
-    updatePin: data => dispatch(updatePin(data)),
-  };
-};
-
 
 /**
- * Component to choose a PIN  
+ * Component to choose a PIN
  * Shows two PIN fields with required pattern and validations
  *
  * @memberof Components
  */
-class ChoosePin extends React.Component {
+function ChoosePin({ success, back }) {
+  const [pin, setPin] = useState('');
   /**
    * Called when input PIN changes the value
    *
-   * @param {string} New value in input
+   * @param {string} value New value in input
    */
-  handleChange = (value) => {
-    this.props.updatePin(value);
+  const handleChange = (value) => {
+    setPin(value);
   }
 
-  render() {
-    const renderMessage = () => {
-      return <p className="mt-4 mb-4">{t`The PIN is a 6-digit password requested to authorize actions in your wallet, such as generating new addresses and sending tokens.`}</p>;
-    }
-
-    return (
-      <PinPasswordWrapper ref="wrapper" message={renderMessage()} success={this.props.success} back={this.props.back} handleChange={this.handleChange} field='PIN' pattern='[0-9]{6}' inputMode='numeric' button={t`Next`} />
-    )
+  const handleSuccess = () => {
+    success(pin);
   }
+
+  const renderMessage = () => {
+    return <p className="mt-4 mb-4">{t`The PIN is a 6-digit password requested to authorize actions in your wallet, such as generating new addresses and sending tokens.`}</p>;
+  }
+
+  return (
+    <PinPasswordWrapper
+      message={renderMessage()}
+      success={handleSuccess}
+      back={back}
+      handleChange={handleChange}
+      field='PIN'
+      pattern='[0-9]{6}'
+      inputMode='numeric'
+      button={t`Next`}
+    />
+  )
 }
 
-export default connect(null, mapDispatchToProps)(ChoosePin);
+export default ChoosePin;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -61,10 +61,6 @@ const initialState = {
   lastFailedRequest: undefined,
   // Status code of last failed response
   requestErrorStatusCode: undefined,
-  // Wallet password
-  password: undefined,
-  // Wallet pin
-  pin: undefined,
   // Wallet words
   words: undefined,
   // Tokens already saved: array of objects
@@ -163,10 +159,6 @@ const rootReducer = (state = initialState, action) => {
       return onCleanData(state, action);
     case 'last_failed_request':
       return Object.assign({}, state, {lastFailedRequest: action.payload});
-    case 'update_password':
-      return Object.assign({}, state, {password: action.payload});
-    case 'update_pin':
-      return Object.assign({}, state, {pin: action.payload});
     case 'update_words':
       return Object.assign({}, state, {words: action.payload});
     case 'select_token':

--- a/src/screens/LoadWallet.js
+++ b/src/screens/LoadWallet.js
@@ -12,8 +12,6 @@ import wallet from '../utils/wallet';
 import ChoosePassword from '../components/ChoosePassword';
 import ChoosePin from '../components/ChoosePin';
 import logo from '../assets/images/hathor-logo.png';
-import { updatePassword, updatePin } from '../actions/index';
-import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import hathorLib from '@hathor/wallet-lib';
 import InitialImages from '../components/InitialImages';
@@ -35,13 +33,13 @@ function LoadWallet() {
   const [words, setWords] = useState('');
   /** askPassword {boolean} If should show password component */
   const [askPassword, setAskPassword] = useState(false);
+  /** password {string} New password being created by the user */
+  const [password, setPassword] = useState('');
   /** askPIN {boolean} If should show PIN component */
   const [askPIN, setAskPIN] = useState(false);
   /** wordsCount {number} Number of words written on words input */
   const [wordsCount, setWordsCount] = useState(0);
   const wordsInputRef = useRef();
-  const dispatch = useDispatch();
-  const { pin, password } = useSelector((state) => ({ pin: state.pin, password: state.password }));
   const navigate = useNavigate();
 
   /**
@@ -66,24 +64,24 @@ function LoadWallet() {
 
   /**
    * Method called when user selects the password with success, so show component to choose pin
+   * @param {string} newPassword New password, already validated
    */
-  const passwordSuccess = () => {
+  const passwordSuccess = (newPassword) => {
+    setPassword(newPassword);
     // This method is called after the ChoosePassword component has a valid password and succeeds
     setAskPIN(true);
   }
 
   /**
    * This method is called after the ChoosePin component has a valid PIN and succeeds
+   * @param {string} newPin New Pin, already validated
    */
-  const pinSuccess = () => {
+  const pinSuccess = (newPin) => {
     LOCAL_STORE.unlock();
     // First we clean what can still be there of a last wallet
-    wallet.generateWallet(words, '', pin, password);
+    wallet.generateWallet(words, '', newPin, password);
     LOCAL_STORE.markBackupDone();
     LOCAL_STORE.open(); // Mark this wallet as open, so that it does not appear locked after loading
-    // Clean pin and password from redux
-    dispatch(updatePassword(null));
-    dispatch(updatePin(null));
   }
 
   /**

--- a/src/screens/NewWallet.js
+++ b/src/screens/NewWallet.js
@@ -13,7 +13,7 @@ import logo from '../assets/images/hathor-logo.png';
 import ChoosePassword from '../components/ChoosePassword';
 import ChoosePin from '../components/ChoosePin';
 import HathorAlert from '../components/HathorAlert';
-import { updatePassword, updatePin, updateWords } from '../actions/index';
+import { updateWords } from '../actions/index';
 import { useDispatch, useSelector } from 'react-redux';
 import hathorLib from '@hathor/wallet-lib';
 import InitialImages from '../components/InitialImages';
@@ -36,12 +36,10 @@ function NewWallet() {
   const context = useContext(GlobalModalContext);
   const dispatch = useDispatch();
 
-  const { password, pin, words } = useSelector(state => ({
-    password: state.password,
-    pin: state.pin,
+  const { words } = useSelector(state => ({
     words: state.words,
   }));
-
+  const [password, setPassword] = useState('');
   const [step2, setStep2] = useState(false);
   const [askPassword, setAskPassword] = useState(false);
   const [askPIN, setAskPIN] = useState(false);
@@ -94,23 +92,24 @@ function NewWallet() {
 
   /**
    * User succeded on choosing a password, then show the Choose PIN component
+   * @param {string} newPassword New password, already validated
    */
-  const passwordSuccess = () => {
+  const passwordSuccess = (newPassword) => {
+    setPassword(newPassword);
     setAskPIN(true);
   }
 
   /**
    * After choosing a new PIN with success, executes the wallet creation and redirect to the wallet
+   * @param {string} newPin New pin, already validated
    */
-  const pinSuccess = () => {
+  const pinSuccess = (newPin) => {
     // Generate addresses and load data
     LOCAL_STORE.unlock();
-    wallet.generateWallet(words, '', pin, password);
+    wallet.generateWallet(words, '', newPin, password);
     // Mark this wallet as open, so that it does not appear locked after loading
     LOCAL_STORE.open();
-    // Clean pin, password and words from redux
-    dispatch(updatePassword(null));
-    dispatch(updatePin(null));
+    // Clean words from redux
     dispatch(updateWords(null));
   }
 


### PR DESCRIPTION
This PR removes the Pin and Password information from Redux, and instead keeps it in the smallest scope possible within the component state of the `NewWallet` and `LoadWallet` screens.

This avoids any future bugs where the Redux store cleanup fails or even security issues should the Redux store happen to leak.

### Acceptance Criteria
- Pin and Password should never be stored on Redux

### Notes
To facilitate the refactor, the `ChossePassword` and `ChoosePin` components were refactored to functional components.

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
