### PR TITLE
feat: verify is tx is confirmed before getting nc state

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -643,9 +643,9 @@ export const nanoContractDetailSetStatus = ({ status, error }) => ({
 /**
  * Set nano contract detail state in redux
  *
- * @param {hathorLib.nano_contracts.types.NanoContractStateAPIResponse} state
+ * @param {hathorLib.nano_contracts.types.NanoContractStateAPIResponse} ncState
  */
-export const nanoContractDetailLoaded = (state) => ({
-  type: types.NANOCONTRACT_DETAIL_LOADED,
-  state,
+export const nanoContractDetailLoaded = (ncState) => ({
+  type: types.NANOCONTRACT_LOAD_DETAILS_SUCCESS,
+  state: ncState,
 });

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -63,9 +63,9 @@ export const types = {
   NANOCONTRACT_EDIT_ADDRESS: 'NANOCONTRACT_EDIT_ADDRESS',
   NANOCONTRACT_UNREGISTER: 'NANOCONTRACT_UNREGISTER',
   BLUEPRINT_ADD_INFORMATION: 'BLUEPRINT_ADD_INFORMATION',
-  NANOCONTRACT_DETAIL_REQUEST: 'NANO_CONTRACT_DETAIL_REQUEST',
-  NANOCONTRACT_DETAIL_SET_STATUS: 'NANO_CONTRACT_DETAIL_SET_STATUS',
-  NANOCONTRACT_DETAIL_LOADED: 'NANO_CONTRACT_DETAIL_LOADED',
+  NANOCONTRACT_LOAD_DETAILS_REQUESTED: 'NANOCONTRACT_LOAD_DETAILS_REQUESTED',
+  NANOCONTRACT_LOAD_DETAILS_STATUS_UPDATE: 'NANOCONTRACT_LOAD_DETAILS_STATUS_UPDATE',
+  NANOCONTRACT_LOAD_DETAILS_SUCCESS: 'NANOCONTRACT_LOAD_DETAILS_SUCCESS',
 };
 
 /**
@@ -624,7 +624,7 @@ export const nanoContractUnregister = (ncId) => ({
  * @param {string} ncId ID of nano contract to load the data
  */
 export const nanoContractDetailRequest = (ncId) => ({
-  type: types.NANOCONTRACT_DETAIL_REQUEST,
+  type: types.NANOCONTRACT_LOAD_DETAILS_REQUESTED,
   ncId,
 });
 
@@ -636,7 +636,7 @@ export const nanoContractDetailRequest = (ncId) => ({
  * @param {string} payload.error Error when loading data
  */
 export const nanoContractDetailSetStatus = ({ status, error }) => ({
-  type: types.NANOCONTRACT_DETAIL_SET_STATUS,
+  type: types.NANOCONTRACT_LOAD_DETAILS_STATUS_UPDATE,
   payload: { status, error },
 });
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -63,6 +63,9 @@ export const types = {
   NANOCONTRACT_EDIT_ADDRESS: 'NANOCONTRACT_EDIT_ADDRESS',
   NANOCONTRACT_UNREGISTER: 'NANOCONTRACT_UNREGISTER',
   BLUEPRINT_ADD_INFORMATION: 'BLUEPRINT_ADD_INFORMATION',
+  NANOCONTRACT_DETAIL_REQUEST: 'NANO_CONTRACT_DETAIL_REQUEST',
+  NANOCONTRACT_DETAIL_SET_STATUS: 'NANO_CONTRACT_DETAIL_SET_STATUS',
+  NANOCONTRACT_DETAIL_LOADED: 'NANO_CONTRACT_DETAIL_LOADED',
 };
 
 /**
@@ -613,4 +616,36 @@ export const editAddressNC = (ncId, address) => ({
 export const nanoContractUnregister = (ncId) => ({
   type: types.NANOCONTRACT_UNREGISTER,
   payload: ncId,
+});
+
+/**
+ * Start a request to load nano contract detail
+ *
+ * @param {string} ncId ID of nano contract to load the data
+ */
+export const nanoContractDetailRequest = (ncId) => ({
+  type: types.NANOCONTRACT_DETAIL_REQUEST,
+  ncId,
+});
+
+/**
+ * Set status of a nano contract detail load
+ *
+ * @param {Object} payload
+ * @param {string} payload.status Status of the load to set in redux
+ * @param {string} payload.error Error when loading data
+ */
+export const nanoContractDetailSetStatus = ({ status, error }) => ({
+  type: types.NANOCONTRACT_DETAIL_SET_STATUS,
+  payload: { status, error },
+});
+
+/**
+ * Set nano contract detail state in redux
+ *
+ * @param {hathorLib.nano_contracts.types.NanoContractStateAPIResponse} state
+ */
+export const nanoContractDetailLoaded = (state) => ({
+  type: types.NANOCONTRACT_DETAIL_LOADED,
+  state,
 });

--- a/src/constants.js
+++ b/src/constants.js
@@ -296,7 +296,7 @@ export const NANO_CONTRACT_HISTORY_COUNT = 5;
  * Base statuses for saga reducer handlers
  * Used by all other statuses objects
  */
-const SAGA_BASE_STATUS = {
+const BASE_STATUS = {
   READY: 'ready',
   ERROR: 'error',
   LOADING: 'loading',
@@ -307,6 +307,6 @@ const SAGA_BASE_STATUS = {
  * Nano contract detail load data statuses for saga reducer handlers
  */
 export const NANO_CONTRACT_DETAIL_STATUS = {
-  ...SAGA_BASE_STATUS,
+  ...BASE_STATUS,
   WAITING_TX_CONFIRMATION: 'waitingTxConfirmation',
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -291,3 +291,22 @@ export const NANO_UPDATE_ADDRESS_LIST_COUNT = 5;
  * Number of elements in the list of transactions of a nano contract
  */
 export const NANO_CONTRACT_HISTORY_COUNT = 5;
+
+/**
+ * Base statuses for saga reducer handlers
+ * Used by all other statuses objects
+ */
+const SAGA_BASE_STATUS = {
+  READY: 'ready',
+  ERROR: 'error',
+  LOADING: 'loading',
+  SUCCESS: 'success',
+}
+
+/**
+ * Nano contract detail load data statuses for saga reducer handlers
+ */
+export const NANO_CONTRACT_DETAIL_STATUS = {
+  ...SAGA_BASE_STATUS,
+  WAITING_TX_CONFIRMATION: 'waitingTxConfirmation',
+}

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -409,9 +409,9 @@ const rootReducer = (state = initialState, action) => {
       return onNanoContractEditAddress(state, action);
     case types.NANOCONTRACT_UNREGISTER:
       return onNanoContractUnregister(state, action);
-    case types.NANOCONTRACT_DETAIL_SET_STATUS:
+    case types.NANOCONTRACT_LOAD_DETAILS_STATUS_UPDATE:
       return onSetNanoContractDetailStatus(state, action);
-    case types.NANOCONTRACT_DETAIL_LOADED:
+    case types.NANOCONTRACT_LOAD_DETAILS_SUCCESS:
       return onNanoContractDetailLoaded(state, action);
     default:
       return state;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { FEATURE_TOGGLE_DEFAULTS, VERSION } from '../constants';
+import { FEATURE_TOGGLE_DEFAULTS, NANO_CONTRACT_DETAIL_STATUS, VERSION } from '../constants';
 import { types } from '../actions';
 import { get, findIndex } from 'lodash';
 import { TOKEN_DOWNLOAD_STATUS } from '../sagas/tokens';
@@ -251,6 +251,20 @@ const initialState = {
    * }
   */
   blueprintsData: {},
+  /**
+   * Stores the status for requesting data for the nano contract detail screen
+   *
+   * {
+   *   state: hathorLib.nano_contracts.types.NanoContractStateAPIResponse,
+   *   status: NANO_CONTRACT_DETAIL_STATUS,
+   *   error: string | null,
+   * }
+  */
+  nanoContractDetailState: {
+    state: null,
+    status: NANO_CONTRACT_DETAIL_STATUS.READY,
+    error: null,
+  },
 };
 
 const rootReducer = (state = initialState, action) => {
@@ -395,6 +409,10 @@ const rootReducer = (state = initialState, action) => {
       return onNanoContractEditAddress(state, action);
     case types.NANOCONTRACT_UNREGISTER:
       return onNanoContractUnregister(state, action);
+    case types.NANOCONTRACT_DETAIL_SET_STATUS:
+      return onSetNanoContractDetailStatus(state, action);
+    case types.NANOCONTRACT_DETAIL_LOADED:
+      return onNanoContractDetailLoaded(state, action);
     default:
       return state;
   }
@@ -1354,5 +1372,50 @@ export const onNanoContractUnregister = (state, { payload }) => {
     nanoContracts: newNanoContracts,
   };
 };
+
+/**
+ * Set nano contract details status
+ *
+ * @param {Object} state
+ * @param {Object} action
+ * @param {Object} action.payload
+ * @param {string} action.payload.status
+ * @param {string | null | undefined} action.payload.error
+ *
+ * @returns {Object}
+ */
+export const onSetNanoContractDetailStatus = (state, { payload }) => {
+  return {
+    ...state,
+    nanoContractDetailState: {
+      ...state.nanoContractDetailState,
+      status: payload.status,
+      error: payload.error,
+      state: null,
+    }
+  }
+}
+
+/**
+ * Set nano contract loaded state and status to success
+ *
+ * @param {Object} state
+ * @param {Object} action
+ * @param {Object} action.payload
+ * @param {hathorLib.nano_contracts.types.NanoContractStateAPIResponse} action.payload.state
+ *
+ * @returns {Object}
+ */
+export const onNanoContractDetailLoaded = (state, payload) => {
+  return {
+    ...state,
+    nanoContractDetailState: {
+      ...state.nanoContractDetailState,
+      state: payload.state,
+      status: NANO_CONTRACT_DETAIL_STATUS.SUCCESS,
+      error: null,
+    }
+  }
+}
 
 export default rootReducer;

--- a/src/sagas/nanoContract.js
+++ b/src/sagas/nanoContract.js
@@ -140,6 +140,7 @@ export function* updateNanoContractRegisteredAddress({ payload }) {
  * }} action with request payload.
  */
 export function* loadNanoContractDetail({ ncId }) {
+  yield put(nanoContractDetailSetStatus({ status: NANO_CONTRACT_DETAIL_STATUS.LOADING }));
   const wallet = getGlobalWallet();
   let response;
   try {

--- a/src/sagas/nanoContract.js
+++ b/src/sagas/nanoContract.js
@@ -20,7 +20,7 @@ import {
 import nanoUtils from '../utils/nanoContracts';
 import { NANO_CONTRACT_DETAIL_STATUS } from '../constants';
 
-import { all, call, put, select, takeEvery } from 'redux-saga/effects';
+import { all, call, delay, put, select, takeEvery } from 'redux-saga/effects';
 
 export const NANOCONTRACT_REGISTER_STATUS = {
   LOADING: 'loading',

--- a/src/sagas/nanoContract.js
+++ b/src/sagas/nanoContract.js
@@ -230,6 +230,6 @@ export function* saga() {
   yield all([
     takeEvery(types.NANOCONTRACT_REGISTER_REQUEST, registerNanoContract),
     takeEvery(types.NANOCONTRACT_EDIT_ADDRESS, updateNanoContractRegisteredAddress),
-    takeEvery(types.NANOCONTRACT_DETAIL_REQUEST, loadNanoContractDetail),
+    takeEvery(types.NANOCONTRACT_LOAD_DETAILS_REQUESTED, loadNanoContractDetail),
   ]);
 }

--- a/src/sagas/nanoContract.js
+++ b/src/sagas/nanoContract.js
@@ -28,6 +28,8 @@ export const NANOCONTRACT_REGISTER_STATUS = {
   SUCCESS: 'success',
 };
 
+const NANOCONTRACT_WAIT_TX_CONFIRMED_DELAY = 5000;
+
 /**
  * Process Nano Contract registration request.
  * @param {{
@@ -173,7 +175,7 @@ export function* loadNanoContractDetail({ ncId }) {
     // leaves the screen
     while (true) {
       // Wait 5s, then we fetch the data again to check if is has been confirmed
-      yield delay(5000);
+      yield delay(NANOCONTRACT_WAIT_TX_CONFIRMED_DELAY);
       const nanoContractDetailState = yield select((state) => state.nanoContractDetailState);
       if (nanoContractDetailState.status !== NANO_CONTRACT_DETAIL_STATUS.WAITING_TX_CONFIRMATION) {
         // User unmounted the screen, so we must stop the saga

--- a/src/screens/nano-contract/NanoContractDetail.js
+++ b/src/screens/nano-contract/NanoContractDetail.js
@@ -54,16 +54,10 @@ function NanoContractDetail() {
   const { nc_id: ncId } = useParams();
   const nc = nanoContracts[ncId];
 
-  // loading {boolean} Bool to show/hide loading element
-  const [loading, setLoading] = useState(true);
   // data {Object} Nano contract loaded data
   const [data, setData] = useState(null);
   // blueprintInformation {Object | null} Blueprint information data
   const [blueprintInformation, setBlueprintInformation] = useState(null);
-  // errorMessage {string} Message to show when error happens on the form
-  const [errorMessage, setErrorMessage] = useState('');
-  // waitingConfirmation {boolean} If transaction was loading and is waiting first block confirmation
-  const [waitingConfirmation, setWaitingConfirmation] = useState(false);
 
   useEffect(() => {
     if (nc) {
@@ -79,22 +73,7 @@ function NanoContractDetail() {
   }, []);
 
   useEffect(() => {
-    if (nanoContractDetailState.status === NANO_CONTRACT_DETAIL_STATUS.LOADING) {
-      setLoading(true);
-    }
-
-    if (nanoContractDetailState.status === NANO_CONTRACT_DETAIL_STATUS.ERROR) {
-      setLoading(false);
-      setErrorMessage(nanoContractDetailState.error);
-    }
-
-    if (nanoContractDetailState.status === NANO_CONTRACT_DETAIL_STATUS.WAITING_TX_CONFIRMATION) {
-      setWaitingConfirmation(true);
-    }
-
     if (nanoContractDetailState.status === NANO_CONTRACT_DETAIL_STATUS.SUCCESS) {
-      setWaitingConfirmation(false);
-      setLoading(false);
       // We know that we will have the blueprint data in redux here
       const blueprintInformation = blueprintsData[nc.blueprintId];
       setBlueprintInformation(blueprintInformation);
@@ -151,8 +130,8 @@ function NanoContractDetail() {
   }
 
   const renderBody = () => {
-    if (loading) {
-      const message = waitingConfirmation ? t`Waiting for transaction to be confirmed...` : t`Loading data...`
+    if (nanoContractDetailState.status === NANO_CONTRACT_DETAIL_STATUS.LOADING || nanoContractDetailState.status === NANO_CONTRACT_DETAIL_STATUS.WAITING_TX_CONFIRMATION) {
+      const message = nanoContractDetailState.status === NANO_CONTRACT_DETAIL_STATUS.WAITING_TX_CONFIRMATION ? t`Waiting for transaction to be confirmed...` : t`Loading data...`;
       return (
         <div className="d-flex flex-row align-items-center">
           <ReactLoading type='spin' width={24} height={24} color={colors.purpleHathor} delay={500} />
@@ -161,9 +140,11 @@ function NanoContractDetail() {
       );
     }
 
-    if (errorMessage) {
-      return <p className='text-danger mb-4'>{errorMessage}</p>;
+    if (nanoContractDetailState.status === NANO_CONTRACT_DETAIL_STATUS.ERROR) {
+      return <p className='text-danger mb-4'>{nanoContractDetailState.error}</p>;
     }
+
+    if (!data) return null;
 
     return renderNCData();
   }

--- a/src/screens/nano-contract/NanoContractDetail.js
+++ b/src/screens/nano-contract/NanoContractDetail.js
@@ -58,7 +58,7 @@ function NanoContractDetail() {
   const [loading, setLoading] = useState(true);
   // data {Object} Nano contract loaded data
   const [data, setData] = useState(null);
-  // blueprintInformation {Object} Blueprint information data
+  // blueprintInformation {Object | null} Blueprint information data
   const [blueprintInformation, setBlueprintInformation] = useState(null);
   // errorMessage {string} Message to show when error happens on the form
   const [errorMessage, setErrorMessage] = useState('');


### PR DESCRIPTION
### Acceptance Criteria
- Verify if transaction is confirmed before getting nc state and history. If it's not confirmed, add a loading and keep polling the data.

The currently screen when we get the state before the tx is confirmed

![image](https://github.com/user-attachments/assets/4005c507-cd9e-49d0-98e4-4bb735bac1a8)

New screen waiting confirmation

![image](https://github.com/user-attachments/assets/6270bae5-a202-42c3-aaa0-6d8bbceca576)


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
