### PR TITLE
feat: Workflow to automatically merge `release` into `master`

### DIFF
--- a/.github/workflows/release-merge.yml
+++ b/.github/workflows/release-merge.yml
@@ -1,0 +1,30 @@
+name: Create PR on Release
+
+# Triggered when a new version is released publicly
+on:
+  release:
+    types: [released]
+
+jobs:
+  create-pull-request:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        id: checkout
+        # https://github.com/actions/checkout/releases/tag/v4.1.6
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
+
+      - name: Create Pull Request
+        id: create_pull
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          # Building the PR Data
+          PR_DATA=$(gh pr create \
+            --title "Merge release into master" \
+            --body "Automated PR to merge `release` branch into `master` based on release event." \
+            --base "master" \
+            --head "release" \
+            --assignee "@me")
+          echo "Merge PR url: $PR_DATA"

--- a/.github/workflows/release-merge.yml
+++ b/.github/workflows/release-merge.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           # Building the PR Data
           PR_DATA=$(gh pr create \
-            --title "Merge release into master" \
+            --title "[${{ github.ref_name }}] Merge release into master" \
             --body "Automated PR to merge `release` branch into `master` based on release event." \
             --base "master" \
             --head "release" \


### PR DESCRIPTION
This is the first version of this automation, with a simple PR creation to ensure the merge is always done for each new public version of the application.

### Acceptance Criteria
- Creates a new workflow to automatically merge `release` into `master` whenever a public version is released

### Future Improvements
#### 1) Add the PR to Hathor's main Project
This requires specific permissions on the workflow GitHub Token, so will be implemented and tested separately

#### 2) Add the Code Owners as reviewers
This requires parsing specific text syntax from [`CODEOWNERS`](https://github.com/HathorNetwork/hathor-wallet/blob/master/.github/CODEOWNERS). So this will be done after the simplest solution is operational.

#### 3) Send a message to Slack informing about the new release
This workflow will be the best place to implement this solution, but will be done at a later moment to allow for a quick release now

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
