### PR TITLE
fix: bigint on TxData and NanoContractDetails

### DIFF
--- a/src/components/TxData.js
+++ b/src/components/TxData.js
@@ -898,7 +898,7 @@ class TxData extends React.Component {
             <label>Type:</label> {upperFirst(action.type)}
           </div>
           <div>
-            <label>Amount:</label> {numberUtils.prettyValue(action.amount, this.props.decimalPlaces)} {this.getSymbol(action.token_uid)}
+            <label>Amount:</label> {numberUtils.prettyValue(typeof action.amount === 'bigint' ? action.amount : BigInt(action.amount), this.props.decimalPlaces)} {this.getSymbol(action.token_uid)}
           </div>
         </div>
       ));

--- a/src/screens/nano-contract/NanoContractDetail.js
+++ b/src/screens/nano-contract/NanoContractDetail.js
@@ -190,7 +190,7 @@ function NanoContractDetail() {
       return (
         <div key={tokenUid} className="d-flex flex-column nc-token-balance">
           <p><strong>Token: </strong>{tokenUid === hathorLib.constants.NATIVE_TOKEN_UID ? tokenUid : <a href="true" onClick={(e) => goToExplorer(e, tokenUid)}>{tokenUid}</a>}</p>
-          <p><strong>Amount: </strong>{hathorLib.numberUtils.prettyValue(amount.value, decimalPlaces)}</p>
+          <p><strong>Amount: </strong>{hathorLib.numberUtils.prettyValue(typeof amount.value === 'bigint' ? amount.value : BigInt(amount.value), decimalPlaces)}</p>
         </div>
       );
     });


### PR DESCRIPTION
## Motivation

Transaction detail screen was crashing on nano contract transactions because the `prettyValue` method from wallet-lib expects a BigInt:

`React Router caught the following error during render Error: value 500 should be a bigint`

### Acceptance Criteria
- The transaction detail screen should work for nano contract transactions



### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
