### PR TITLE
refactor: hide register execute nc

### DIFF
--- a/src/components/InputNumber.js
+++ b/src/components/InputNumber.js
@@ -154,7 +154,7 @@ const InputNumber = React.forwardRef(
       }
     }, [value]);
 
-    return <input ref={innerRef} value={format(value)} {...otherProps} type="text" />;
+    return <input ref={innerRef} value={format(value)} onChange={() => {}} {...otherProps} type="text" />;
   }
 );
 

--- a/src/sagas/nanoContract.js
+++ b/src/sagas/nanoContract.js
@@ -159,7 +159,7 @@ export function* loadNanoContractDetail({ ncId }) {
     return;
   }
 
-  const isNanoContractCreate = nanoUtils.isNanoContractCreate(response.tx);
+  const isNanoContractCreate = nanoUtils.isNanoContractCreateTx(response.tx);
   if (!isNanoContractCreate) {
     console.debug(`Fail loading Nano Contract detail because [ncId=${ncId}] is not a nano contract creation tx.`);
     yield put(nanoContractDetailSetStatus({ status: NANO_CONTRACT_DETAIL_STATUS.ERROR, error: t`Transaction must be a nano contract creation.` }));

--- a/src/screens/nano-contract/NanoContractDetail.js
+++ b/src/screens/nano-contract/NanoContractDetail.js
@@ -182,7 +182,9 @@ function NanoContractDetail() {
     ).map((method) => {
       return (
         <li key={method}>
-          <a href="true" onClick={(e) => executeMethod(e, method)}>{method}</a>
+          {/* TODO: Re-enable when we update the wallet-lib methods calls */}
+          {/* <a href="true" onClick={(e) => executeMethod(e, method)}>{method}</a> */}
+          <span className="text-muted">{method}</span>
         </li>
       );
     });

--- a/src/screens/nano-contract/NanoContractExecuteMethod.js
+++ b/src/screens/nano-contract/NanoContractExecuteMethod.js
@@ -54,7 +54,6 @@ function NanoContractExecuteMethod() {
     nanoContracts,
     blueprintsData,
     tokenMetadata,
-    decimalPlaces,
     registeredTokens,
   } = useSelector((state) => {
     return {
@@ -132,7 +131,7 @@ function NanoContractExecuteMethod() {
     // First I validate the Address inputs in the arguments list, then I validate the addresses
     // in the withdrawal actions
     const args = get(data.blueprintInformation.public_methods, `${data.method}.args`, []);
-    for (let i=0; i<args.length; i++) {
+    for (let i = 0; i < args.length; i++) {
       const splittedType = args[i].type.split('?');
       const isOptional = splittedType.length === 2;
       // Skip optional arguments that are null
@@ -148,7 +147,7 @@ function NanoContractExecuteMethod() {
       validateAddress(addressInputValue, formRefs[i].ref.current);
     }
 
-    for (let i=0; i<actions.length; i++) {
+    for (let i = 0; i < actions.length; i++) {
       const action = actions[i];
       // Only withdrawal actions have address
       if (action.type !== NanoContractActionType.WITHDRAWAL) {
@@ -178,7 +177,7 @@ function NanoContractExecuteMethod() {
 
     // Here the form is valid, so we show the PIN modal to send the tx
     globalModalContext.showModal(MODAL_TYPES.PIN, {
-      onSuccess: ({pin}) => {
+      onSuccess: ({ pin }) => {
         globalModalContext.showModal(MODAL_TYPES.SEND_TX, {
           pin,
           prepareSendTransaction,
@@ -238,7 +237,7 @@ function NanoContractExecuteMethod() {
     // First we get all the argument values and parse the input values to the expected type
     const argValues = [];
     const args = get(data.blueprintInformation.public_methods, `${data.method}.args`, []);
-    for (let i=0; i<args.length; i++) {
+    for (let i = 0; i < args.length; i++) {
       let value = formRefs[i].getValue();
       // Check optional type
       // Optional fields end with ?
@@ -374,11 +373,11 @@ function NanoContractExecuteMethod() {
   const renderInput = (name, type, isOptional, ref) => {
     if (type === 'Amount') {
       return <InputNumber
-              required={!isOptional}
-              requirePositive={true}
-              onValueChange={(value) => setAmountValues({...amountValues, [name]: value})}
-              className="form-control output-value"
-            />
+        required={!isOptional}
+        requirePositive={true}
+        onValueChange={(value) => setAmountValues({ ...amountValues, [name]: value })}
+        className="form-control output-value"
+      />
     }
 
     if (type === 'TokenUid') {
@@ -386,7 +385,7 @@ function NanoContractExecuteMethod() {
     }
 
     let inputType;
-    switch(type) {
+    switch (type) {
       case 'int':
       case 'float':
         inputType = 'number';
@@ -447,14 +446,14 @@ function NanoContractExecuteMethod() {
       ref = useRef(null);
       getValue = () => ref.current.value;
     }
-    formRefs.push({ ref, getValue});
+    formRefs.push({ ref, getValue });
 
     return (
       <div className="row" key={name}>
         <div className="form-group col-6">
           <label>{name} {!isOptional && '*'}</label>
           {renderInput(name, typeToRender, isOptional, ref)}
-          { isSignedData && <div className="mt-2"><a href="true" onClick={e => onSelectAddressToSignData(ref, e)}>{t`Select address to sign`}</a></div> }
+          {isSignedData && <div className="mt-2"><a href="true" onClick={e => onSelectAddressToSignData(ref, e)}>{t`Select address to sign`}</a></div>}
         </div>
       </div>
     );
@@ -662,7 +661,7 @@ function NanoContractExecuteMethod() {
             {renderActions()}
           </div>
           <button type="button" className="mt-3 btn btn-hathor" onClick={executeMethod}>{isCreateNanoContract ? t`Create` : t`Execute Method`}</button>
-          { errorMessage && <p className="text-danger mt-3 white-space-pre-wrap">{errorMessage}</p> }
+          {errorMessage && <p className="text-danger mt-3 white-space-pre-wrap">{errorMessage}</p>}
         </form>
       </div>
     </div>

--- a/src/screens/nano-contract/NanoContractList.js
+++ b/src/screens/nano-contract/NanoContractList.js
@@ -50,7 +50,8 @@ function NanoContractList() {
     <div className="content-wrapper">
       <div>
         <div className="d-flex flex-row justify-content-between mt-5 mb-4">
-          <button className="btn btn-hathor" onClick={createNC}>{t`Create a nano contract`}</button>
+          {/* TODO: Re-enable when we update the method calls to wallet-lib */}
+          {/* <button className="btn btn-hathor" onClick={createNC}>{t`Create a nano contract`}</button> */}
           <button className="btn btn-hathor" onClick={registerNC}>{t`Register a nano contract`}</button>
         </div>
         <div className="table-responsive">


### PR DESCRIPTION
<img width="1433" height="916" alt="image" src="https://github.com/user-attachments/assets/2576e822-10e0-4109-93ef-4ebe3b53e71c" />


<img width="1430" height="1130" alt="image" src="https://github.com/user-attachments/assets/24482618-7453-4dee-b4c1-f9e9208ec800" />


### Acceptance Criteria
- We should hide the execute and register nano contract buttons for now (they need to be updated to the new wallet-lib methods, for now they'll work only with Reown/WalletConnect)
- Fixed wrong method call in `nanoContracts` saga preventing the nano contract details screen to be shown


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
