### PR TITLE
fix: missing bigint constants

### DIFF
--- a/src/components/ModalAddManyTokens.js
+++ b/src/components/ModalAddManyTokens.js
@@ -119,7 +119,7 @@ class ModalAddManyTokens extends React.Component {
           available: 0n,
           locked: 0n,
         });
-        const tokenHasZeroBalance = (available + locked) === 0;
+        const tokenHasZeroBalance = (available + locked) === 0n;
 
         /*
          * We only make this validation if the "Hide Zero-Balance Tokens" setting is active,

--- a/src/components/ModalAddToken.js
+++ b/src/components/ModalAddToken.js
@@ -90,7 +90,7 @@ class ModalAddToken extends React.Component {
       const tokenUid = tokenData.uid;
       const tokenBalance = tokensBalance[tokenUid]?.data;
       const tokenHasZeroBalance = !tokenBalance
-        || (tokenBalance.available + tokenBalance.locked) === 0;
+        || (tokenBalance.available + tokenBalance.locked) === 0n;
 
       /*
        * We only make this validation if the "Hide Zero-Balance Tokens" setting is active,

--- a/src/components/atomic-swap/ModalAtomicReceive.js
+++ b/src/components/atomic-swap/ModalAtomicReceive.js
@@ -45,7 +45,7 @@ export function ModalAtomicReceive ({ sendClickHandler, receivableTokens, manage
             return false;
         }
 
-        if (amount === 0 || !amount) {
+        if (amount === 0n || !amount) {
             setErrMessage(t`Must receive a positive amount of tokens`);
             return false;
         }

--- a/src/components/atomic-swap/ModalAtomicSend.js
+++ b/src/components/atomic-swap/ModalAtomicSend.js
@@ -196,7 +196,7 @@ export function ModalAtomicSend ({ sendClickHandler, sendableTokens, tokenBalanc
         }
 
         // Validating mandatory amount
-        if (amount === 0 || !amount) {
+        if (amount === 0n || !amount) {
             setErrMessage(t`Must send a positive amount of tokens`);
             return false;
         }

--- a/src/utils/wallet.js
+++ b/src/utils/wallet.js
@@ -252,7 +252,7 @@ const wallet = {
         const totalBalance = balance.available + balance.locked;
 
         // This token has zero balance: skip it.
-        if (hideZeroBalance && totalBalance === 0) {
+        if (hideZeroBalance && totalBalance === 0n) {
           continue;
         }
       }
@@ -302,7 +302,7 @@ const wallet = {
         const totalBalance = balance.available + balance.locked;
 
         // This token has zero balance: skip it.
-        if (totalBalance === 0) {
+        if (totalBalance === 0n) {
           continue;
         }
       }


### PR DESCRIPTION
### Motivation

Some constants were missing to be updated from `number` to `bigint`.

### Acceptance Criteria

- Change constants from `0` to `0n`.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
