### PR TITLE
feat: create a reset navigation link component to be used by the nano contract detail screen

### DIFF
--- a/src/components/BackButton.js
+++ b/src/components/BackButton.js
@@ -8,6 +8,7 @@
 import React from 'react';
 import { t } from 'ttag';
 import { useNavigate } from 'react-router-dom';
+import ResetNavigationLink from './ResetNavigationLink';
 
 
 /**
@@ -20,20 +21,12 @@ function BackButton() {
 
   /**
    * Called when link is clicked and goes back one page
-   *
-   * @param {Object} e Event emitted when link is clicked
    */
-  const goBack = (e) => {
-    e.preventDefault();
+  const goBack = () => {
     navigate(-1);
   }
 
-  return (
-    <div className="d-flex flex-row align-items-center back-div mb-3">
-      <i className="fa fa-long-arrow-left mr-2" />
-      <a href="true" onClick={(e) => goBack(e)}>{t`Back`}</a>
-    </div>
-  )
+  return <ResetNavigationLink to={goBack} name={t`Back`} />;
 }
 
 export default BackButton;

--- a/src/components/ResetNavigationLink.js
+++ b/src/components/ResetNavigationLink.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+
+
+/**
+ * Component that has a left arrow and a link to another page
+ *
+ * @memberof Components
+ */
+function ResetNavigationLink({ to, name }) {
+  /**
+   * Called when link is clicked
+   *
+   * @param {Object} e Event emitted when link is clicked
+   */
+  const go = (e) => {
+    e.preventDefault();
+    to();
+  }
+
+  return (
+    <div className="d-flex flex-row align-items-center back-div mb-3">
+      <i className="fa fa-long-arrow-left mr-2" />
+      <a href="true" onClick={(e) => go(e)}>{name}</a>
+    </div>
+  )
+}
+
+export default ResetNavigationLink;

--- a/src/components/ResetNavigationLink.js
+++ b/src/components/ResetNavigationLink.js
@@ -11,6 +11,9 @@ import React from 'react';
 /**
  * Component that has a left arrow and a link to another page
  *
+ * @param props.to Method that will be used to navigate to another screen
+ * @param props.name Name of the link
+ *
  * @memberof Components
  */
 function ResetNavigationLink({ to, name }) {

--- a/src/screens/nano/NanoContractDetail.js
+++ b/src/screens/nano/NanoContractDetail.js
@@ -8,7 +8,7 @@
 import React, { useContext, useEffect, useState } from 'react';
 import { t } from 'ttag'
 import $ from 'jquery';
-import BackButton from '../../components/BackButton';
+import ResetNavigationLink from '../../components/ResetNavigationLink';
 import ReactLoading from 'react-loading';
 import colors from '../../index.module.scss';
 import ModalChangeAddress from '../../components/nano/ModalChangeAddress';
@@ -207,6 +207,13 @@ function NanoContractDetail() {
     helpers.openExternalURL(url);
   }
 
+  /**
+   * Method called when user clicked the link to go to the nano list
+   */
+  const goToRegisteredList = () => {
+    navigate('/nano_contract/');
+  }
+
   const renderNanoBalances = () => {
     return Object.entries(data.balances).map(([tokenUid, amount]) => {
       return (
@@ -266,7 +273,7 @@ function NanoContractDetail() {
 
   return (
     <div className="content-wrapper">
-      <BackButton />
+      <ResetNavigationLink name={t`Go to list`} to={goToRegisteredList} />
       <h3 className="mt-4">{t`Nano Contract Detail`}</h3>
       <div className="mt-5">
         <p><strong>ID: </strong>{ncId} <span className="ml-1">(<a href="true" onClick={unregister}>{t`Unregister`}</a>)</span></p>


### PR DESCRIPTION
### Context

The back button of the Nano Contract Detail screen was working fine when we clicked a nano contract from the registered link. However, after creating a new nano contract, or after executing a nano contract method, the back button was navigating to the form screen, instead of the Registered list screen.

I created a new component that has a link to navigate to any screen.

### Acceptance Criteria
- Add `ResetNavigationLink` component and use it in the nano contract detail screen.
- BackButton component should use this new navigation link component.


https://github.com/user-attachments/assets/1e6ab7eb-54d5-4d1f-aeeb-8838b242eaa4


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
