### PR TITLE
feat: add modal to help user to select an address to sign the nano initialize tx

### DIFF
--- a/src/components/GlobalModal.js
+++ b/src/components/GlobalModal.js
@@ -26,6 +26,7 @@ import ModalRegisterNanoContract from "./nano/ModalRegisterNanoContract";
 import ModalChangeAddress from "./nano/ModalChangeAddress";
 import ModalConfirmUnregister from "./nano/ModalConfirmUnregister";
 import ModalSelectAddressToSignData from "./nano/ModalSelectAddressToSignData";
+import ModalSelectAddressToSignTx from "./nano/ModalSelectAddressToSignTx";
 import { ModalAtomicSend } from "./atomic-swap/ModalAtomicSend";
 import { ModalAtomicReceive } from "./atomic-swap/ModalAtomicReceive";
 import { ModalAtomicExternalChange } from "./atomic-swap/ExternalChangeModal";
@@ -59,6 +60,7 @@ export const MODAL_TYPES = {
   'NANOCONTRACT_CHANGE_ADDRESS': 'NANOCONTRACT_CHANGE_ADDRESS',
   'NANOCONTRACT_CONFIRM_UNREGISTER': 'NANOCONTRACT_CONFIRM_UNREGISTER',
   'NANOCONTRACT_SELECT_ADDRESS_TO_SIGN_DATA': 'NANOCONTRACT_SELECT_ADDRESS_TO_SIGN_DATA',
+  'NANOCONTRACT_SELECT_ADDRESS_TO_SIGN_TX': 'NANOCONTRACT_SELECT_ADDRESS_TO_SIGN_TX',
 };
 
 export const MODAL_COMPONENTS = {
@@ -84,6 +86,7 @@ export const MODAL_COMPONENTS = {
   [MODAL_TYPES.NANOCONTRACT_CHANGE_ADDRESS]: ModalChangeAddress,
   [MODAL_TYPES.NANOCONTRACT_CONFIRM_UNREGISTER]: ModalConfirmUnregister,
   [MODAL_TYPES.NANOCONTRACT_SELECT_ADDRESS_TO_SIGN_DATA]: ModalSelectAddressToSignData,
+  [MODAL_TYPES.NANOCONTRACT_SELECT_ADDRESS_TO_SIGN_TX]: ModalSelectAddressToSignTx,
 };
 
 export const GlobalModalContext = createContext(initialState);

--- a/src/components/nano/ModalSelectAddressToSignTx.js
+++ b/src/components/nano/ModalSelectAddressToSignTx.js
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { useEffect, useRef, useState } from 'react';
+import { t } from 'ttag';
+import $ from 'jquery';
+import AddressList from '../../components/AddressList';
+import { NANO_UPDATE_ADDRESS_LIST_COUNT } from '../../constants';
+
+/**
+ * Component that shows a modal to select an address
+ * to sign a nano contract tx
+ *
+ * @param props.onAddressSelect Method to be called when the user clicks an address
+ * @param props.onClose GlobalModal method added in all modals
+ *
+ * @memberof Components
+ */
+function ModalSelectAddressToSignTx({ onClose, onAddressSelect }) {
+  const addressToSignModalID = 'selectAddressToSignTxModal';
+
+  useEffect(() => {
+    $(`#${addressToSignModalID}`).modal('show');
+    $(`#${addressToSignModalID}`).on('hidden.bs.modal', (e) => {
+      // We always need to call on close when using global context modal
+      // it will remove event listeners
+      onClose();
+    })
+  }, []);
+
+  /**
+   * Called when user selects one address, so we close the modal
+   * and fills the address to sign input with the selected address
+   *
+   * @param {string} address Address clicked
+   */
+  const onAddressClick = async (address) => {
+    onClose();
+    onAddressSelect(address);
+  }
+
+  const renderAddressList = () => {
+    return (
+      <div>
+        <p>{t`Select the address that will be used to sign the transaction`}</p>
+        <AddressList
+          showNumberOfTransaction={false}
+          onAddressClick={onAddressClick}
+          count={NANO_UPDATE_ADDRESS_LIST_COUNT}
+          isModal={true}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="modal fade" id={addressToSignModalID} tabIndex="-1" role="dialog" aria-labelledby={addressToSignModalID} aria-hidden="true">
+      <div className="modal-dialog" role="document">
+        <div className="modal-content">
+          <div className="modal-header">
+            <h5 className="modal-title" id="exampleModalLabel">{t`Select address`}</h5>
+            <button type="button" className="close" data-dismiss="modal" aria-label="Close">
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+          <div className="modal-body">
+            {renderAddressList()}
+          </div>
+          <div className="modal-footer">
+            <button type="button" className="btn btn-secondary" data-dismiss="modal">{t`Cancel`}</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ModalSelectAddressToSignTx;

--- a/src/screens/nano/NanoContractExecuteMethod.js
+++ b/src/screens/nano/NanoContractExecuteMethod.js
@@ -319,6 +319,21 @@ function NanoContractExecuteMethod() {
   }
 
   /**
+   * Method executed when link to select an address to sign the tx is clicked
+   *
+   * @param {Object} ref Input reference
+   * @param {Object} e Event emitted by the link clicked
+   */
+  const onSelectAddressToSignTx = (ref, e) => {
+    e.preventDefault();
+    globalModalContext.showModal(MODAL_TYPES.NANOCONTRACT_SELECT_ADDRESS_TO_SIGN_TX, {
+      onAddressSelect: (value) => {
+        ref.current.value = value;
+      },
+    });
+  }
+
+  /**
    * This renders all the options of the token select for a tokenUid argument
    */
   const renderTokenOptions = () => {
@@ -460,6 +475,7 @@ function NanoContractExecuteMethod() {
         <div className="form-group col-6">
           <label>Address to Sign</label>
           <input required ref={addressRef} type="text" className="form-control" />
+          <div className="mt-2"><a href="true" onClick={e => onSelectAddressToSignTx(addressRef, e)}>{t`Select from a list`}</a></div>
         </div>
       </div>
     );


### PR DESCRIPTION
### Acceptance Criteria
- Add link below the input for the Address to Sign tx to open a modal that helps user select an address from the loaded wallet.

https://github.com/user-attachments/assets/91ab7617-739c-4198-a51a-1ceb9aa6f2ba


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
