### PR TITLE
fix: use 3 columns in the methods list

### DIFF
--- a/src/index.module.scss
+++ b/src/index.module.scss
@@ -907,15 +907,15 @@ span.software {
   border-top: 1px solid;
 }
 
-.five-column-list {
+.three-column-list {
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
+  grid-template-columns: repeat(3, 1fr);
   gap: 1rem;
   list-style: none;
   padding-left: 0;
 }
 
-.five-column-list li {
+.three-column-list li {
   padding: 0.5rem;
   text-align: center;
 }

--- a/src/screens/nano-contract/NanoContractDetail.js
+++ b/src/screens/nano-contract/NanoContractDetail.js
@@ -262,7 +262,7 @@ function NanoContractDetail() {
         <hr />
         <div>
           <p className="text-center mb-4"><strong>Available methods:</strong></p>
-          <ul className="five-column-list mt-3">
+          <ul className="three-column-list mt-3">
             {renderNanoMethods()}
           </ul>
         </div>


### PR DESCRIPTION
### Context

Depending on the length of the method names, the UI is still not good with 5 columns. I changed to 3 columns only, which fits well the blueprints we have nowadays. If the method names are too big, it will still break but this is unlikely because they are also code method names, which shouldn't be too big, so I think it's safe to go with this solution for now.

### Acceptance Criteria
- Use only 3 columns to list the available methods of a nano contract.

Old UI:

![image](https://github.com/user-attachments/assets/9cb1222d-41a8-4aff-bbf7-d9085f0be2f0)

New UI:

![image](https://github.com/user-attachments/assets/04594adc-a0bc-449e-ad37-c9f7f956a9a1)


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
