### PR TITLE
fix: nano amount is not coming as big int from the lib

### DIFF
--- a/src/screens/nano-contract/NanoContractDetail.js
+++ b/src/screens/nano-contract/NanoContractDetail.js
@@ -159,7 +159,7 @@ function NanoContractDetail() {
     }
 
     if (type === 'Amount') {
-      return hathorLib.numberUtils.prettyValue(value, decimalPlaces);
+      return hathorLib.numberUtils.prettyValue(typeof value === 'bigint' ? value : BigInt(value), decimalPlaces);
     }
 
     return value;


### PR DESCRIPTION
### Motivation

The nano contract detail screen is currently throwing an error if an amount argument exists. It uses the `prettyValue` method that expects a `bigint` but it's currently returning a `number`.

There's a [full node PR](https://github.com/HathorNetwork/nano-hathor-core/pull/167) in review process that will add support for bigint in the Amount nano arguments, so this handling code won't be needed as soon as it's merged and we also add this support in the wallet-lib.

### Acceptance Criteria
- Handle amount nano argument as big int or number.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
