### PR TITLE
chore: bump to 0.31.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hathor-wallet",
-  "version": "0.31.0-rc.3",
+  "version": "0.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hathor-wallet",
-      "version": "0.31.0-rc.3",
+      "version": "0.31.0",
       "hasInstallScript": true,
       "dependencies": {
         "@hathor/wallet-lib": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "productName": "Hathor Wallet",
   "description": "Light wallet for Hathor Network",
   "author": "Hathor Labs <contact@hathor.network> (https://hathor.network/)",
-  "version": "0.31.0-rc.3",
+  "version": "0.31.0",
   "engines": {
     "node": ">=22.0.0",
     "npm": ">=10.0.0"


### PR DESCRIPTION
### Acceptance Criteria
- Bumps to public release version `0.31.0`


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
