### PR TITLE
fix: nft creation without data ouput

### DIFF
--- a/src/screens/CreateNFT.js
+++ b/src/screens/CreateNFT.js
@@ -136,7 +136,8 @@ function CreateNFT() {
         symbol,
         parseInt(amount),
         {
-          nftData,
+          data: [nftData],
+          isCreateNFT: true,
           address,
           pinCode: pin,
           createMint,


### PR DESCRIPTION
### Context

This PR https://github.com/HathorNetwork/hathor-wallet-lib/pull/596 changes the method to declare an NFT creation on `prepareCreateNewToken` method, but the wallet desktop wasn't updated.

### Acceptance Criteria

- NFT creation transaction must have a data output

It closes https://github.com/HathorNetwork/internal-issues/issues/397

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
