### PR TITLE
fix: Router for Electron on release build

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ import './i18nInit';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import ErrorWrapper from './ErrorWrapper';
-import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import { createHashRouter, RouterProvider } from 'react-router-dom';
 import { GlobalModal } from './components/GlobalModal';
 
 import 'bootstrap';
@@ -20,7 +20,12 @@ import './index.css';
 import store from "./store/index";
 import { Provider } from "react-redux";
 
-const routerInstance = createBrowserRouter([
+/*
+ * We use a HashRouter for this application because when it is built for production we no longer interact with
+ * a regular HTTP server, but instead with a filesystem.
+ * @see https://reactrouter.com/en/main/routers/create-hash-router
+ */
+const routerInstance = createHashRouter([
   { path: '*', element: <ErrorWrapper /> },
 ])
 


### PR DESCRIPTION
### Acceptance Criteria
- The production build of the application within Electron should work correctly

### Summary of the error
After the upgrade to React Router v6 ( #555 ) our production-built router stopped working: all requests were being redirected to the 404 page.

Upon investigation it was identified that the router's `location.pathname` was being retrieved with the full file path ( ex.: `/tmp/.mount_HathorUnoEsq/resources/app.asar/build/index.html/welcome` ) instead of a relative path from the root of the application ( ex.: `/welcome` ).

### Solution description
Some issues[^1][^2] within the React repository, articles[^3] and SO answers[^4] indicate that switching the router type is a reasonable solution. There is a possibility of configuring the `BrowserRouter` to work with the Electron production builds, but that would involve more research, trial and error and possibly more maintenance in future modifications.

This solution only changed two lines of the current code and is an adequate solution for navigation URLs that will not be seen or interacted with by the end user. It's worth noting that the [official docs on the HashRouter](https://reactrouter.com/en/main/routers/create-hash-router) do not recommend its usage, mainly because it wants to ensure full compatibility with modern web servers.

### Notes
Routing on Electron applications can become quite complex, as can be seen by the [electron-router-dom](https://www.npmjs.com/package/electron-router-dom) library: an abstraction built on the React Router itself.

Since our application has only one screen, we don't reach those edge cases, but it's important to keep that in mind for future improvements.

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.

[^1]: [Issue on v5 that also applies to v6](https://github.com/remix-run/react-router/issues/6726#issuecomment-2053682143)
[^2]: [More recent issue on v6](https://github.com/remix-run/react-router/issues/8331#issuecomment-968578588)
[^3]: [Article on using HashRouter on Electron](https://berom0227.medium.com/why-using-hashrouter-in-electron-is-a-win-for-your-sanity-627a55ffbfbc)
[^4]: [SO Answer about v6](https://stackoverflow.com/a/72164742/1123007)