### PR TITLE
fix: a nano contract might have no argument, so the render method should consider this

### DIFF
--- a/src/components/TxData.js
+++ b/src/components/TxData.js
@@ -917,6 +917,10 @@ class TxData extends React.Component {
     }
 
     const renderNCArguments = (args) => {
+      if (!Array.isArray(args) || args.length === 0) {
+        return ' - ';
+      }
+
       return args.map((arg) => (
         <div key={arg.name}>
           <label>{arg.name}:</label> {renderArgValue(arg)}


### PR DESCRIPTION

### Acceptance Criteria
- Method to render nano arguments should consider a tx without arguments


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
