### PR TITLE
refactor: Remove seed words from Redux

### DIFF
--- a/locale/texts.pot
+++ b/locale/texts.pot
@@ -3,7 +3,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Plural-Forms: nplurals=2; plural=(n!=1);\n"
 
-#: src/constants.js:45
+#: src/constants.js:46
 msgid "I want to reset my wallet"
 msgstr ""
 
@@ -15,14 +15,14 @@ msgstr ""
 msgid "Addresses"
 msgstr ""
 
-#: src/components/OutputsWrapper.js:68
+#: src/components/OutputsWrapper.js:60
 #: src/components/atomic-swap/ModalAtomicReceive.js:104
 #: src/components/atomic-swap/ModalAtomicReceive.js:106
 #: src/components/atomic-swap/ModalAtomicSend.js:333
-#: src/components/tokens/TokenMint.js:146
+#: src/components/tokens/TokenMint.js:148
 #: src/screens/AddressList.js:191
-#: src/screens/CreateNFT.js:325
-#: src/screens/CreateToken.js:289
+#: src/screens/CreateNFT.js:326
+#: src/screens/CreateToken.js:290
 msgid "Address"
 msgstr ""
 
@@ -43,15 +43,15 @@ msgstr ""
 msgid "Passphrase and confirm passphrase must be equal"
 msgstr ""
 
-#: src/components/ModalBackupWords.js:120
-#: src/components/ModalResetAllData.js:81
+#: src/components/ModalBackupWords.js:105
+#: src/components/ModalResetAllData.js:75
 #: src/screens/ChoosePassphrase.js:71
 msgid "Invalid password"
 msgstr ""
 
-#: src/components/ModalPin.js:82
+#: src/components/ModalPin.js:76
 #: src/screens/ChoosePassphrase.js:76
-#: src/screens/LockedWallet.js:66
+#: src/screens/LockedWallet.js:67
 msgid "Invalid PIN"
 msgstr ""
 
@@ -78,14 +78,14 @@ msgstr ""
 msgid "Please, enter your password and PIN to confirm the operation."
 msgstr ""
 
-#: src/components/ChoosePassword.js:51
+#: src/components/ChoosePassword.js:52
 #: src/screens/ChoosePassphrase.js:154
 msgid "Password"
 msgstr ""
 
 #: src/screens/ChoosePassphrase.js:157
-#: src/screens/LockedWallet.js:116
-#: src/screens/Server.js:405
+#: src/screens/LockedWallet.js:117
+#: src/screens/Server.js:406
 msgid "PIN"
 msgstr ""
 
@@ -121,59 +121,59 @@ msgstr ""
 msgid "Confirm"
 msgstr ""
 
-#: src/screens/CreateNFT.js:72
-#: src/screens/CreateToken.js:64
+#: src/screens/CreateNFT.js:73
+#: src/screens/CreateToken.js:65
 msgid "Must choose an address or auto select"
 msgstr ""
 
-#: src/screens/CreateNFT.js:78
+#: src/screens/CreateNFT.js:79
 #, javascript-format
 msgid "Maximum NFT units to mint is ${ hathorLib.constants.MAX_OUTPUT_VALUE }"
 msgstr ""
 
-#: src/screens/CreateNFT.js:102
+#: src/screens/CreateNFT.js:103
 msgid "Creating NFT"
 msgstr ""
 
-#: src/screens/CreateNFT.js:195
+#: src/screens/CreateNFT.js:196
 #, javascript-format
 msgid "NFT ${ token.name } created"
 msgstr ""
 
-#: src/screens/CreateNFT.js:200
+#: src/screens/CreateNFT.js:201
 msgid "Your NFT has been successfully created!"
 msgstr ""
 
-#: src/screens/CreateNFT.js:201
+#: src/screens/CreateNFT.js:202
 msgid ""
 "You can share the following configuration string with other people to let "
 "them register your brand new NFT in their wallets."
 msgstr ""
 
-#: src/screens/CreateNFT.js:202
-#: src/screens/CreateToken.js:232
+#: src/screens/CreateNFT.js:203
+#: src/screens/CreateToken.js:233
 msgid "Remember to **make a backup** of this configuration string."
 msgstr ""
 
-#: src/screens/CreateNFT.js:271
+#: src/screens/CreateNFT.js:272
 msgid ""
 "Here you will create a new NFT. After the creation, you will be able to "
 "send the units of this NFT to other addresses."
 msgstr ""
 
-#: src/screens/CreateNFT.js:272
+#: src/screens/CreateNFT.js:273
 msgid ""
 "NFTs share the address space with all other tokens, including HTR. This "
 "means that you can send and receive tokens using any valid address."
 msgstr ""
 
-#: src/screens/CreateNFT.js:273
+#: src/screens/CreateNFT.js:274
 msgid ""
 "Remember to make a backup of your new token's configuration string. You "
 "will need to send it to other people to allow them to use your NFT."
 msgstr ""
 
-#: src/screens/CreateNFT.js:276
+#: src/screens/CreateNFT.js:277
 #, javascript-format
 msgid ""
 "When creating and minting NFTs, a |bold:deposit of ${ htrDeposit }%| in HTR "
@@ -183,7 +183,7 @@ msgid ""
 "NFT standard |link:here|."
 msgstr ""
 
-#: src/screens/CreateNFT.js:285
+#: src/screens/CreateNFT.js:286
 msgid ""
 "The most common usage for an NFT is to represent a digital asset. Please "
 "see |link:this guide| that explains how to create an NFT data (including "
@@ -191,102 +191,102 @@ msgid ""
 "standard in order to be able to show your asset in our explorer."
 msgstr ""
 
-#: src/screens/CreateNFT.js:295
+#: src/screens/CreateNFT.js:296
 msgid "NFT Data"
 msgstr ""
 
-#: src/screens/CreateNFT.js:296
+#: src/screens/CreateNFT.js:297
 msgid "ipfs://..."
-msgstr ""
-
-#: src/screens/CreateNFT.js:302
-#: src/screens/CreateToken.js:261
-msgid "Short name"
 msgstr ""
 
 #: src/screens/CreateNFT.js:303
 #: src/screens/CreateToken.js:262
-msgid "MyCoin"
+msgid "Short name"
 msgstr ""
 
-#: src/screens/CreateNFT.js:306
-#: src/screens/CreateToken.js:265
-msgid "Symbol"
+#: src/screens/CreateNFT.js:304
+#: src/screens/CreateToken.js:263
+msgid "MyCoin"
 msgstr ""
 
 #: src/screens/CreateNFT.js:307
 #: src/screens/CreateToken.js:266
+msgid "Symbol"
+msgstr ""
+
+#: src/screens/CreateNFT.js:308
+#: src/screens/CreateToken.js:267
 msgid "MYC (2-5 characters)"
 msgstr ""
 
 #: src/components/atomic-swap/ModalAtomicReceive.js:114
 #: src/components/atomic-swap/ModalAtomicSend.js:323
-#: src/screens/CreateNFT.js:312
-#: src/screens/CreateToken.js:271
+#: src/screens/CreateNFT.js:313
+#: src/screens/CreateToken.js:272
 msgid "Amount"
 msgstr ""
 
-#: src/screens/CreateNFT.js:319
-#: src/screens/CreateToken.js:283
+#: src/screens/CreateNFT.js:320
+#: src/screens/CreateToken.js:284
 msgid "Select address automatically"
 msgstr ""
 
-#: src/screens/CreateNFT.js:324
-#: src/screens/CreateToken.js:288
+#: src/screens/CreateNFT.js:325
+#: src/screens/CreateToken.js:289
 msgid "Destination address"
 msgstr ""
 
-#: src/screens/CreateNFT.js:333
+#: src/screens/CreateNFT.js:334
 msgid "Create a mint authority"
 msgstr ""
 
-#: src/screens/CreateNFT.js:341
+#: src/screens/CreateNFT.js:342
 msgid "Create a melt authority"
 msgstr ""
 
-#: src/screens/CreateToken.js:72
+#: src/screens/CreateToken.js:73
 #, javascript-format
 msgid "Maximum value to mint token is ${ max_output_value_str }"
 msgstr ""
 
-#: src/screens/CreateToken.js:96
+#: src/screens/CreateToken.js:97
 msgid "Creating token"
 msgstr ""
 
-#: src/screens/CreateToken.js:176
+#: src/screens/CreateToken.js:177
 #, javascript-format
 msgid "Token ${ token.name } created"
 msgstr ""
 
-#: src/screens/CreateToken.js:230
+#: src/screens/CreateToken.js:231
 msgid "Your token has been successfully created!"
 msgstr ""
 
-#: src/screens/CreateToken.js:231
+#: src/screens/CreateToken.js:232
 msgid ""
 "You can share the following configuration string with other people to let "
 "them use your brand new token."
 msgstr ""
 
-#: src/screens/CreateToken.js:245
+#: src/screens/CreateToken.js:246
 msgid ""
 "Here you will create a new customized token. After the creation, you will "
 "be able to send this new token to other addresses."
 msgstr ""
 
-#: src/screens/CreateToken.js:246
+#: src/screens/CreateToken.js:247
 msgid ""
 "Custom tokens share the address space with all other tokens, including HTR. "
 "This means that you can send and receive tokens using any valid address."
 msgstr ""
 
-#: src/screens/CreateToken.js:247
+#: src/screens/CreateToken.js:248
 msgid ""
 "Remember to make a backup of your new token's configuration string. You "
 "will need to send it to other people to allow them to use your new token."
 msgstr ""
 
-#: src/screens/CreateToken.js:250
+#: src/screens/CreateToken.js:251
 #, javascript-format
 msgid ""
 "When creating and minting tokens, a |bold:deposit of ${ htrDeposit }%| in "
@@ -337,26 +337,26 @@ msgstr ""
 msgid "Token registered with success!"
 msgstr ""
 
-#: src/screens/LoadWallet.js:139
+#: src/screens/LoadWallet.js:142
 msgid "Write the 24 words of your wallet (separated by space)."
 msgstr ""
 
-#: src/screens/LoadWallet.js:140
+#: src/screens/LoadWallet.js:143
 msgid "Words separated by single space"
 msgstr ""
 
 #: src/components/BackButton.js:34
 #: src/components/PinPasswordWrapper.js:60
-#: src/screens/LoadWallet.js:144
-#: src/screens/NewWallet.js:151
-#: src/screens/NewWallet.js:164
+#: src/screens/LoadWallet.js:147
+#: src/screens/NewWallet.js:149
+#: src/screens/NewWallet.js:162
 #: src/screens/Signin.js:45
 #: src/screens/SoftwareWalletWarning.js:55
-#: src/screens/StartHardwareWallet.js:182
+#: src/screens/StartHardwareWallet.js:181
 msgid "Back"
 msgstr ""
 
-#: src/screens/LoadWallet.js:145
+#: src/screens/LoadWallet.js:148
 msgid "Import data"
 msgstr ""
 
@@ -387,18 +387,18 @@ msgstr ""
 msgid "**Transactions found:** ${ transactionsFound }"
 msgstr ""
 
-#: src/screens/LockedWallet.js:114
+#: src/screens/LockedWallet.js:115
 msgid "Your wallet is locked. Please write down your PIN to unlock it."
 msgstr ""
 
 #: src/components/ModalConfirmClearStorage.js:58
-#: src/components/ModalResetAllData.js:134
-#: src/screens/LockedWallet.js:120
+#: src/components/ModalResetAllData.js:128
+#: src/screens/LockedWallet.js:121
 #: src/screens/Settings.js:318
 msgid "Reset all data"
 msgstr ""
 
-#: src/screens/LockedWallet.js:130
+#: src/screens/LockedWallet.js:131
 msgid "Unlock"
 msgstr ""
 
@@ -412,51 +412,51 @@ msgid ""
 "have a digital asset being shown in our explorer."
 msgstr ""
 
-#: src/screens/NewWallet.js:141
+#: src/screens/NewWallet.js:139
 msgid ". A new wallet is generated by 24 words."
 msgstr ""
 
-#: src/screens/NewWallet.js:142
+#: src/screens/NewWallet.js:140
 msgid ""
 ". To have access to this wallet you must have all the words saved in the "
 "same order we will show to you."
 msgstr ""
 
-#: src/screens/NewWallet.js:143
+#: src/screens/NewWallet.js:141
 msgid ""
 ". If someone manages to discover your words they can steal your tokens, so "
 "we advise you to save your words physically and don't show them to anyone."
 msgstr ""
 
-#: src/screens/NewWallet.js:147
+#: src/screens/NewWallet.js:145
 msgid "Ok, I got it!"
 msgstr ""
 
-#: src/screens/NewWallet.js:152
+#: src/screens/NewWallet.js:150
 msgid "Create my words"
 msgstr ""
 
-#: src/screens/NewWallet.js:161
+#: src/screens/NewWallet.js:159
 msgid "Your words have been created!"
 msgstr ""
 
-#: src/screens/NewWallet.js:162
+#: src/screens/NewWallet.js:160
 msgid ""
 "You should save them in a non-digital media, such as a piece of paper. We "
 "advise you to do it now, but you can do it later."
 msgstr ""
 
-#: src/components/ModalBackupWords.js:267
-#: src/screens/NewWallet.js:165
+#: src/components/ModalBackupWords.js:254
+#: src/screens/NewWallet.js:163
 msgid "Do it later"
 msgstr ""
 
-#: src/screens/NewWallet.js:166
+#: src/screens/NewWallet.js:164
 msgid "Backup now"
 msgstr ""
 
-#: src/screens/NewWallet.js:195
-#: src/screens/Wallet.js:215
+#: src/screens/NewWallet.js:193
+#: src/screens/Wallet.js:214
 msgid "Backup completed!"
 msgstr ""
 
@@ -468,7 +468,7 @@ msgstr ""
 msgid "You tried to access a page that does not exist in Hathor Wallet"
 msgstr ""
 
-#: src/screens/SendTokens.js:145
+#: src/screens/SendTokens.js:146
 msgid "Invalid custom tokens"
 msgstr ""
 
@@ -476,28 +476,28 @@ msgstr ""
 #: src/components/ModalAlertNotSupported.js:34
 #: src/components/ModalLedgerResetTokenSignatures.js:122
 #: src/components/ModalLedgerSignToken.js:243
-#: src/screens/SendTokens.js:146
-#: src/screens/SendTokens.js:273
-#: src/screens/SendTokens.js:446
+#: src/screens/SendTokens.js:147
+#: src/screens/SendTokens.js:274
+#: src/screens/SendTokens.js:447
 msgid "Close"
 msgstr ""
 
-#: src/screens/SendTokens.js:203
-#: src/screens/SendTokens.js:330
+#: src/screens/SendTokens.js:204
+#: src/screens/SendTokens.js:331
 msgid "Validate outputs on Ledger"
 msgstr ""
 
-#: src/screens/SendTokens.js:271
+#: src/screens/SendTokens.js:272
 #.  there are tokens without signatures, missingSigs
 #.  set tittle and content
 msgid "Unverified custom tokens"
 msgstr ""
 
-#: src/screens/SendTokens.js:360
+#: src/screens/SendTokens.js:361
 msgid "Sending transaction"
 msgstr ""
 
-#: src/screens/SendTokens.js:433
+#: src/screens/SendTokens.js:434
 #.  Custom token not allowed for this Ledger version
 msgid ""
 "Unfortunately this feature is not supported with the Hathor app version on "
@@ -505,7 +505,7 @@ msgid ""
 "the most recent Hathor app."
 msgstr ""
 
-#: src/screens/SendTokens.js:441
+#: src/screens/SendTokens.js:442
 #.  limit is 10 custom tokens per tx
 #, javascript-format
 msgid ""
@@ -513,36 +513,36 @@ msgid ""
 "per transaction."
 msgstr ""
 
-#: src/screens/SendTokens.js:444
+#: src/screens/SendTokens.js:445
 msgid "Token limit reached"
 msgstr ""
 
-#: src/screens/SendTokens.js:453
+#: src/screens/SendTokens.js:454
 msgid "All your tokens were already added"
 msgstr ""
 
-#: src/screens/SendTokens.js:518
+#: src/screens/SendTokens.js:519
 msgid ""
 "Please go to you Ledger and validate each output of your transaction. Press "
 "both buttons in case the output is correct."
 msgstr ""
 
-#: src/screens/SendTokens.js:519
+#: src/screens/SendTokens.js:520
 msgid "In the end, a final screen will ask you to confirm sending the transaction."
 msgstr ""
 
 #: src/components/tokens/TokenAction.js:147
-#: src/screens/SendTokens.js:551
+#: src/screens/SendTokens.js:552
 msgid "Loading metadata..."
 msgstr ""
 
-#: src/screens/SendTokens.js:559
+#: src/screens/SendTokens.js:560
 msgid "Add another token"
 msgstr ""
 
 #: src/components/atomic-swap/ModalAtomicSend.js:296
-#: src/screens/SendTokens.js:560
-#: src/screens/SendTokens.js:571
+#: src/screens/SendTokens.js:561
+#: src/screens/SendTokens.js:572
 msgid "Send Tokens"
 msgstr ""
 
@@ -587,43 +587,43 @@ msgstr ""
 msgid "I allow Hathor Wallet to report error information to Hathor team."
 msgstr ""
 
-#: src/screens/Server.js:82
-#: src/screens/Server.js:92
+#: src/screens/Server.js:83
+#: src/screens/Server.js:93
 msgid "New server is not valid"
 msgstr ""
 
-#: src/screens/Server.js:87
-#: src/screens/Server.js:96
+#: src/screens/Server.js:88
+#: src/screens/Server.js:97
 msgid "New real-time server is not valid"
 msgstr ""
 
-#: src/screens/Server.js:357
+#: src/screens/Server.js:358
 msgid "Select one of the default servers to connect or choose a new one"
 msgstr ""
 
-#: src/screens/Server.js:362
-#: src/screens/Server.js:392
+#: src/screens/Server.js:363
+#: src/screens/Server.js:393
 msgid "Base server"
 msgstr ""
 
-#: src/screens/Server.js:375
-#: src/screens/Server.js:399
+#: src/screens/Server.js:376
+#: src/screens/Server.js:400
 msgid "Real-time server"
 msgstr ""
 
-#: src/screens/Server.js:387
+#: src/screens/Server.js:388
 msgid "Select a new server"
 msgstr ""
 
-#: src/screens/Server.js:395
+#: src/screens/Server.js:396
 msgid "New server"
 msgstr ""
 
-#: src/screens/Server.js:400
+#: src/screens/Server.js:401
 msgid "New real-time server"
 msgstr ""
 
-#: src/screens/Server.js:408
+#: src/screens/Server.js:409
 msgid "Connect to server"
 msgstr ""
 
@@ -697,7 +697,7 @@ msgstr ""
 msgid "Allow notifications:"
 msgstr ""
 
-#: src/components/ModalResetAllData.js:170
+#: src/components/ModalResetAllData.js:164
 #: src/components/TokenGeneralInfo.js:138
 #: src/screens/Settings.js:297
 #: src/screens/Settings.js:301
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: src/components/ModalResetAllData.js:169
+#: src/components/ModalResetAllData.js:163
 #: src/components/TokenGeneralInfo.js:139
 #: src/screens/Settings.js:297
 #: src/screens/Settings.js:302
@@ -740,10 +740,10 @@ msgstr ""
 
 #: src/components/ModalAddressQRCode.js:101
 #: src/components/TokenGeneralInfo.js:164
-#: src/components/WalletAddress.js:174
+#: src/components/WalletAddress.js:175
 #: src/screens/Settings.js:312
-#: src/screens/atomic-swap/EditSwap.js:90
-#: src/screens/atomic-swap/EditSwap.js:104
+#: src/screens/atomic-swap/EditSwap.js:91
+#: src/screens/atomic-swap/EditSwap.js:105
 msgid "Copy to clipboard"
 msgstr ""
 
@@ -755,10 +755,10 @@ msgstr ""
 msgid "Untrust all tokens on Ledger"
 msgstr ""
 
-#: src/components/TxData.js:949
-#: src/components/WalletAddress.js:194
+#: src/components/TxData.js:955
+#: src/components/WalletAddress.js:195
 #: src/screens/Settings.js:327
-#: src/screens/atomic-swap/EditSwap.js:589
+#: src/screens/atomic-swap/EditSwap.js:590
 msgid "Copied to clipboard!"
 msgstr ""
 
@@ -784,29 +784,29 @@ msgid "Unsupported Ledger app version"
 msgstr ""
 
 #: src/components/ModalLedgerResetTokenSignatures.js:121
-#: src/screens/StartHardwareWallet.js:154
+#: src/screens/StartHardwareWallet.js:153
 #: src/screens/TransactionDetail.js:159
 #: src/screens/VersionError.js:58
 msgid "Try again"
 msgstr ""
 
-#: src/screens/StartHardwareWallet.js:161
+#: src/screens/StartHardwareWallet.js:160
 msgid "You need to authorize the operation on your Ledger."
 msgstr ""
 
-#: src/screens/StartHardwareWallet.js:163
+#: src/screens/StartHardwareWallet.js:162
 msgid "Please connect your Ledger device to the computer and open the Hathor app."
 msgstr ""
 
-#: src/screens/StartHardwareWallet.js:169
+#: src/screens/StartHardwareWallet.js:168
 msgid "Step 2/2"
 msgstr ""
 
-#: src/screens/StartHardwareWallet.js:171
+#: src/screens/StartHardwareWallet.js:170
 msgid "Step 1/2"
 msgstr ""
 
-#: src/screens/StartHardwareWallet.js:178
+#: src/screens/StartHardwareWallet.js:177
 msgid "Connecting to Ledger"
 msgstr ""
 
@@ -855,11 +855,11 @@ msgstr ""
 msgid "Download failed, please"
 msgstr ""
 
-#: src/components/TxData.js:665
-#: src/components/TxData.js:680
-#: src/components/TxData.js:836
+#: src/components/TxData.js:671
+#: src/components/TxData.js:686
+#: src/components/TxData.js:842
 #: src/screens/UnknownTokens.js:216
-#: src/screens/Wallet.js:465
+#: src/screens/Wallet.js:464
 msgid "try again"
 msgstr ""
 
@@ -910,66 +910,66 @@ msgstr ""
 msgid "Change Server"
 msgstr ""
 
-#: src/screens/Wallet.js:231
-#: src/screens/Wallet.js:479
+#: src/screens/Wallet.js:230
+#: src/screens/Wallet.js:478
 msgid "Unregister token"
 msgstr ""
 
-#: src/screens/Wallet.js:239
+#: src/screens/Wallet.js:238
 #, javascript-format
 msgid ""
 "Are you sure you want to unregister the token **${ token.name } (${ "
 "token.symbol })**?"
 msgstr ""
 
-#: src/screens/Wallet.js:240
+#: src/screens/Wallet.js:239
 msgid ""
 "You won't lose your tokens, you just won't see this token on the side bar "
 "anymore."
 msgstr ""
 
-#: src/screens/Wallet.js:327
+#: src/screens/Wallet.js:326
 msgid ""
 "You haven't done the backup of your wallet yet. You should do it as soon as "
 "possible for your own safety."
 msgstr ""
 
-#: src/screens/Wallet.js:328
+#: src/screens/Wallet.js:327
 msgid "Do it now"
 msgstr ""
 
-#: src/screens/Wallet.js:364
+#: src/screens/Wallet.js:363
 msgid "Administrative Tools"
 msgstr ""
 
-#: src/screens/Wallet.js:379
+#: src/screens/Wallet.js:378
 msgid "Balance & History"
 msgstr ""
 
-#: src/screens/Wallet.js:383
+#: src/screens/Wallet.js:382
 #, javascript-format
 msgid "About ${ token.name }"
 msgstr ""
 
-#: src/screens/Wallet.js:431
+#: src/screens/Wallet.js:430
 msgid "Sign token on Ledger"
 msgstr ""
 
-#: src/screens/Wallet.js:432
+#: src/screens/Wallet.js:431
 msgid "Token signed with Ledger"
 msgstr ""
 
-#: src/screens/Wallet.js:452
+#: src/screens/Wallet.js:451
 msgid "Loading token information, please wait..."
 msgstr ""
 
+#: src/components/TokenBar.js:201
 #: src/components/TokenBar.js:202
-#: src/components/TokenBar.js:203
-#: src/screens/Wallet.js:460
+#: src/screens/Wallet.js:459
 msgid "Settings"
 msgstr ""
 
-#: src/screens/Wallet.js:463
+#: src/screens/Wallet.js:462
 msgid "Token load failed, please"
 msgstr ""
 
@@ -1003,42 +1003,42 @@ msgstr ""
 msgid "Ledger disconnected! Either the app was closed or the connection was lost!"
 msgstr ""
 
-#: src/screens/WalletVersionError.js:92
+#: src/screens/WalletVersionError.js:91
 msgid ""
 "You've recently updated your wallet, and this new version is not compatible "
 "with your local data."
 msgstr ""
 
-#: src/screens/WalletVersionError.js:93
+#: src/screens/WalletVersionError.js:92
 msgid "You have two alternatives:"
 msgstr ""
 
-#: src/screens/WalletVersionError.js:95
+#: src/screens/WalletVersionError.js:94
 msgid ""
 "Use this new wallet version. In this case, you must reset and import your "
 "wallet again."
 msgstr ""
 
-#: src/screens/WalletVersionError.js:96
+#: src/screens/WalletVersionError.js:95
 msgid "Go back to the previous installed version."
 msgstr ""
 
-#: src/screens/WalletVersionError.js:98
+#: src/screens/WalletVersionError.js:97
 msgid ""
 "If you are going to reset your wallet, please double-check your backup "
 "before doing so."
 msgstr ""
 
-#: src/components/ModalBackupWords.js:365
-#: src/screens/WalletVersionError.js:99
+#: src/components/ModalBackupWords.js:352
+#: src/screens/WalletVersionError.js:98
 msgid "Backup Words"
 msgstr ""
 
-#: src/screens/WalletVersionError.js:100
+#: src/screens/WalletVersionError.js:99
 msgid "Reset Wallet"
 msgstr ""
 
-#: src/screens/WalletVersionError.js:102
+#: src/screens/WalletVersionError.js:101
 msgid "Backup done with success!"
 msgstr ""
 
@@ -1078,111 +1078,111 @@ msgstr ""
 msgid "Get started"
 msgstr ""
 
-#: src/screens/atomic-swap/EditSwap.js:68
+#: src/screens/atomic-swap/EditSwap.js:69
 msgid "All existing signatures will be discarded."
 msgstr ""
 
-#: src/screens/atomic-swap/EditSwap.js:109
+#: src/screens/atomic-swap/EditSwap.js:110
 msgid "Show password"
 msgstr ""
 
-#: src/screens/atomic-swap/EditSwap.js:110
+#: src/screens/atomic-swap/EditSwap.js:111
 msgid "Hide password"
 msgstr ""
 
-#: src/screens/atomic-swap/EditSwap.js:127
+#: src/screens/atomic-swap/EditSwap.js:128
 msgid "This input is signed"
 msgstr ""
 
-#: src/screens/atomic-swap/EditSwap.js:138
+#: src/screens/atomic-swap/EditSwap.js:139
 msgid "This input belongs to this wallet"
 msgstr ""
 
-#: src/screens/atomic-swap/EditSwap.js:153
+#: src/screens/atomic-swap/EditSwap.js:154
 msgid "This output is for a change on this wallet"
 msgstr ""
 
-#: src/screens/atomic-swap/EditSwap.js:158
+#: src/screens/atomic-swap/EditSwap.js:159
 msgid "This output belongs to this wallet"
 msgstr ""
 
-#: src/screens/atomic-swap/EditSwap.js:167
+#: src/screens/atomic-swap/EditSwap.js:168
 msgid "No tokens exchanged on this proposal"
 msgstr ""
 
 #: src/components/atomic-swap/ModalAtomicReceive.js:95
 #: src/components/atomic-swap/ModalAtomicSend.js:304
-#: src/screens/atomic-swap/EditSwap.js:183
+#: src/screens/atomic-swap/EditSwap.js:184
 msgid "Token"
 msgstr ""
 
-#: src/screens/atomic-swap/EditSwap.js:204
+#: src/screens/atomic-swap/EditSwap.js:205
 msgid "No Inputs"
 msgstr ""
 
-#: src/screens/atomic-swap/EditSwap.js:222
+#: src/screens/atomic-swap/EditSwap.js:223
 msgid "No Outputs"
 msgstr ""
 
-#: src/screens/atomic-swap/EditSwap.js:520
+#: src/screens/atomic-swap/EditSwap.js:521
 #.  Main screen render
 msgid "Editing Atomic Swap Proposal"
 msgstr ""
 
-#: src/screens/atomic-swap/EditSwap.js:524
+#: src/screens/atomic-swap/EditSwap.js:525
 #.  Main screen render
 msgid "Summary"
 msgstr ""
 
-#: src/screens/atomic-swap/EditSwap.js:534
+#: src/screens/atomic-swap/EditSwap.js:535
 #.  Main screen render
 msgid "Save and Upload"
 msgstr ""
 
 #: src/components/atomic-swap/ModalAtomicSend.js:368
-#: src/screens/atomic-swap/EditSwap.js:539
+#: src/screens/atomic-swap/EditSwap.js:540
 #.  Main screen render
 msgid "Send"
 msgstr ""
 
 #: src/components/atomic-swap/ModalAtomicReceive.js:131
-#: src/screens/atomic-swap/EditSwap.js:544
+#: src/screens/atomic-swap/EditSwap.js:545
 #.  Main screen render
 msgid "Receive"
 msgstr ""
 
-#: src/screens/atomic-swap/EditSwap.js:549
+#: src/screens/atomic-swap/EditSwap.js:550
 #.  Main screen render
 msgid "Remove all my inputs and outputs"
 msgstr ""
 
-#: src/screens/atomic-swap/EditSwap.js:555
+#: src/screens/atomic-swap/EditSwap.js:556
 #.  Main screen render
 msgid "Sign my Inputs"
 msgstr ""
 
-#: src/screens/atomic-swap/EditSwap.js:560
+#: src/screens/atomic-swap/EditSwap.js:561
 #.  Main screen render
 msgid "Send Transaction"
 msgstr ""
 
-#: src/screens/atomic-swap/EditSwap.js:571
+#: src/screens/atomic-swap/EditSwap.js:572
 #.  Main screen render
 msgid "Proposal Details"
 msgstr ""
 
 #: src/screens/atomic-swap/ImportExisting.js:75
-#: src/screens/atomic-swap/NewSwap.js:50
+#: src/screens/atomic-swap/NewSwap.js:51
 msgid "New Atomic Swap Proposal"
 msgstr ""
 
 #: src/screens/atomic-swap/ImportExisting.js:79
-#: src/screens/atomic-swap/NewSwap.js:54
+#: src/screens/atomic-swap/NewSwap.js:55
 msgid "Proposal Identifier"
 msgstr ""
 
 #: src/screens/atomic-swap/ImportExisting.js:96
-#: src/screens/atomic-swap/NewSwap.js:69
+#: src/screens/atomic-swap/NewSwap.js:70
 msgid "Proposal Password"
 msgstr ""
 
@@ -1190,15 +1190,15 @@ msgstr ""
 msgid "Import"
 msgstr ""
 
-#: src/screens/atomic-swap/NewSwap.js:30
+#: src/screens/atomic-swap/NewSwap.js:31
 msgid "Please insert a password more than 3 characters long"
 msgstr ""
 
-#: src/screens/atomic-swap/NewSwap.js:73
+#: src/screens/atomic-swap/NewSwap.js:74
 msgid "Proposal password"
 msgstr ""
 
-#: src/screens/atomic-swap/NewSwap.js:91
+#: src/screens/atomic-swap/NewSwap.js:92
 msgid "Create"
 msgstr ""
 
@@ -1223,46 +1223,46 @@ msgstr ""
 msgid "Currently participating in:"
 msgstr ""
 
-#: src/sagas/atomicSwap.js:111
+#: src/sagas/atomicSwap.js:113
 msgid "Proposal not found."
 msgstr ""
 
-#: src/sagas/atomicSwap.js:114
+#: src/sagas/atomicSwap.js:116
 msgid "Incorrect password."
 msgstr ""
 
-#: src/sagas/atomicSwap.js:117
+#: src/sagas/atomicSwap.js:119
 msgid "An error occurred while fetching this proposal."
 msgstr ""
 
-#: src/sagas/atomicSwap.js:141
+#: src/sagas/atomicSwap.js:143
 msgid "An error occurred while creating this proposal."
 msgstr ""
 
-#: src/sagas/tokens.js:361
+#: src/sagas/tokens.js:362
 msgid "An error occurred while fetching this token data"
 msgstr ""
 
-#: src/components/ChoosePassword.js:44
+#: src/components/ChoosePassword.js:40
 msgid ""
 "Please, choose a password to encrypt your sensitive data while using the "
 "wallet."
 msgstr ""
 
-#: src/components/ChoosePassword.js:45
+#: src/components/ChoosePassword.js:41
 msgid ""
 "Your password must have at least 8 characters and at least one lower case "
 "character, one upper case character, one number, and one special character."
 msgstr ""
 
-#: src/components/ChoosePassword.js:51
-#: src/components/ChoosePin.js:45
+#: src/components/ChoosePassword.js:53
+#: src/components/ChoosePin.js:47
 #: src/components/HathorPaginate.js:23
 #: src/components/TokenPagination.js:29
 msgid "Next"
 msgstr ""
 
-#: src/components/ChoosePin.js:41
+#: src/components/ChoosePin.js:35
 msgid ""
 "The PIN is a 6-digit password requested to authorize actions in your "
 "wallet, such as generating new addresses and sending tokens."
@@ -1288,11 +1288,11 @@ msgstr ""
 msgid "Name:"
 msgstr ""
 
-#: src/components/ModalAddManyTokens.js:91
+#: src/components/ModalAddManyTokens.js:86
 msgid "Must provide configuration string"
 msgstr ""
 
-#: src/components/ModalAddManyTokens.js:157
+#: src/components/ModalAddManyTokens.js:153
 msgid ""
 "The following tokens have no balance on your wallet and you have the \"hide "
 "zero-balance tokens\" settings on.\n"
@@ -1300,51 +1300,51 @@ msgid ""
 "token info screen.)"
 msgstr ""
 
-#: src/components/ModalAddManyTokens.js:183
+#: src/components/ModalAddManyTokens.js:179
 msgid "Always show these tokens"
 msgstr ""
 
-#: src/components/ModalAddManyTokens.js:186
+#: src/components/ModalAddManyTokens.js:182
 #: src/components/TokenGeneralInfo.js:143
 msgid "If selected, it will override the \"Hide zero-balance tokens\" settings."
 msgstr ""
 
-#: src/components/ModalAddManyTokens.js:208
+#: src/components/ModalAddManyTokens.js:204
 msgid "Register Custom Tokens"
 msgstr ""
 
-#: src/components/ModalAddManyTokens.js:214
+#: src/components/ModalAddManyTokens.js:210
 msgid ""
 "You can register one or more tokens writing the configuration string of "
 "each one below."
 msgstr ""
 
-#: src/components/ModalAddManyTokens.js:218
+#: src/components/ModalAddManyTokens.js:214
 msgid "Configuration strings"
 msgstr ""
 
-#: src/components/ModalAddManyTokens.js:233
-#: src/components/ModalAddToken.js:187
-#: src/components/ModalBackupWords.js:215
+#: src/components/ModalAddManyTokens.js:229
+#: src/components/ModalAddToken.js:183
+#: src/components/ModalBackupWords.js:202
 #: src/components/ModalConfirmClearStorage.js:61
-#: src/components/ModalPin.js:127
-#: src/components/ModalUnregisteredTokenInfo.js:131
+#: src/components/ModalPin.js:121
+#: src/components/ModalUnregisteredTokenInfo.js:128
 #: src/components/atomic-swap/ModalAtomicReceive.js:130
 #: src/components/atomic-swap/ModalAtomicSend.js:367
 #: src/components/tokens/TokenAction.js:155
 msgid "Cancel"
 msgstr ""
 
-#: src/components/ModalAddManyTokens.js:234
-#: src/components/ModalAddToken.js:189
+#: src/components/ModalAddManyTokens.js:230
+#: src/components/ModalAddToken.js:185
 msgid "Register"
 msgstr ""
 
-#: src/components/ModalAddToken.js:86
+#: src/components/ModalAddToken.js:81
 msgid "Must provide configuration string or uid, name, and symbol"
 msgstr ""
 
-#: src/components/ModalAddToken.js:111
+#: src/components/ModalAddToken.js:107
 msgid ""
 "This token has no balance on your wallet and you have the \"hide "
 "zero-balance tokens\" settings on.\n"
@@ -1352,27 +1352,27 @@ msgid ""
 "token info screen.)"
 msgstr ""
 
-#: src/components/ModalAddToken.js:133
+#: src/components/ModalAddToken.js:129
 msgid "Always show this token"
 msgstr ""
 
-#: src/components/ModalAddToken.js:136
+#: src/components/ModalAddToken.js:132
 msgid ""
 "If selected, it will override the \"Hide zero-balance tokens\" settings for "
 "this token."
 msgstr ""
 
-#: src/components/ModalAddToken.js:157
+#: src/components/ModalAddToken.js:153
 msgid "Register a new token"
 msgstr ""
 
-#: src/components/ModalAddToken.js:167
+#: src/components/ModalAddToken.js:163
 msgid ""
 "To register a token that already exists, just write down its configuration "
 "string"
 msgstr ""
 
-#: src/components/ModalAddToken.js:171
+#: src/components/ModalAddToken.js:167
 msgid "Configuration string"
 msgstr ""
 
@@ -1382,7 +1382,7 @@ msgid "Address copied to clipboard!"
 msgstr ""
 
 #: src/components/ModalAddressQRCode.js:91
-#: src/components/WalletAddress.js:150
+#: src/components/WalletAddress.js:151
 msgid "Address to receive tokens"
 msgstr ""
 
@@ -1409,41 +1409,41 @@ msgstr ""
 msgid "Action not supported"
 msgstr ""
 
-#: src/components/ModalBackupWords.js:182
+#: src/components/ModalBackupWords.js:168
 msgid "Wrong word. Please double check the words you saved."
 msgstr ""
 
-#: src/components/ModalBackupWords.js:183
+#: src/components/ModalBackupWords.js:169
 msgid "Click here to start the process again."
 msgstr ""
 
-#: src/components/ModalBackupWords.js:201
+#: src/components/ModalBackupWords.js:188
 msgid "We need your password to show the words"
 msgstr ""
 
-#: src/components/ModalBackupWords.js:204
-#: src/components/ModalResetAllData.js:146
+#: src/components/ModalBackupWords.js:191
+#: src/components/ModalResetAllData.js:140
 msgid "Password*"
 msgstr ""
 
-#: src/components/ModalBackupWords.js:216
-#: src/components/ModalPin.js:129
-#: src/components/tokens/TokenMelt.js:184
-#: src/components/tokens/TokenMint.js:217
+#: src/components/ModalBackupWords.js:203
+#: src/components/ModalPin.js:123
+#: src/components/tokens/TokenMelt.js:185
+#: src/components/tokens/TokenMint.js:220
 msgid "Go"
 msgstr ""
 
-#: src/components/ModalBackupWords.js:254
+#: src/components/ModalBackupWords.js:241
 msgid ""
 "Save the words and never share them. Anyone who has access to them will "
 "control your tokens."
 msgstr ""
 
-#: src/components/ModalBackupWords.js:268
+#: src/components/ModalBackupWords.js:255
 msgid "Ok, I have saved them"
 msgstr ""
 
-#: src/components/ModalBackupWords.js:332
+#: src/components/ModalBackupWords.js:319
 msgid ""
 "To make sure you saved, please select the word that corresponds to the "
 "number below."
@@ -1492,7 +1492,7 @@ msgid ""
 msgstr ""
 
 #: src/components/ModalConfirmClearStorage.js:49
-#: src/components/ModalResetAllData.js:152
+#: src/components/ModalResetAllData.js:146
 #, javascript-format
 msgid "Write '${ CONFIRM_RESET_MESSAGE }'"
 msgstr ""
@@ -1587,31 +1587,31 @@ msgstr ""
 msgid "Error signing token!"
 msgstr ""
 
-#: src/components/ModalPin.js:116
+#: src/components/ModalPin.js:110
 msgid "Write your PIN"
 msgstr ""
 
-#: src/components/ModalResetAllData.js:67
+#: src/components/ModalResetAllData.js:60
 msgid "Confirmation message does not match"
 msgstr ""
 
-#: src/components/ModalResetAllData.js:73
+#: src/components/ModalResetAllData.js:66
 msgid "You must write your password or check that you have forgotten it"
 msgstr ""
 
-#: src/components/ModalResetAllData.js:122
+#: src/components/ModalResetAllData.js:116
 msgid ""
 "If you reset your wallet, all data will be deleted, and you will lose "
 "access to your tokens. To recover access to your tokens, you will need to "
 "import your words again."
 msgstr ""
 
-#: src/components/ModalResetAllData.js:124
+#: src/components/ModalResetAllData.js:118
 #, javascript-format
 msgid "${ firstMessage } You still haven't done the backup of your words."
 msgstr ""
 
-#: src/components/ModalResetAllData.js:142
+#: src/components/ModalResetAllData.js:136
 msgid ""
 "You will need to register all your tokens again when your import your "
 "words. If you prefer, you can go to Settings > Export Registered Tokens, in "
@@ -1619,141 +1619,145 @@ msgid ""
 "by one after you start your wallet again."
 msgstr ""
 
-#: src/components/ModalResetAllData.js:143
+#: src/components/ModalResetAllData.js:137
 #, javascript-format
 msgid ""
 "If you still wanna do it, we need your password and for you to write down "
 "**'${ CONFIRM_RESET_MESSAGE }'** to confirm the operation."
 msgstr ""
 
-#: src/components/ModalResetAllData.js:151
+#: src/components/ModalResetAllData.js:145
 msgid "Confirm message*"
 msgstr ""
 
-#: src/components/ModalResetAllData.js:157
+#: src/components/ModalResetAllData.js:151
 msgid "I forgot my password"
 msgstr ""
 
-#: src/components/ModalSendTx.js:157
+#: src/components/ModalSendTx.js:158
 msgid "Ok"
 msgstr ""
 
-#: src/components/ModalUnhandledError.js:62
+#: src/components/ModalUnhandledError.js:61
 msgid "Report sent to Hathor Team! Thanks for the support!"
 msgstr ""
 
-#: src/components/ModalUnhandledError.js:72
+#: src/components/ModalUnhandledError.js:70
 #, javascript-format
 msgid ""
 "Error Message: ${ message }\n"
 "Stack trace: ${ stack }"
 msgstr ""
 
-#: src/components/ModalUnhandledError.js:78
+#: src/components/ModalUnhandledError.js:76
 msgid "Ooops... Something went wrong..."
 msgstr ""
 
-#: src/components/ModalUnhandledError.js:81
+#: src/components/ModalUnhandledError.js:79
 msgid "An unhandled exception occurred in your wallet."
 msgstr ""
 
-#: src/components/ModalUnhandledError.js:82
+#: src/components/ModalUnhandledError.js:80
 msgid ""
 "If you'd like to help us improve it, please click in the button bellow to "
 "copy the error details to your clipboard."
 msgstr ""
 
-#: src/components/ModalUnhandledError.js:86
+#: src/components/ModalUnhandledError.js:84
 msgid "Copy Error"
 msgstr ""
 
-#: src/components/ModalUnhandledError.js:89
+#: src/components/ModalUnhandledError.js:87
 msgid "Send error report to help the developers"
 msgstr ""
 
-#: src/components/ModalUnhandledError.js:91
+#: src/components/ModalUnhandledError.js:89
 msgid ""
 "Send it to us with all relevant information about the issues you are "
 "experiencing."
 msgstr ""
 
-#: src/components/ModalUnhandledError.js:92
+#: src/components/ModalUnhandledError.js:90
 msgid ""
 "If you are facing recurrent issues, resetting your wallet may solve your "
 "problem. Please, double-check your backup before doing it."
 msgstr ""
 
-#: src/components/ModalUnhandledError.js:99
+#: src/components/ModalUnhandledError.js:97
 msgid "Home"
 msgstr ""
 
-#: src/components/ModalUnhandledError.js:100
+#: src/components/ModalUnhandledError.js:98
 msgid "Dismiss"
 msgstr ""
 
-#: src/components/ModalUnhandledError.js:101
+#: src/components/ModalUnhandledError.js:99
 msgid "Reset wallet"
 msgstr ""
 
-#: src/components/ModalUnregisteredTokenInfo.js:100
+#: src/components/ModalUnregisteredTokenInfo.js:97
 msgid "Unregistered token"
 msgstr ""
 
-#: src/components/ModalUnregisteredTokenInfo.js:116
+#: src/components/ModalUnregisteredTokenInfo.js:113
 msgid ""
 "This token is **not registered** in your wallet. You must **always validate "
 "the token uid**, to ensure you are not being scammed."
 msgstr ""
 
-#: src/components/ModalUnregisteredTokenInfo.js:117
+#: src/components/ModalUnregisteredTokenInfo.js:114
 msgid "The token uid is always unique, and your only trust point."
 msgstr ""
 
-#: src/components/ModalUnregisteredTokenInfo.js:122
+#: src/components/ModalUnregisteredTokenInfo.js:119
 msgid "I want to register this token"
 msgstr ""
 
-#: src/components/ModalUnregisteredTokenInfo.js:130
+#: src/components/ModalUnregisteredTokenInfo.js:127
 msgid "Register token"
 msgstr ""
 
-#: src/components/Navigation.js:49
+#: src/components/Navigation.js:54
 msgid "Wallet"
 msgstr ""
 
-#: src/components/Navigation.js:52
+#: src/components/Navigation.js:57
 msgid "Send tokens"
 msgstr ""
 
-#: src/components/Navigation.js:55
+#: src/components/Navigation.js:60
 msgid "Custom tokens"
 msgstr ""
 
-#: src/components/Navigation.js:58
+#: src/components/Navigation.js:63
 msgid "NFTs"
 msgstr ""
 
-#: src/components/Navigation.js:61
+#: src/components/Navigation.js:66
 msgid "Atomic Swap"
 msgstr ""
 
-#: src/components/Navigation.js:64
+#: src/components/Navigation.js:69
 msgid "Public Explorer"
 msgstr ""
 
-#: src/components/OutputsWrapper.js:73
+#: src/components/Navigation.js:72
+msgid "Nano Contract"
+msgstr ""
+
+#: src/components/OutputsWrapper.js:65
 msgid "This feature is disabled for hardware wallet"
 msgstr ""
 
-#: src/components/OutputsWrapper.js:73
+#: src/components/OutputsWrapper.js:65
 msgid "Timelock"
 msgstr ""
 
-#: src/components/OutputsWrapper.js:76
+#: src/components/OutputsWrapper.js:68
 msgid "Time lock"
 msgstr ""
 
-#: src/components/OutputsWrapper.js:79
+#: src/components/OutputsWrapper.js:71
 msgid "Date and time in GMT"
 msgstr ""
 
@@ -1896,7 +1900,7 @@ msgid "Operations"
 msgstr ""
 
 #: src/components/TokenAdministrative.js:153
-#: src/components/tokens/TokenMelt.js:183
+#: src/components/tokens/TokenMelt.js:184
 msgid "Melt tokens"
 msgstr ""
 
@@ -1909,7 +1913,7 @@ msgid "Destroy melt"
 msgstr ""
 
 #: src/components/TokenAdministrative.js:164
-#: src/components/tokens/TokenMint.js:214
+#: src/components/tokens/TokenMint.js:217
 msgid "Mint tokens"
 msgstr ""
 
@@ -1946,12 +1950,12 @@ msgstr ""
 msgid "Your balance available:"
 msgstr ""
 
-#: src/components/TokenBar.js:170
+#: src/components/TokenBar.js:169
 msgid "Tokens"
 msgstr ""
 
+#: src/components/TokenBar.js:197
 #: src/components/TokenBar.js:198
-#: src/components/TokenBar.js:199
 msgid "Lock wallet"
 msgstr ""
 
@@ -2043,7 +2047,7 @@ msgid "Page ${ page }"
 msgstr ""
 
 #: src/components/TokenInfoBox.js:27
-#: src/components/TxData.js:873
+#: src/components/TxData.js:879
 msgid "Type:"
 msgstr ""
 
@@ -2071,210 +2075,210 @@ msgstr ""
 msgid "Total number of transactions:"
 msgstr ""
 
-#: src/components/TxData.js:443
+#: src/components/TxData.js:449
 msgid "Mint authority"
 msgstr ""
 
-#: src/components/TxData.js:445
+#: src/components/TxData.js:451
 msgid "Melt authority"
 msgstr ""
 
-#: src/components/TxData.js:448
+#: src/components/TxData.js:454
 #.  Should never come here
 msgid "Unknown authority"
 msgstr ""
 
-#: src/components/TxData.js:458
+#: src/components/TxData.js:464
 msgid "This token is not registered in your wallet."
 msgstr ""
 
-#: src/components/TxData.js:474
+#: src/components/TxData.js:480
 msgid "Spent"
 msgstr ""
 
-#: src/components/TxData.js:532
+#: src/components/TxData.js:538
 #, javascript-format
 msgid "${ ret } | Locked until ${ parsedTimestamp }"
 msgstr ""
 
-#: src/components/TxData.js:539
+#: src/components/TxData.js:545
 #, javascript-format
 msgid ""
 "Match values (nano contract), oracle id: ${ decoded.oracle_data_id } hash: "
 "${ decoded.oracle_pubkey_hash }"
 msgstr ""
 
-#: src/components/TxData.js:579
-#: src/components/TxData.js:588
+#: src/components/TxData.js:585
+#: src/components/TxData.js:594
 #.  there are conflicts, but it is not voided
 msgid "This ${ typeStr } is valid."
 msgstr ""
 
-#: src/components/TxData.js:590
+#: src/components/TxData.js:596
 #.  there are conflicts, but it is not voided
 msgid ""
 "Although there is a double-spending transaction, this transaction has the "
 "highest accumulated weight and is valid."
 msgstr ""
 
-#: src/components/TxData.js:595
+#: src/components/TxData.js:601
 #.  there are conflicts, but it is not voided
 msgid "Transactions double spending the same outputs as this transaction:"
 msgstr ""
 
-#: src/components/TxData.js:609
+#: src/components/TxData.js:615
 #.  it is voided, but there is no conflict
 #, javascript-format
 msgid "This ${ typeStr } is voided and **NOT** valid."
 msgstr ""
 
-#: src/components/TxData.js:611
+#: src/components/TxData.js:617
 #.  it is voided, but there is no conflict
 msgid ""
 "This ${ typeStr } is verifying (directly or indirectly) a voided "
 "double-spending transaction, hence it is voided as well."
 msgstr ""
 
-#: src/components/TxData.js:614
+#: src/components/TxData.js:620
 #.  it is voided, but there is no conflict
 #, javascript-format
 msgid "This ${ typeStr } is voided because of these transactions: "
 msgstr ""
 
-#: src/components/TxData.js:624
+#: src/components/TxData.js:630
 #.  it is voided, and there is a conflict
 msgid "This ${ typeStr } is **NOT** valid."
 msgstr ""
 
-#: src/components/TxData.js:626
+#: src/components/TxData.js:632
 #.  it is voided, and there is a conflict
 msgid "It is voided by: "
 msgstr ""
 
-#: src/components/TxData.js:632
+#: src/components/TxData.js:638
 #.  it is voided, and there is a conflict
 msgid "Conflicts with: "
 msgstr ""
 
-#: src/components/TxData.js:662
+#: src/components/TxData.js:668
 msgid "Download failed"
 msgstr ""
 
-#: src/components/TxData.js:679
+#: src/components/TxData.js:685
 msgid "Error retrieving accumulated weight data..."
 msgstr ""
 
-#: src/components/TxData.js:688
+#: src/components/TxData.js:694
 #, javascript-format
 msgid "Over ${ acc }"
 msgstr ""
 
-#: src/components/TxData.js:693
+#: src/components/TxData.js:699
 msgid "Retrieving accumulated weight data..."
 msgstr ""
 
-#: src/components/TxData.js:745
+#: src/components/TxData.js:751
 msgid "Tokens:"
 msgstr ""
 
-#: src/components/TxData.js:759
+#: src/components/TxData.js:765
 msgid "Your address"
 msgstr ""
 
-#: src/components/TxData.js:773
+#: src/components/TxData.js:779
 #, javascript-format
 msgid "**${ tokenSymbol }:** Received"
 msgstr ""
 
-#: src/components/TxData.js:779
+#: src/components/TxData.js:785
 msgid "**${ tokenSymbol }:** Sent"
 msgstr ""
 
-#: src/components/TxData.js:802
+#: src/components/TxData.js:808
 msgid "Balance:"
 msgstr ""
 
-#: src/components/TxData.js:811
+#: src/components/TxData.js:817
 msgid "First block:"
 msgstr ""
 
-#: src/components/TxData.js:820
+#: src/components/TxData.js:826
 msgid "Accumulated weight:"
 msgstr ""
 
-#: src/components/TxData.js:835
+#: src/components/TxData.js:841
 msgid "Error retrieving confirmation level..."
 msgstr ""
 
-#: src/components/TxData.js:845
+#: src/components/TxData.js:851
 msgid "Retrieving confirmation level data..."
 msgstr ""
 
-#: src/components/TxData.js:850
+#: src/components/TxData.js:856
 msgid "Confirmation level:"
 msgstr ""
 
-#: src/components/TxData.js:869
+#: src/components/TxData.js:875
 msgid "Block"
 msgstr ""
 
-#: src/components/TxData.js:869
+#: src/components/TxData.js:875
 msgid "Transaction"
 msgstr ""
 
-#: src/components/TxData.js:874
+#: src/components/TxData.js:880
 msgid "Time:"
 msgstr ""
 
-#: src/components/TxData.js:875
+#: src/components/TxData.js:881
 msgid "Nonce:"
 msgstr ""
 
-#: src/components/TxData.js:876
+#: src/components/TxData.js:882
 msgid "Weight:"
 msgstr ""
 
-#: src/components/TxData.js:888
+#: src/components/TxData.js:894
 msgid "Inputs:"
 msgstr ""
 
-#: src/components/TxData.js:892
+#: src/components/TxData.js:898
 msgid "Outputs:"
 msgstr ""
 
-#: src/components/TxData.js:899
+#: src/components/TxData.js:905
 msgid "Parents:"
 msgstr ""
 
-#: src/components/TxData.js:903
+#: src/components/TxData.js:909
 msgid "Children:"
 msgstr ""
 
-#: src/components/TxData.js:903
+#: src/components/TxData.js:909
 msgid "Click to hide"
 msgstr ""
 
-#: src/components/TxData.js:903
+#: src/components/TxData.js:909
 msgid "Click to show"
 msgstr ""
 
-#: src/components/TxData.js:909
+#: src/components/TxData.js:915
 msgid "Verification neighbors"
 msgstr ""
 
-#: src/components/TxData.js:918
+#: src/components/TxData.js:924
 msgid "Funds neighbors"
 msgstr ""
 
-#: src/components/TxData.js:935
+#: src/components/TxData.js:941
 msgid "Hide raw transaction"
 msgstr ""
 
-#: src/components/TxData.js:935
+#: src/components/TxData.js:941
 msgid "Show raw transaction"
 msgstr ""
 
-#: src/components/TxData.js:938
+#: src/components/TxData.js:944
 msgid "Copy raw tx to clipboard"
 msgstr ""
 
@@ -2291,46 +2295,46 @@ msgstr ""
 msgid "Software Wallet"
 msgstr ""
 
-#: src/components/WalletAddress.js:91
+#: src/components/WalletAddress.js:92
 msgid "Validate address on Ledger"
 msgstr ""
 
-#: src/components/WalletAddress.js:139
+#: src/components/WalletAddress.js:140
 msgid "Validate that the address below is the same presented on the Ledger screen."
 msgstr ""
 
-#: src/components/WalletAddress.js:140
+#: src/components/WalletAddress.js:141
 msgid "Press both buttons on your Ledger in case the address is valid."
 msgstr ""
 
-#: src/components/WalletAddress.js:153
+#: src/components/WalletAddress.js:154
 msgid "Generate new address"
 msgstr ""
 
-#: src/components/WalletAddress.js:153
+#: src/components/WalletAddress.js:154
 msgid "Get new address"
 msgstr ""
 
-#: src/components/WalletAddress.js:157
+#: src/components/WalletAddress.js:158
 #.  hide the QR code for hardware wallet
 msgid "QR Code"
 msgstr ""
 
-#: src/components/WalletAddress.js:157
+#: src/components/WalletAddress.js:158
 #.  hide the QR code for hardware wallet
 msgid "Get qrcode"
 msgstr ""
 
-#: src/components/WalletAddress.js:162
+#: src/components/WalletAddress.js:163
 #.  hide all addresses for hardware wallet
 msgid "See all addresses"
 msgstr ""
 
-#: src/components/WalletAddress.js:184
+#: src/components/WalletAddress.js:185
 msgid "Show full address"
 msgstr ""
 
-#: src/components/WalletAddress.js:195
+#: src/components/WalletAddress.js:196
 msgid "You must use an old address before generating new ones"
 msgstr ""
 
@@ -2339,129 +2343,129 @@ msgid "Transaction history"
 msgstr ""
 
 #: src/components/tokens/TokenDelegate.js:47
-#: src/components/tokens/TokenDelegate.js:73
-#: src/components/tokens/TokenDelegate.js:101
-#: src/components/tokens/TokenDestroy.js:70
-#: src/components/tokens/TokenDestroy.js:111
+#: src/components/tokens/TokenDelegate.js:74
+#: src/components/tokens/TokenDelegate.js:102
+#: src/components/tokens/TokenDestroy.js:71
+#: src/components/tokens/TokenDestroy.js:112
 msgid "Mint"
 msgstr ""
 
 #: src/components/tokens/TokenDelegate.js:47
-#: src/components/tokens/TokenDelegate.js:73
-#: src/components/tokens/TokenDelegate.js:101
-#: src/components/tokens/TokenDestroy.js:70
-#: src/components/tokens/TokenDestroy.js:111
+#: src/components/tokens/TokenDelegate.js:74
+#: src/components/tokens/TokenDelegate.js:102
+#: src/components/tokens/TokenDestroy.js:71
+#: src/components/tokens/TokenDestroy.js:112
 msgid "Melt"
 msgstr ""
 
-#: src/components/tokens/TokenDelegate.js:74
+#: src/components/tokens/TokenDelegate.js:75
 #, javascript-format
 msgid "${ type } output delegated!"
 msgstr ""
 
-#: src/components/tokens/TokenDelegate.js:79
-#: src/components/tokens/TokenDestroy.js:83
-#: src/components/tokens/TokenDestroy.js:92
+#: src/components/tokens/TokenDelegate.js:80
+#: src/components/tokens/TokenDestroy.js:84
+#: src/components/tokens/TokenDestroy.js:93
 msgid "mint"
 msgstr ""
 
-#: src/components/tokens/TokenDelegate.js:79
-#: src/components/tokens/TokenDestroy.js:83
-#: src/components/tokens/TokenDestroy.js:92
+#: src/components/tokens/TokenDelegate.js:80
+#: src/components/tokens/TokenDestroy.js:84
+#: src/components/tokens/TokenDestroy.js:93
 msgid "melt"
 msgstr ""
 
-#: src/components/tokens/TokenDelegate.js:84
+#: src/components/tokens/TokenDelegate.js:85
 #, javascript-format
 msgid "Address of the new ${ type } authority"
 msgstr ""
 
-#: src/components/tokens/TokenDelegate.js:92
+#: src/components/tokens/TokenDelegate.js:93
 msgid "Create another ${ type } output for you?"
 msgstr ""
 
-#: src/components/tokens/TokenDelegate.js:94
-#: src/components/tokens/TokenMelt.js:161
-#: src/components/tokens/TokenMint.js:192
+#: src/components/tokens/TokenDelegate.js:95
+#: src/components/tokens/TokenMelt.js:162
+#: src/components/tokens/TokenMint.js:194
 msgid "Leave it checked unless you know what you are doing"
 msgstr ""
 
-#: src/components/tokens/TokenDelegate.js:107
+#: src/components/tokens/TokenDelegate.js:108
 msgid "Delegate"
 msgstr ""
 
-#: src/components/tokens/TokenDelegate.js:110
+#: src/components/tokens/TokenDelegate.js:111
 msgid "Delegating authority"
 msgstr ""
 
-#: src/components/tokens/TokenDestroy.js:71
+#: src/components/tokens/TokenDestroy.js:72
 #, javascript-format
 msgid "${ label } outputs destroyed!"
 msgstr ""
 
-#: src/components/tokens/TokenDestroy.js:85
+#: src/components/tokens/TokenDestroy.js:86
 #, javascript-format
 msgid "You only have ${ authoritiesLength } ${ type } ${ plural } to destroy."
 msgstr ""
 
-#: src/components/tokens/TokenDestroy.js:96
+#: src/components/tokens/TokenDestroy.js:97
 #, javascript-format
 msgid ""
 "Are you sure you want to destroy **${ quantity } ${ type }** authority ${ "
 "plural }?"
 msgstr ""
 
-#: src/components/tokens/TokenDestroy.js:118
+#: src/components/tokens/TokenDestroy.js:119
 msgid "Destroy"
 msgstr ""
 
-#: src/components/tokens/TokenDestroy.js:122
+#: src/components/tokens/TokenDestroy.js:123
 msgid "Destroying authorities"
 msgstr ""
 
-#: src/components/tokens/TokenMelt.js:93
+#: src/components/tokens/TokenMelt.js:94
 #, javascript-format
 msgid "${ prettyAmountValue } ${ this.props.token.symbol } melted!"
 msgstr ""
 
-#: src/components/tokens/TokenMelt.js:108
+#: src/components/tokens/TokenMelt.js:109
 #, javascript-format
 msgid "The total amount you have is only ${ prettyWalletAmount }."
 msgstr ""
 
-#: src/components/tokens/TokenMelt.js:152
-#: src/components/tokens/TokenMint.js:182
+#: src/components/tokens/TokenMelt.js:153
+#: src/components/tokens/TokenMint.js:184
 msgid ""
 "This is an NFT token. The amount will be an integer number, without decimal "
 "places."
 msgstr ""
 
-#: src/components/tokens/TokenMelt.js:159
+#: src/components/tokens/TokenMelt.js:160
 msgid "Create another melt output for you?"
 msgstr ""
 
-#: src/components/tokens/TokenMelt.js:188
+#: src/components/tokens/TokenMelt.js:189
 msgid "Melting tokens"
 msgstr ""
 
-#: src/components/tokens/TokenMint.js:97
+#: src/components/tokens/TokenMint.js:99
 #, javascript-format
 msgid "${ prettyAmountValue } ${ this.props.token.symbol } minted!"
 msgstr ""
 
-#: src/components/tokens/TokenMint.js:107
+#: src/components/tokens/TokenMint.js:109
 msgid "Address is required when not selected automatically"
 msgstr ""
 
-#: src/components/tokens/TokenMint.js:140
+#: src/components/tokens/TokenMint.js:142
 msgid "Automatically select address to receive new tokens"
 msgstr ""
 
-#: src/components/tokens/TokenMint.js:190
+#: src/components/tokens/TokenMint.js:192
 msgid "Create another mint output for you?"
 msgstr ""
 
-#: src/components/tokens/TokenMint.js:221
+#: src/components/tokens/TokenMint.js:224
 msgid "Minting tokens"
 msgstr ""
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -95,11 +95,6 @@ export const networkUpdate = data => ({ type: 'network_update', payload: data })
 export const lastFailedRequest = data => ({ type: 'last_failed_request', payload: data });
 
 /**
- * Save words in Redux (it's always cleaned after the use)
- */
-export const updateWords = data => ({ type: 'update_words', payload: data });
-
-/**
  * Update token that is selected in the wallet
  */
 export const selectToken = data => ({ type: 'select_token', payload: data });

--- a/src/components/ModalBackupWords.js
+++ b/src/components/ModalBackupWords.js
@@ -74,6 +74,7 @@ class ModalBackupWords extends React.Component {
   };
 
   componentWillUnmount = () => {
+    this.setState({ words: '' }); // Being extra cautious with sensitive information
     $('#backupWordsModal').modal('hide');
     // Removing all event listeners
     $('#backupWordsModal').off();
@@ -172,6 +173,7 @@ class ModalBackupWords extends React.Component {
       return;
     }
     if (validationStep.last) {
+      this.setState({ words: '' }); // Being extra cautious with sensitive information
       this.props.validationSuccess();
       return;
     }

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -61,8 +61,6 @@ const initialState = {
   lastFailedRequest: undefined,
   // Status code of last failed response
   requestErrorStatusCode: undefined,
-  // Wallet words
-  words: undefined,
   // Tokens already saved: array of objects
   // {'name', 'symbol', 'uid'}
   tokens: [hathorLib.constants.HATHOR_TOKEN_CONFIG],
@@ -159,8 +157,6 @@ const rootReducer = (state = initialState, action) => {
       return onCleanData(state, action);
     case 'last_failed_request':
       return Object.assign({}, state, {lastFailedRequest: action.payload});
-    case 'update_words':
-      return Object.assign({}, state, {words: action.payload});
     case 'select_token':
       return Object.assign({}, state, {selectedToken: action.payload});
     case 'new_tokens':

--- a/src/screens/LoadWallet.js
+++ b/src/screens/LoadWallet.js
@@ -80,6 +80,11 @@ function LoadWallet() {
     LOCAL_STORE.unlock();
     // First we clean what can still be there of a last wallet
     wallet.generateWallet(words, '', newPin, password);
+
+    // Being extra cautious with sensitive information
+    setWords('');
+    setPassword('');
+
     LOCAL_STORE.markBackupDone();
     LOCAL_STORE.open(); // Mark this wallet as open, so that it does not appear locked after loading
   }

--- a/src/screens/NewWallet.js
+++ b/src/screens/NewWallet.js
@@ -13,7 +13,6 @@ import logo from '../assets/images/hathor-logo.png';
 import ChoosePassword from '../components/ChoosePassword';
 import ChoosePin from '../components/ChoosePin';
 import HathorAlert from '../components/HathorAlert';
-import { useDispatch } from 'react-redux';
 import hathorLib from '@hathor/wallet-lib';
 import InitialImages from '../components/InitialImages';
 import { GlobalModalContext, MODAL_TYPES } from '../components/GlobalModal';
@@ -33,7 +32,6 @@ import LOCAL_STORE from '../storage';
 function NewWallet() {
   const navigate = useNavigate();
   const context = useContext(GlobalModalContext);
-  const dispatch = useDispatch();
 
   const [words, setWords] = useState('');
   const [password, setPassword] = useState('');
@@ -105,6 +103,11 @@ function NewWallet() {
     // Generate addresses and load data
     LOCAL_STORE.unlock();
     wallet.generateWallet(words, '', newPin, password);
+
+    // Being extra cautious with sensitive information
+    setWords('');
+    setPassword('');
+
     // Mark this wallet as open, so that it does not appear locked after loading
     LOCAL_STORE.open();
   }

--- a/src/screens/NewWallet.js
+++ b/src/screens/NewWallet.js
@@ -13,8 +13,7 @@ import logo from '../assets/images/hathor-logo.png';
 import ChoosePassword from '../components/ChoosePassword';
 import ChoosePin from '../components/ChoosePin';
 import HathorAlert from '../components/HathorAlert';
-import { updateWords } from '../actions/index';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import hathorLib from '@hathor/wallet-lib';
 import InitialImages from '../components/InitialImages';
 import { GlobalModalContext, MODAL_TYPES } from '../components/GlobalModal';
@@ -36,9 +35,7 @@ function NewWallet() {
   const context = useContext(GlobalModalContext);
   const dispatch = useDispatch();
 
-  const { words } = useSelector(state => ({
-    words: state.words,
-  }));
+  const [words, setWords] = useState('');
   const [password, setPassword] = useState('');
   const [step2, setStep2] = useState(false);
   const [askPassword, setAskPassword] = useState(false);
@@ -55,8 +52,8 @@ function NewWallet() {
     const isValid = confirmFormRef.current.checkValidity();
     if (isValid) {
       confirmFormRef.current.classList.remove('was-validated')
-      const words = hathorLib.walletUtils.generateWalletWords(hathorLib.constants.HD_WALLET_ENTROPY);
-      dispatch(updateWords(words));
+      const newWords = hathorLib.walletUtils.generateWalletWords(hathorLib.constants.HD_WALLET_ENTROPY);
+      setWords(newWords);
       setStep2(true);
     } else {
       confirmFormRef.current.classList.add('was-validated')
@@ -85,6 +82,7 @@ function NewWallet() {
    */
   const backupNow = () => {
     context.showModal(MODAL_TYPES.BACKUP_WORDS, {
+      words,
       needPassword: false,
       validationSuccess,
     });
@@ -109,8 +107,6 @@ function NewWallet() {
     wallet.generateWallet(words, '', newPin, password);
     // Mark this wallet as open, so that it does not appear locked after loading
     LOCAL_STORE.open();
-    // Clean words from redux
-    dispatch(updateWords(null));
   }
 
   /**

--- a/src/screens/Wallet.js
+++ b/src/screens/Wallet.js
@@ -26,7 +26,7 @@ import BackButton from '../components/BackButton';
 import { colors } from '../constants';
 import { TOKEN_DOWNLOAD_STATUS } from '../sagas/tokens';
 import { GlobalModalContext, MODAL_TYPES } from '../components/GlobalModal';
-import { tokenFetchBalanceRequested, tokenFetchHistoryRequested, updateWords, } from '../actions/index';
+import { tokenFetchBalanceRequested, tokenFetchHistoryRequested } from '../actions/index';
 import LOCAL_STORE from '../storage';
 import { useNavigate } from 'react-router-dom';
 import { getGlobalWallet } from "../modules/wallet";
@@ -210,7 +210,6 @@ function Wallet() {
       context.hideModal();
       LOCAL_STORE.markBackupDone();
 
-      dispatch(updateWords(null));
       setBackupDone(true);
       setSuccessMessage(t`Backup completed!`);
       alertSuccessRef.current.show(3000);

--- a/src/screens/WalletVersionError.js
+++ b/src/screens/WalletVersionError.js
@@ -10,7 +10,7 @@ import { t } from 'ttag';
 import logo from '../assets/images/hathor-white-logo.png';
 import Version from '../components/Version';
 import HathorAlert from '../components/HathorAlert';
-import { updateWords, walletReset } from '../actions/index';
+import { walletReset } from '../actions/index';
 import { useDispatch } from "react-redux";
 import { GlobalModalContext, MODAL_TYPES } from '../components/GlobalModal';
 import LOCAL_STORE from '../storage';
@@ -35,7 +35,6 @@ function WalletVersionError() {
   const backupSuccess = () => {
     context.hideModal();
     LOCAL_STORE.markBackupDone();
-    dispatch(updateWords(null));
     alertSuccessRef.current.show(3000);
   }
 


### PR DESCRIPTION
This PR removes the Seed Words from Redux, and instead keeps it in the smallest scope possible within the component state of the `NewWallet` and `ModalBackupWords` screens.

This avoids any future bugs where the Redux store cleanup fails or even security issues should the Redux store happen to leak.

### Acceptance Criteria
- The seed words should never be stored on Redux

### Notes
The translations file also had to be updated, as there were changes to the screen component files.

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
