### PR TITLE
fix: close event channel on wallet stopped

### DIFF
--- a/src/sagas/wallet.js
+++ b/src/sagas/wallet.js
@@ -620,6 +620,12 @@ export function* setupWalletListeners(wallet) {
     while (true) {
       const message = yield take(channel);
 
+      if (message.type === 'WALLET_CHANGE_STATE' && message.payload === HathorWallet.CLOSED) {
+        // If the wallet was stopped, we close the channel
+        channel.close();
+        return;
+      }
+
       yield put({
         type: message.type,
         payload: message.data,


### PR DESCRIPTION
### Motivation

On wallet start we were creating an event channel that was being closed only when the saga was cancelled, so the channel would stay opened even after the wallet was stopped.

### Acceptance Criteria
- Close event channel on wallet stopped.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
