### PR TITLE
fix: save tx mining server on the lib config when wallet is started

### DIFF
--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -70,8 +70,9 @@ const helpers = {
       }
     }
 
-    let miningServer = LOCAL_STORE.getMiningServer();
+    const miningServer = LOCAL_STORE.getMiningServer();
     if (miningServer) {
+      hathorLib.config.setTxMiningUrl(miningServer);
       store.dispatch(setMiningServer(miningServer));
     }
   },


### PR DESCRIPTION
### Acceptance Criteria
- We should update the tx mining service URL in the lib config when the wallet is started

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
