### PR TITLE
refactor: use lib methods to avoid duplicate code

### DIFF
--- a/src/screens/Server.js
+++ b/src/screens/Server.js
@@ -161,15 +161,7 @@ function Server() {
       const versionData = await wallet.getVersionData();
 
       if (versionData.network !== 'mainnet') {
-        const network = versionData.network;
-        let newSelectedNetwork = network;
-
-        // Network might be 'testnet-golf', 'testnet-charlie', 'nano-testnet-alpha'
-        if (network.includes('testnet')) {
-          newSelectedNetwork = 'testnet';
-        } else {
-          newSelectedNetwork = 'privatenet';
-        }
+        const newSelectedNetwork = hathorLib.helpersUtils.getNetworkFromFullNodeNetwork(versionData.network);
 
         // Go back to the previous server
         // If the user decides to continue with this change, we will update again

--- a/src/screens/nano/NanoContractDetail.js
+++ b/src/screens/nano/NanoContractDetail.js
@@ -236,7 +236,7 @@ function NanoContractDetail() {
   const renderNanoMethods = () => {
     const publicMethods = get(blueprintInformation, 'public_methods', {});
     return Object.keys(publicMethods).filter((method) =>
-      method !== 'initialize'
+      method !== hathorLib.constants.NANO_CONTRACTS_INITIALIZE_METHOD
     ).map((method) => {
       return (
         <div key={method}>

--- a/src/screens/nano/NanoContractSelectBlueprint.js
+++ b/src/screens/nano/NanoContractSelectBlueprint.js
@@ -62,7 +62,7 @@ function NanoContractSelectBlueprint() {
     navigate('/nano_contract/execute_method/', {
       state: {
         blueprintInformation,
-        method: 'initialize'
+        method: hathorLib.constants.NANO_CONTRACTS_INITIALIZE_METHOD
       },
     });
   }

--- a/src/utils/version.js
+++ b/src/utils/version.js
@@ -46,12 +46,7 @@ const version = {
     }));
 
     // Set network in lib to use the correct address byte
-    let network = data.network;
-
-    if (data.network.includes('testnet')) {
-      network = 'testnet';
-    }
-
+    const network = hathorLib.helpersUtils.getNetworkFromFullNodeNetwork(data.network);
     helpers.updateNetwork(network);
     return {
       ...data,


### PR DESCRIPTION
### Acceptance Criteria
- Use `getNetworkFromFullNodeNetwork` from lib helpers utils to get wallet network from full node network.
- Use constant for nano contract initialize method string from the lib instead of hardcoded string.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
