### PR TITLE
feat: add data output to token transaction

### DIFF
--- a/locale/texts.pot
+++ b/locale/texts.pot
@@ -594,7 +594,7 @@ msgstr ""
 msgid "Add data output"
 msgstr ""
 
-#: src/components/atomic-swap/ModalAtomicSend.js:296
+#: src/components/atomic-swap/ModalAtomicSend.js:298
 #: src/screens/SendTokens.js:627
 #: src/screens/SendTokens.js:639
 msgid "Send Tokens"
@@ -1339,7 +1339,7 @@ msgid "Create"
 msgstr ""
 
 #: src/components/SendDataOutputOne.js:29
-#: src/components/SendTokensOne.js:244
+#: src/components/SendTokensOne.js:245
 #: src/screens/atomic-swap/ProposalList.js:107
 msgid "Remove"
 msgstr ""
@@ -2005,7 +2005,7 @@ msgstr ""
 msgid "Data content"
 msgstr ""
 
-#: src/components/SendTokensOne.js:201
+#: src/components/SendTokensOne.js:202
 msgid "Select token"
 msgstr ""
 

--- a/locale/texts.pot
+++ b/locale/texts.pot
@@ -518,7 +518,7 @@ msgstr ""
 msgid "You tried to access a page that does not exist in Hathor Wallet"
 msgstr ""
 
-#: src/screens/SendTokens.js:146
+#: src/screens/SendTokens.js:147
 msgid "Invalid custom tokens"
 msgstr ""
 
@@ -526,28 +526,28 @@ msgstr ""
 #: src/components/ModalAlertNotSupported.js:34
 #: src/components/ModalLedgerResetTokenSignatures.js:122
 #: src/components/ModalLedgerSignToken.js:243
-#: src/screens/SendTokens.js:147
-#: src/screens/SendTokens.js:274
-#: src/screens/SendTokens.js:447
+#: src/screens/SendTokens.js:148
+#: src/screens/SendTokens.js:284
+#: src/screens/SendTokens.js:457
 msgid "Close"
 msgstr ""
 
-#: src/screens/SendTokens.js:204
-#: src/screens/SendTokens.js:331
+#: src/screens/SendTokens.js:214
+#: src/screens/SendTokens.js:341
 msgid "Validate outputs on Ledger"
 msgstr ""
 
-#: src/screens/SendTokens.js:272
+#: src/screens/SendTokens.js:282
 #.  there are tokens without signatures, missingSigs
 #.  set tittle and content
 msgid "Unverified custom tokens"
 msgstr ""
 
-#: src/screens/SendTokens.js:361
+#: src/screens/SendTokens.js:371
 msgid "Sending transaction"
 msgstr ""
 
-#: src/screens/SendTokens.js:434
+#: src/screens/SendTokens.js:444
 #.  Custom token not allowed for this Ledger version
 msgid ""
 "Unfortunately this feature is not supported with the Hathor app version on "
@@ -555,7 +555,7 @@ msgid ""
 "the most recent Hathor app."
 msgstr ""
 
-#: src/screens/SendTokens.js:442
+#: src/screens/SendTokens.js:452
 #.  limit is 10 custom tokens per tx
 #, javascript-format
 msgid ""
@@ -563,37 +563,55 @@ msgid ""
 "per transaction."
 msgstr ""
 
-#: src/screens/SendTokens.js:445
+#: src/screens/SendTokens.js:455
 msgid "Token limit reached"
 msgstr ""
 
-#: src/screens/SendTokens.js:454
+#: src/screens/SendTokens.js:464
 msgid "All your tokens were already added"
 msgstr ""
 
-#: src/screens/SendTokens.js:519
+#: src/screens/SendTokens.js:529
 msgid ""
 "Please go to you Ledger and validate each output of your transaction. Press "
 "both buttons in case the output is correct."
 msgstr ""
 
-#: src/screens/SendTokens.js:520
+#: src/screens/SendTokens.js:530
 msgid "In the end, a final screen will ask you to confirm sending the transaction."
 msgstr ""
 
 #: src/components/tokens/TokenAction.js:147
-#: src/screens/SendTokens.js:552
+#: src/screens/SendTokens.js:592
 msgid "Loading metadata..."
 msgstr ""
 
-#: src/screens/SendTokens.js:560
+#: src/screens/SendTokens.js:606
+msgid "Add data output"
+msgstr ""
+
+#: src/screens/SendTokens.js:613
 msgid "Add another token"
 msgstr ""
 
-#: src/components/atomic-swap/ModalAtomicSend.js:298
-#: src/screens/SendTokens.js:561
-#: src/screens/SendTokens.js:572
+#: src/components/atomic-swap/ModalAtomicSend.js:296
+#: src/screens/SendTokens.js:620
+#: src/screens/SendTokens.js:632
 msgid "Send Tokens"
+msgstr ""
+
+#: src/screens/SendTokens.js:641
+msgid "Data Output"
+msgstr ""
+
+#: src/components/SendTokensOne.js:244
+#: src/screens/SendTokens.js:647
+#: src/screens/atomic-swap/ProposalList.js:107
+msgid "Remove"
+msgstr ""
+
+#: src/screens/SendTokens.js:654
+msgid "Data content"
 msgstr ""
 
 #: src/screens/SentryPermission.js:71

--- a/locale/texts.pot
+++ b/locale/texts.pot
@@ -518,7 +518,7 @@ msgstr ""
 msgid "You tried to access a page that does not exist in Hathor Wallet"
 msgstr ""
 
-#: src/screens/SendTokens.js:147
+#: src/screens/SendTokens.js:156
 msgid "Invalid custom tokens"
 msgstr ""
 
@@ -526,28 +526,28 @@ msgstr ""
 #: src/components/ModalAlertNotSupported.js:34
 #: src/components/ModalLedgerResetTokenSignatures.js:122
 #: src/components/ModalLedgerSignToken.js:243
-#: src/screens/SendTokens.js:148
-#: src/screens/SendTokens.js:284
-#: src/screens/SendTokens.js:457
+#: src/screens/SendTokens.js:157
+#: src/screens/SendTokens.js:293
+#: src/screens/SendTokens.js:466
 msgid "Close"
 msgstr ""
 
-#: src/screens/SendTokens.js:214
-#: src/screens/SendTokens.js:341
+#: src/screens/SendTokens.js:223
+#: src/screens/SendTokens.js:350
 msgid "Validate outputs on Ledger"
 msgstr ""
 
-#: src/screens/SendTokens.js:282
+#: src/screens/SendTokens.js:291
 #.  there are tokens without signatures, missingSigs
 #.  set tittle and content
 msgid "Unverified custom tokens"
 msgstr ""
 
-#: src/screens/SendTokens.js:371
+#: src/screens/SendTokens.js:380
 msgid "Sending transaction"
 msgstr ""
 
-#: src/screens/SendTokens.js:444
+#: src/screens/SendTokens.js:453
 #.  Custom token not allowed for this Ledger version
 msgid ""
 "Unfortunately this feature is not supported with the Hathor app version on "
@@ -555,7 +555,7 @@ msgid ""
 "the most recent Hathor app."
 msgstr ""
 
-#: src/screens/SendTokens.js:452
+#: src/screens/SendTokens.js:461
 #.  limit is 10 custom tokens per tx
 #, javascript-format
 msgid ""
@@ -563,55 +563,41 @@ msgid ""
 "per transaction."
 msgstr ""
 
-#: src/screens/SendTokens.js:455
+#: src/screens/SendTokens.js:464
 msgid "Token limit reached"
 msgstr ""
 
-#: src/screens/SendTokens.js:464
+#: src/screens/SendTokens.js:473
 msgid "All your tokens were already added"
 msgstr ""
 
-#: src/screens/SendTokens.js:529
+#: src/screens/SendTokens.js:538
 msgid ""
 "Please go to you Ledger and validate each output of your transaction. Press "
 "both buttons in case the output is correct."
 msgstr ""
 
-#: src/screens/SendTokens.js:530
+#: src/screens/SendTokens.js:539
 msgid "In the end, a final screen will ask you to confirm sending the transaction."
 msgstr ""
 
 #: src/components/tokens/TokenAction.js:147
-#: src/screens/SendTokens.js:592
+#: src/screens/SendTokens.js:599
 msgid "Loading metadata..."
-msgstr ""
-
-#: src/screens/SendTokens.js:606
-msgid "Add data output"
 msgstr ""
 
 #: src/screens/SendTokens.js:613
 msgid "Add another token"
 msgstr ""
 
-#: src/components/atomic-swap/ModalAtomicSend.js:296
 #: src/screens/SendTokens.js:620
-#: src/screens/SendTokens.js:632
+msgid "Add data output"
+msgstr ""
+
+#: src/components/atomic-swap/ModalAtomicSend.js:296
+#: src/screens/SendTokens.js:627
+#: src/screens/SendTokens.js:639
 msgid "Send Tokens"
-msgstr ""
-
-#: src/screens/SendTokens.js:641
-msgid "Data Output"
-msgstr ""
-
-#: src/components/SendTokensOne.js:244
-#: src/screens/SendTokens.js:647
-#: src/screens/atomic-swap/ProposalList.js:107
-msgid "Remove"
-msgstr ""
-
-#: src/screens/SendTokens.js:654
-msgid "Data content"
 msgstr ""
 
 #: src/screens/SentryPermission.js:71
@@ -1352,7 +1338,8 @@ msgstr ""
 msgid "Create"
 msgstr ""
 
-#: src/components/SendTokensOne.js:245
+#: src/components/SendDataOutputOne.js:29
+#: src/components/SendTokensOne.js:244
 #: src/screens/atomic-swap/ProposalList.js:107
 msgid "Remove"
 msgstr ""
@@ -2010,7 +1997,15 @@ msgstr ""
 msgid "Retry request"
 msgstr ""
 
-#: src/components/SendTokensOne.js:202
+#: src/components/SendDataOutputOne.js:23
+msgid "Data Output"
+msgstr ""
+
+#: src/components/SendDataOutputOne.js:36
+msgid "Data content"
+msgstr ""
+
+#: src/components/SendTokensOne.js:201
 msgid "Select token"
 msgstr ""
 

--- a/src/components/OutputData.js
+++ b/src/components/OutputData.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import { t } from 'ttag';
+
+/**
+ * It renders a card containing a input field for the data cotent as string,
+ * and an action to remove the card.
+ *
+ * @param {Object} props
+ * @property {MutableRefObject} dataInputRef Reference for input field value
+ * @property {number} index Data output position in the list
+ * @property {(index: number) => void} remove Callback to remove the data output from the list
+ */
+export const OutputData = ({ dataInputRef, index, remove }) => (
+  <div className='send-tokens-wrapper card'>
+    <div className="outputs-wrapper">
+      <label>{t`Data Output`}</label>
+      <button
+        type="button"
+        className="text-danger remove-token-btn ml-3"
+        onClick={() => remove(index)}
+      >
+        {t`Remove`}
+      </button>
+      <div className="input-group mb-3">
+        <input
+          className="form-control output-address col-5"
+          type="text"
+          ref={dataInputRef}
+          placeholder={t`Data content`}
+        />
+      </div>
+    </div>
+  </div>
+);

--- a/src/components/SendDataOutputOne.js
+++ b/src/components/SendDataOutputOne.js
@@ -9,7 +9,7 @@ import React from 'react';
 import { t } from 'ttag';
 
 /**
- * It renders a card containing a input field for the data cotent as string,
+ * It renders a card containing an input field for the data content as string,
  * and an action to remove the card.
  *
  * @param {Object} props

--- a/src/components/SendDataOutputOne.js
+++ b/src/components/SendDataOutputOne.js
@@ -17,7 +17,7 @@ import { t } from 'ttag';
  * @property {number} index Data output position in the list
  * @property {(index: number) => void} remove Callback to remove the data output from the list
  */
-export const OutputData = ({ dataInputRef, index, remove }) => (
+export const SendDataOutputOne = ({ dataInputRef, index, remove }) => (
   <div className='send-tokens-wrapper card'>
     <div className="outputs-wrapper">
       <label>{t`Data Output`}</label>

--- a/src/screens/SendTokens.js
+++ b/src/screens/SendTokens.js
@@ -23,6 +23,7 @@ import LOCAL_STORE from '../storage';
 import { useNavigate } from 'react-router-dom';
 import { getGlobalWallet } from "../modules/wallet";
 import { OutputType } from '@hathor/wallet-lib/lib/wallet/types';
+import { OutputData } from '../components/OutputData';
 
 /** @typedef {0|1} LEDGER_MODAL_STATE */
 const LEDGER_MODAL_STATE = {
@@ -67,6 +68,8 @@ function SendTokens() {
   const [errorMessage, setErrorMessage] = useState('');
   /** txTokens {Array} Array of tokens configs already added by the user (start with only hathor) */
   const [txTokens, setTxTokens] = useState([...getSelectedToken()]);
+  /** dataOutputs {Array} Array of data output added by the user */
+  const [dataOutputs, setDataOutputs] = useState([]);
 
   // Create refs
   const formSendTokensRef = useRef();
@@ -76,6 +79,12 @@ function SendTokens() {
    * @type MutableRefObject<SendTransaction>
    */
   const sendTransactionRef = useRef(null);
+  /**
+   * It contains a map of data output ref values by its unique ID.
+   * @type MutableRefObject<{ [uniqueRefId: string]: MutableRefObject }>
+   */
+  const dataOutputRefs = useRef({});
+
 
   // Convert componentDidMount and componentWillUnmount
   useEffect(() => {
@@ -557,11 +566,6 @@ function SendTokens() {
     });
   }
 
-  // It must be a state to make component render for every change.
-  const [dataOutputs, setDataOutputs] = useState([]);
-  // Scheme: { current: { [uniqueRefId: string]: MutableRefObject } }
-  const dataOutputRefs = useRef({});
-
   const addDataOutput = () => {
     const uId = _.uniqueId('data_output');
     setDataOutputs([...dataOutputs, uId]);
@@ -576,6 +580,9 @@ function SendTokens() {
     ]);
   };
 
+  /**
+   * It renders a list of data output as cards.
+   */
   const renderDataOutputs = () => (
     dataOutputs.map((uId, index) => (
       <OutputData
@@ -634,28 +641,5 @@ function SendTokens() {
     </div>
   );
 }
-
-const OutputData = ({ dataInputRef, index, remove }) => (
-  <div className='send-tokens-wrapper card'>
-    <div className="outputs-wrapper">
-      <label>{t`Data Output`}</label>
-      <button
-        type="button"
-        className="text-danger remove-token-btn ml-3"
-        onClick={() => remove(index)}
-      >
-        {t`Remove`}
-      </button>
-      <div className="input-group mb-3">
-        <input
-          className="form-control output-address col-5"
-          type="text"
-          ref={dataInputRef}
-          placeholder={t`Data content`}
-        />
-      </div>
-    </div>
-  </div>
-);
 
 export default SendTokens;

--- a/src/screens/SendTokens.js
+++ b/src/screens/SendTokens.js
@@ -23,7 +23,7 @@ import LOCAL_STORE from '../storage';
 import { useNavigate } from 'react-router-dom';
 import { getGlobalWallet } from "../modules/wallet";
 import { OutputType } from '@hathor/wallet-lib/lib/wallet/types';
-import { OutputData } from '../components/OutputData';
+import { SendDataOutputOne } from '../components/SendDataOutputOne';
 
 /** @typedef {0|1} LEDGER_MODAL_STATE */
 const LEDGER_MODAL_STATE = {
@@ -585,7 +585,7 @@ function SendTokens() {
    */
   const renderDataOutputs = () => (
     dataOutputs.map((uId, index) => (
-      <OutputData
+      <SendDataOutputOne
         key={uId}
         dataInputRef={dataOutputRefs.current[uId]}
         index={index}
@@ -608,16 +608,16 @@ function SendTokens() {
             <button
               type="button"
               className="btn btn-secondary mr-4"
-              onClick={addDataOutput}
+              onClick={addAnotherToken}
             >
-              {t`Add data output`}
+              {t`Add another token`}
             </button>
             <button
               type="button"
               className="btn btn-secondary mr-4"
-              onClick={addAnotherToken}
+              onClick={addDataOutput}
             >
-              {t`Add another token`}
+              {t`Add data output`}
             </button>
             <button
               type="button"


### PR DESCRIPTION
### Acceptance Criteria
- It should add "Add data output" button on Token Transaction screen
- It should add a new tile in the list of tokens representing a data output when "Add data output" is clicked 
- It should have a "Remove" button on each data output tile
- It should remove the data output tile itself when "Remove" is clicked
- It should add each data output to transaction's outputs as a `data` output, converting any input value to a string

##### Initial Screen
<img alt="Initial Screen" height="600" src="https://github.com/HathorNetwork/hathor-wallet/assets/5992210/98a37139-77c4-4d49-9c5d-cb1ddde5c49c" />

##### Add a Data Output
<img alt="Transaction with 1 Data Output" height="600" src="https://github.com/HathorNetwork/hathor-wallet/assets/5992210/78cac438-9ef8-4c08-9a08-b9601bbe2251" />

##### Add another Data Output

<img alt="Transaction with 2 Data Output" height="600" src="https://github.com/HathorNetwork/hathor-wallet/assets/5992210/c52cdcc1-616e-4990-99b3-e1745ca563d3" />

##### Remove the first Data Output

<img alt="Transaction without the first Data Output added" src="https://github.com/HathorNetwork/hathor-wallet/assets/5992210/7a5a0727-49d2-4473-b2ef-d3ede0b86ec3" />

##### Example

The following transaction is an example of a token transaction sent with data output.
https://explorer.testnet.hathor.network/transaction/00002a0dabb26966a74f67522db275d7174dfdfc3c151c4d1d788f4daa0b16c9

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
