### PR TITLE
docs: Checksum validation on SHORT_QA

### DIFF
--- a/SHORT_QA.md
+++ b/SHORT_QA.md
@@ -1,6 +1,7 @@
 # Test sequence
 
 1. Make sure you have the latest stable version of the desktop wallet installed with a loaded wallet that has at least one transaction.
+1. Download the new version and validate its SHA256 checksum against the one present in the release files
 1. Install the new version that must be tested and unlock your loaded wallet.
 1. Check that the transactions are listed correctly.
 1. Check that the balance is correct.


### PR DESCRIPTION
### Acceptance Criteria
- The short QA must validate the checksum of the binaries


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
