### PR TITLE
chore(release.sh): Fails if the team id is missing

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -17,6 +17,11 @@ step0() {
 	echo - npm $(npm -v)
 	echo - python $(python --version | awk '{print $2}')
 	echo
+
+	if grep "TEAM-ID-HERE" package.json >/dev/null; then
+		echo [ERROR] Team ID not in package.json.
+		exit -1
+	fi
 }
 
 step1() {


### PR DESCRIPTION
### Acceptance Criteria

1. Fails fast `release.sh` when team id is missing.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
