### PR TITLE
refactor: improve amount handling

### DIFF
--- a/src/components/OutputsWrapper.js
+++ b/src/components/OutputsWrapper.js
@@ -9,7 +9,6 @@ import React from 'react';
 import { t } from 'ttag';
 import $ from 'jquery';
 import _ from 'lodash';
-import hathorLib from '@hathor/wallet-lib';
 import InputNumber from './InputNumber';
 import LOCAL_STORE from '../storage';
 import { connect } from 'react-redux';
@@ -30,7 +29,7 @@ class OutputsWrapper extends React.Component {
     super(props);
 
     this.address = React.createRef();
-    this.value = React.createRef();
+    this.value = null;
     this.timelock = React.createRef();
     this.timelockCheckbox = React.createRef();
     this.uniqueID = _.uniqueId()
@@ -55,11 +54,7 @@ class OutputsWrapper extends React.Component {
   render = () => {
     const renderInputNumber = () => {
       const classNames = "form-control output-value col-2";
-      if (this.props.isNFT) {
-        return <InputNumber key="nft-value" ref={this.value} className={classNames} placeholder="0" precision={0} />;
-      } else {
-        return <InputNumber key="value" ref={this.value} placeholder={hathorLib.numberUtils.prettyValue(0, this.props.decimalPlaces)} className={classNames} />;
-      }
+      return <InputNumber key={this.props.isNFT ? "nft-value" : "value"} onValueChange={(value) => this.value = value} className={classNames} isNFT={this.props.isNFT} />;
     }
 
     return (

--- a/src/components/SendTokensOne.js
+++ b/src/components/SendTokensOne.js
@@ -106,16 +106,15 @@ class SendTokensOne extends React.Component {
     let data = {'outputs': [], 'inputs': []};
     for (const output of this.outputs) {
       const address = output.current.address.current.value.replace(/\s/g, '');
-      const valueStr = (output.current.value.current.value || "").replace(/,/g, '');
+      const value = output.current.value;
 
-      if (address && valueStr) {
+      if (address && value) {
         // Doing the check here because need to validate before doing parseInt
-        const tokensValue = this.isNFT() ? parseInt(valueStr) : wallet.decimalToInteger(valueStr, this.props.decimalPlaces);
-        if (tokensValue > hathorLib.constants.MAX_OUTPUT_VALUE) {
+        if (value > hathorLib.constants.MAX_OUTPUT_VALUE) {
           this.props.updateState({ errorMessage: `Token: ${this.state.selected.symbol}. Output: ${output.current.props.index}. Maximum output value is ${hathorLib.numberUtils.prettyValue(hathorLib.constants.MAX_OUTPUT_VALUE, this.isNFT() ? 0 : this.props.decimalPlaces)}` });
           return null;
         }
-        let dataOutput = {'address': address, 'value': parseInt(tokensValue, 10), 'token': this.state.selected.uid};
+        let dataOutput = {'address': address, 'value': value, 'token': this.state.selected.uid};
 
         const hasTimelock = output.current.timelockCheckbox.current.checked;
         if (hasTimelock) {

--- a/src/components/atomic-swap/ModalAtomicReceive.js
+++ b/src/components/atomic-swap/ModalAtomicReceive.js
@@ -8,7 +8,7 @@
 import React, { useState, useRef, useEffect } from "react";
 import { t } from "ttag";
 import InputNumber from "../InputNumber";
-import hathorLib, { Address } from "@hathor/wallet-lib";
+import { Address } from "@hathor/wallet-lib";
 import walletUtils from '../../utils/wallet';
 import { getGlobalWallet } from "../../modules/wallet";
 import { useSelector } from 'react-redux';
@@ -18,7 +18,6 @@ export function ModalAtomicReceive ({ sendClickHandler, receivableTokens, manage
     const wallet = getGlobalWallet();
     const [selectedToken, setSelectedToken] = useState(receivableTokens[0]);
     const [address, setAddress] = useState('');
-    let amountRef = useRef();
     const [amount, setAmount] = useState(0);
     const [errMessage, setErrMessage] = useState('');
     const modalDomId = 'atomicReceiveModal';
@@ -69,7 +68,7 @@ export function ModalAtomicReceive ({ sendClickHandler, receivableTokens, manage
 
         // On success, clean error message and return user input
         setErrMessage('');
-        sendClickHandler({ selectedToken, address, amount: walletUtils.decimalToInteger(amount, decimalPlaces) });
+        sendClickHandler({ selectedToken, address, amount });
         onClose(`#${modalDomId}`);
     }
 
@@ -116,9 +115,7 @@ export function ModalAtomicReceive ({ sendClickHandler, receivableTokens, manage
                                 <label htmlFor="amount" className="col-3 my-auto">{t`Amount`}: </label>
                                 <InputNumber key="value"
                                              name="amount"
-                                             ref={amountRef}
-                                             defaultValue={hathorLib.numberUtils.prettyValue(amount, decimalPlaces)}
-                                             placeholder={hathorLib.numberUtils.prettyValue(0, decimalPlaces)}
+                                             defaultValue={amount}
                                              onValueChange={value => setAmount(value)}
                                              className="form-control output-value col-3"/>
                             </div>

--- a/src/components/atomic-swap/ModalAtomicSend.js
+++ b/src/components/atomic-swap/ModalAtomicSend.js
@@ -8,7 +8,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { t } from "ttag";
 import InputNumber from "../InputNumber";
-import hathorLib, { Address, numberUtils } from "@hathor/wallet-lib";
+import { Address, numberUtils } from "@hathor/wallet-lib";
 import { translateTxToProposalUtxo } from "../../utils/atomicSwap";
 import { TOKEN_DOWNLOAD_STATUS } from "../../sagas/tokens";
 import { get } from 'lodash';
@@ -130,7 +130,6 @@ function UtxoSelection ({ wallet, utxos, token, utxosChanged, setErrMessage }) {
 export function ModalAtomicSend ({ sendClickHandler, sendableTokens, tokenBalances, manageDomLifecycle, onClose, wallet }) {
     const [selectedToken, setSelectedToken] = useState(sendableTokens.length && sendableTokens[0]);
     const [changeAddress, setChangeAddress] = useState('');
-    let amountRef = useRef();
     const [amount, setAmount] = useState(0);
     const [errMessage, setErrMessage] = useState('');
     const modalDomId = 'atomicSendModal';
@@ -203,9 +202,8 @@ export function ModalAtomicSend ({ sendClickHandler, sendableTokens, tokenBalanc
         }
 
         // Validating available balance
-        const selectedAmount = walletUtils.decimalToInteger(amount, decimalPlaces);
         const availableAmount = selectedTokenBalance.data.available;
-        if (selectedAmount > availableAmount) {
+        if (amount > availableAmount) {
             setErrMessage(t`Insufficient balance`);
             return false;
         }
@@ -214,7 +212,7 @@ export function ModalAtomicSend ({ sendClickHandler, sendableTokens, tokenBalanc
         if (showUtxoSelection) {
             const validUtxos = utxos.filter(u => u.amount);
             const totalAmount = validUtxos.reduce((acc, u) => acc + u.amount, 0);
-            if (selectedAmount > totalAmount) {
+            if (amount > totalAmount) {
                 setErrMessage(t`Insufficient balance on selected inputs`);
                 return false;
             }
@@ -239,7 +237,7 @@ export function ModalAtomicSend ({ sendClickHandler, sendableTokens, tokenBalanc
         sendClickHandler({
             selectedToken,
             changeAddress: changeAddress,
-            amount: walletUtils.decimalToInteger(amount, decimalPlaces),
+            amount,
             utxos: selectedUtxos,
         });
         onClose(`#${modalDomId}`);
@@ -325,9 +323,7 @@ export function ModalAtomicSend ({ sendClickHandler, sendableTokens, tokenBalanc
                                 <label htmlFor="amount" className="col-3 my-auto">{t`Amount`}: </label>
                                 <InputNumber key="value"
                                              name="amount"
-                                             ref={amountRef}
-                                             defaultValue={numberUtils.prettyValue(amount, decimalPlaces)}
-                                             placeholder={numberUtils.prettyValue(0, decimalPlaces)}
+                                             defaultValue={amount}
                                              onValueChange={value => setAmount(value)}
                                              className="form-control output-value col-3"/>
                             </div>

--- a/src/components/tokens/TokenMelt.js
+++ b/src/components/tokens/TokenMelt.js
@@ -42,8 +42,6 @@ class TokenMelt extends React.Component {
   constructor(props) {
     super(props);
 
-    // Reference to amount input
-    this.amount = React.createRef();
     // Reference to create another melt output checkbox
     this.createAnother = React.createRef();
   }
@@ -58,11 +56,10 @@ class TokenMelt extends React.Component {
    * In case of error, an object with {success: false, message}
    */
   prepareSendTransaction = async (pin) => {
-    const amountValue = this.isNFT() ? this.state.amount : walletUtils.decimalToInteger(this.state.amount, this.props.decimalPlaces);
     const wallet = getGlobalWallet();
     const transaction = await wallet.prepareMeltTokensData(
       this.props.token.uid,
-      amountValue,
+      this.state.amount,
       {
         createAnotherMelt: this.createAnother.current.checked,
         pinCode: pin
@@ -90,8 +87,7 @@ class TokenMelt extends React.Component {
    * Return a message to be shown in case of success
    */
   getSuccessMessage = () => {
-    const amount = this.isNFT() ? this.state.amount : walletUtils.decimalToInteger(this.state.amount, this.props.decimalPlaces);
-    const prettyAmountValue = hathorLib.numberUtils.prettyValue(amount, this.isNFT() ? 0 : this.props.decimalPlaces);
+    const prettyAmountValue = hathorLib.numberUtils.prettyValue(this.state.amount, this.isNFT() ? 0 : this.props.decimalPlaces);
     return t`${prettyAmountValue} ${this.props.token.symbol} melted!`;
   }
 
@@ -102,10 +98,9 @@ class TokenMelt extends React.Component {
    * @return {string} Error message, in case of form invalid. Nothing, otherwise.
    */
   melt = () => {
-    const amountValue = this.isNFT() ? this.state.amount : walletUtils.decimalToInteger(this.state.amount, this.props.decimalPlaces);
     const walletAmount = get(this.props.tokenBalance, 'data.available', 0);
 
-    if (amountValue > walletAmount) {
+    if (this.state.amount > walletAmount) {
       const prettyWalletAmount = hathorLib.numberUtils.prettyValue(walletAmount, this.isNFT() ? 0 : this.props.decimalPlaces);
       return t`The total amount you have is only ${prettyWalletAmount}.`;
     }
@@ -119,30 +114,14 @@ class TokenMelt extends React.Component {
   }
 
   render() {
-    const renderInputNumber = () => {
-      if (this.isNFT()) {
-        return (
-          <InputNumber
-           required
-           ref={this.amount}
-           placeholder="0"
-           className="form-control"
-           precision={0}
-           onValueChange={this.onAmountChange}
-          />
-        )
-      } else {
-        return (
-          <InputNumber
-           required
-           ref={this.amount}
-           placeholder={hathorLib.numberUtils.prettyValue(0, this.props.decimalPlaces)}
-           className="form-control"
-           onValueChange={this.onAmountChange}
-          />
-        )
-      }
-    }
+    const renderInputNumber = () => (
+      <InputNumber
+       required
+       className="form-control"
+       isNFT={this.isNFT()}
+       onValueChange={this.onAmountChange}
+      />
+    )
 
     const renderForm = () => {
       return (

--- a/src/components/tokens/TokenMint.js
+++ b/src/components/tokens/TokenMint.js
@@ -61,12 +61,11 @@ class TokenMint extends React.Component {
    * In case of error, an object with {success: false, message}
    */
   prepareSendTransaction = async (pin) => {
-    const amountValue = this.isNFT() ? this.state.amount : walletUtils.decimalToInteger(this.state.amount, this.props.decimalPlaces);
     const address = this.chooseAddress.current.checked ? null : this.address.current.value;
     const wallet = getGlobalWallet();
     const transaction = await wallet.prepareMintTokensData(
       this.props.token.uid,
-      amountValue,
+      this.state.amount,
       {
         address,
         createAnotherMint: this.createAnother.current.checked,
@@ -95,8 +94,7 @@ class TokenMint extends React.Component {
    * Return a message to be shown in case of success
    */
   getSuccessMessage = () => {
-    const amount = this.isNFT() ? this.state.amount : walletUtils.decimalToInteger(this.state.amount, this.props.decimalPlaces);
-    const prettyAmountValue = hathorLib.numberUtils.prettyValue(amount, this.isNFT() ? 0 : this.props.decimalPlaces);
+    const prettyAmountValue = hathorLib.numberUtils.prettyValue(this.state.amount, this.isNFT() ? 0 : this.props.decimalPlaces);
     return t`${prettyAmountValue} ${this.props.token.symbol} minted!`;
   }
 
@@ -152,28 +150,14 @@ class TokenMint extends React.Component {
       );
     }
 
-    const renderInputNumber = () => {
-      if (this.isNFT()) {
-        return (
-          <InputNumber
-           required
-           className="form-control"
-           onValueChange={this.onAmountChange}
-           placeholder="0"
-           precision={0}
-          />
-        );
-      } else {
-        return (
-          <InputNumber
-           required
-           className="form-control"
-           onValueChange={this.onAmountChange}
-           placeholder={hathorLib.numberUtils.prettyValue(0, this.props.decimalPlaces)}
-          />
-        );
-      }
-    }
+    const renderInputNumber = () => (
+      <InputNumber
+       required
+       className="form-control"
+       onValueChange={this.onAmountChange}
+       isNFT={this.isNFT()}
+      />
+    );
 
     const renderForm = () => {
       return (

--- a/src/screens/CreateNFT.js
+++ b/src/screens/CreateNFT.js
@@ -314,7 +314,7 @@ function CreateNFT() {
         <div className="row">
           <div className="form-group col-4">
             <label>{t`Amount`}</label>
-            <InputNumber required className="form-control" precision={0} placeholder="How many NFT units to create" onValueChange={onAmountChange} />
+            <InputNumber required className="form-control" isNFT={true} onValueChange={onAmountChange} />
           </div>
           <div className="form-group d-flex flex-row align-items-center address-checkbox">
             <div className="form-check">

--- a/src/screens/CreateToken.js
+++ b/src/screens/CreateToken.js
@@ -68,8 +68,7 @@ function CreateToken() {
       }
 
       // Validating maximum amount
-      const tokensValue = walletUtils.decimalToInteger(amount, decimalPlaces);
-      if (tokensValue > hathorLib.constants.MAX_OUTPUT_VALUE) {
+      if (amount > hathorLib.constants.MAX_OUTPUT_VALUE) {
         const max_output_value_str = hathorLib.numberUtils.prettyValue(hathorLib.constants.MAX_OUTPUT_VALUE, decimalPlaces);
         setErrorMessage(t`Maximum value to mint token is ${max_output_value_str}`);
         return false;
@@ -122,7 +121,7 @@ function CreateToken() {
       transaction = await wallet.prepareCreateNewToken(
         shortNameRef.current.value,
         symbolRef.current.value,
-        walletUtils.decimalToInteger(amount, decimalPlaces),
+        amount,
         { address, pinCode: pin }
       );
 
@@ -276,7 +275,6 @@ function CreateToken() {
              required
              className="form-control"
              onValueChange={onAmountChange}
-             placeholder={hathorLib.numberUtils.prettyValue(0, decimalPlaces)}
             />
           </div>
           <div className="form-group d-flex flex-row align-items-center address-checkbox">

--- a/src/screens/nano-contract/NanoContractExecuteMethod.js
+++ b/src/screens/nano-contract/NanoContractExecuteMethod.js
@@ -9,7 +9,6 @@ import React, { useContext, useEffect, useRef, useState } from 'react';
 import { t } from 'ttag'
 import BackButton from '../../components/BackButton';
 import InputNumber from '../../components/InputNumber';
-import colors from '../../index.module.scss';
 import hathorLib from '@hathor/wallet-lib';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { get, pullAt } from 'lodash';
@@ -88,6 +87,10 @@ function NanoContractExecuteMethod() {
   // This will store each action in an array of objects
   // { type, token, amount, address }
   const [actions, setActions] = useState([]);
+
+  // Store values for Amount fields based on arg names
+  const [amountValues, setAmountValues] = useState({});
+
   const globalModalContext = useContext(GlobalModalContext);
 
   // We must store the ref of action addresses because we use for the validation
@@ -141,8 +144,8 @@ function NanoContractExecuteMethod() {
       if (typeToCheck !== 'Address') {
         continue;
       }
-      const addressInputValue = formRefs[i].current.value;
-      validateAddress(addressInputValue, formRefs[i].current);
+      const addressInputValue = formRefs[i].getValue();
+      validateAddress(addressInputValue, formRefs[i].ref.current);
     }
 
     for (let i=0; i<actions.length; i++) {
@@ -236,7 +239,7 @@ function NanoContractExecuteMethod() {
     const argValues = [];
     const args = get(data.blueprintInformation.public_methods, `${data.method}.args`, []);
     for (let i=0; i<args.length; i++) {
-      let value = formRefs[i].current.value;
+      let value = formRefs[i].getValue();
       // Check optional type
       // Optional fields end with ?
       const splittedType = args[i].type.split('?');
@@ -264,8 +267,7 @@ function NanoContractExecuteMethod() {
       }
 
       if (typeToCheck === 'Amount') {
-        const amountValue = walletUtils.decimalToInteger(value, decimalPlaces);
-        argValues.push(amountValue);
+        argValues.push(value);
         continue;
       }
 
@@ -282,10 +284,6 @@ function NanoContractExecuteMethod() {
         // We will skip if the user has just added an empty action
         continue;
       }
-
-      const amountValue = isNFT(action.token) ? action.amount : walletUtils.decimalToInteger(action.amount, decimalPlaces);
-      action.amount = amountValue;
-
       actionsData.push(action);
     }
 
@@ -368,18 +366,18 @@ function NanoContractExecuteMethod() {
    * Timestamp will have a datetime-local
    * The rest will be a text input
    *
+   * @param {string} name Argument name of the input
    * @param {string} type Argument type to render the input
    * @param {boolean} isOptional If this argument is optional
    * @param {Object} ref React reference object
    */
-  const renderInput = (type, isOptional, ref) => {
+  const renderInput = (name, type, isOptional, ref) => {
     if (type === 'Amount') {
       return <InputNumber
               required={!isOptional}
               requirePositive={true}
-              ref={ref}
+              onValueChange={(value) => setAmountValues({...amountValues, [name]: value})}
               className="form-control output-value"
-              placeholder={hathorLib.numberUtils.prettyValue(0, decimalPlaces)}
             />
     }
 
@@ -439,14 +437,23 @@ function NanoContractExecuteMethod() {
     }
 
     // Create a new ref for this argument to be used in the input and adds it to the array of refs
-    const ref = useRef(null);
-    formRefs.push(ref);
+    let ref;
+    let getValue;
+    if (type.startsWith('Amount')) {
+      // Amount fields don't use refs, so we store and retrieve values manually
+      ref = null;
+      getValue = () => amountValues[name];
+    } else {
+      ref = useRef(null);
+      getValue = () => ref.current.value;
+    }
+    formRefs.push({ ref, getValue});
 
     return (
       <div className="row" key={name}>
         <div className="form-group col-6">
           <label>{name} {!isOptional && '*'}</label>
-          {renderInput(typeToRender, isOptional, ref)}
+          {renderInput(name, typeToRender, isOptional, ref)}
           { isSignedData && <div className="mt-2"><a href="true" onClick={e => onSelectAddressToSignData(ref, e)}>{t`Select address to sign`}</a></div> }
         </div>
       </div>
@@ -520,21 +527,6 @@ function NanoContractExecuteMethod() {
     // I start the ref as null, then I set it in the input if it's a withdrawal
     actionAddressesRef.current[index] = null;
 
-    const token = actions[index].token;
-    // Depending on the token, the input for the amount changes because it might be an NFT
-    const nft = isNFT(token);
-    let inputNumberProps;
-    if (nft) {
-      inputNumberProps = {
-        placeholder: '0',
-        precision: 0,
-      };
-    } else {
-      inputNumberProps = {
-        placeholder: hathorLib.numberUtils.prettyValue(0, decimalPlaces)
-      };
-    }
-
     const renderCommon = () => {
       return (
         <div className="d-flex flex-grow-1">
@@ -549,7 +541,7 @@ function NanoContractExecuteMethod() {
               requirePositive={true}
               onValueChange={amount => onActionValueChange(index, 'amount', amount)}
               className="form-control output-value"
-              {...inputNumberProps}
+              isNFT={isNFT(actions[index].token)}
             />
           </div>
         </div>

--- a/src/utils/tokens.js
+++ b/src/utils/tokens.js
@@ -96,8 +96,7 @@ const tokens = {
    */
   getDepositAmount(mintAmount, depositPercent, decimalPlaces) {
     if (mintAmount) {
-      const amountValue = wallet.decimalToInteger(mintAmount, decimalPlaces);
-      const deposit = hathorLib.tokensUtils.getDepositAmount(amountValue, depositPercent);
+      const deposit = hathorLib.tokensUtils.getDepositAmount(mintAmount, depositPercent);
       return hathorLib.numberUtils.prettyValue(deposit, decimalPlaces);
     } else {
       return '0';

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -615,25 +615,6 @@ const wallet = {
   },
 
   /**
-   * Converts a decimal value to integer. On the full node and the wallet lib, we only deal with
-   * integer values for amount. So a value of 45.97 for the user is handled by them as 4597.
-   * We need the Math.round because of some precision errors in js
-   * 35.05*100 = 3504.9999999999995 Precision error
-   * Math.round(35.05*100) = 3505
-   *
-   * @param {number} value The decimal amount
-   * @param {number} decimalPlaces Number of decimal places
-   *
-   * @return {number} Value as an integer
-   *
-   * @memberof Wallet
-   * @inner
-   */
-  decimalToInteger(value, decimalPlaces) {
-    return Math.round(value*(10**decimalPlaces));
-  },
-
-  /**
    * Returns a string map containing the identifiers for proposals currently being watched.
    * @returns {Record<string,{ id:string, password:string }>}
    */


### PR DESCRIPTION
### Motivation

In our network, the amount used by output values is always an integer number, that is, it cannot have a fractional part. However, we do have decimal places for _cosmetic only_ reasons: we show 2 decimal places for tokens and 0 decimal places for NFTs.

This means internally amount values should always be handled (stored, sent, processed) as integer values, and we should only consider decimal places when interfacing with the user, that is, displaying values or receiving input. This is straightforward in Python by using the `int` type. In JS, the `Number` type is used, which is a `double`.

This resulted in a bit of a mess in our wallet code. Currently, we have different functions/react components storing and expecting amounts in different formats. Sometimes, strings are used and they have to be processed as they contain thousand and decimal separators (`,` and `.`). Sometimes, `Numbers` are used, but depending on the function/component, it can expect it as a whole number or a fractional number. That is, the amount `12.34` may be represented as the fractional `12.34` JS `Number`, or the whole `1234.0` JS `Number`. On top of that, NFTs introduce different handling.

This means in multiple parts of the code we have to consider decimal places and convert back and forth between formats. This is not only redundant but error prone. What we should do instead, is only ever store and process amounts as whole `Numbers`, that is, the amount `12.34` should always be handled as the `1234.0` JS `Number`. We should never use fractional parts for amounts internally. This PR implements this refactor, removing the `decimalToInteger` conversion function that was used to handle this, and now amounts in React props and states are always whole.

This is done as part of the conversion to `BigInt` project. After this refactor, changing the amount type from `Number` to `BigInt` will be straight forward, as we won't have to deal with any conversion logic — the amount values will already be integers, but typed as `Numbers`, so the conversion to `BigInts` is simply a type conversion.

The refactor is implemented by changing the way the `InputNumber` component is used. Currently, its value is available as a `string` through `ref` or `onValueChange`. Then, it's the component's user responsibility to handle format conversion. The component now handles everything as whole `Numbers`, so users can work with them directly, and only consider decimals when pretty printing. The `ref` is removed as it provided access to the underlying `<input>` element, which is of `text` type. Instead, users should use the updated `onValueChange` with `Numbers`.

**ATTENTION**: The changes in this PR are extremely sensitive and important as they deal with conversion between user input and internal representation. It should be reviewed with extra caution.

### Acceptance Criteria

- Update `InputNumber` component
  - Change `defaultValue` prop and `value` state from `string` to `number`.
  - Remove `precision` prop and introduce `isNFT` instead. This allows for removing some duplication.
  - Remove support for `ref`.
  - For further simplification, remove unused props `separator`, `locale`, `onChange`.
- Remove `decimalToInteger` function.


### Security Checklist

- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
