### PR TITLE
fix: stop wallet on wallet reset

### DIFF
--- a/src/sagas/wallet.js
+++ b/src/sagas/wallet.js
@@ -757,7 +757,7 @@ export function* onWalletReset() {
   // This will update the lib config and redux state with the default network settings
   helpersUtils.loadStorageState();
   if (wallet) {
-    yield call([wallet.storage, wallet.storage.cleanStorage], true, true);
+    yield call([wallet, wallet.stop], { cleanStorage: true, cleanAddresses: true });
   }
 
   yield put(setNavigateTo('/welcome'));


### PR DESCRIPTION
### Motivation

After wallet reset, the wallet object was still receiving ws messages, and the handling would throw an error because the storage was being cleaned.

### Acceptance Criteria
- Stop wallet on wallet reset instead of just cleaning the storage 


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
