### PR TITLE
refactor: use pin pad for the pin in the wallet load error screen

### DIFF
--- a/src/screens/LoadWalletFailed.js
+++ b/src/screens/LoadWalletFailed.js
@@ -5,55 +5,47 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useContext } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { useNavigate } from 'react-router-dom';
 import { t } from 'ttag';
 import { str2jsx } from '../utils/i18n';
 import logo from '../assets/images/hathor-logo.png';
 import InitialImages from '../components/InitialImages';
-import { networkSettingsRequestUpdate, setNetworkSettingsStatus, walletReset } from '../actions';
+import { hideGlobalModal, networkSettingsRequestUpdate, setNetworkSettingsStatus, walletReset } from '../actions';
 import { NETWORK_SETTINGS, NETWORK_SETTINGS_STATUS, colors } from '../constants';
 import LOCAL_STORE from '../storage';
 import ReactLoading from 'react-loading';
-import { getGlobalWallet } from '../modules/wallet';
+import { GlobalModalContext, MODAL_TYPES } from '../components/GlobalModal';
 
 export default function LoadFailed(props) {
   const lastAction = useSelector((state) => state.startWalletAction);
   const dispatch = useDispatch();
 
-  // If the user clicked to connect to mainnet
-  const [connectToMainnetClicked, setConnectToMainnetClicked] = useState(false);
+  const context = useContext(GlobalModalContext);
   const isHardwareWallet = LOCAL_STORE.isHardwareWallet();
   // Use selector to fetch current network settings
   const { networkSettings } = useSelector(state => ({
     networkSettings: state.networkSettings
   }));
-  const pinRef = useRef(null);
-  const wallet = getGlobalWallet();
-  const navigate = useNavigate();
   
   const retry = useCallback((e) => {
     e.preventDefault();
     dispatch(lastAction);
   }, [lastAction, dispatch]);
 
-  const executeConnectToMainnet = useCallback(async (e) => {
-    e.preventDefault();
-    const pin = pinRef.current.value;
-    if (!await wallet.checkPin(pin)) {
-      dispatch(setNetworkSettingsStatus({ status: NETWORK_SETTINGS_STATUS.ERROR, error: t`Invalid PIN.` }));
-      return;
-    }
-
-    dispatch(setNetworkSettingsStatus({ status: NETWORK_SETTINGS_STATUS.LOADING }));
-    dispatch(networkSettingsRequestUpdate(NETWORK_SETTINGS['mainnet'], pin));
-  }, [dispatch]);
-
   const connectToMainnet = useCallback((e) => {
     e.preventDefault();
-    setConnectToMainnetClicked(true);
-  }, [setConnectToMainnetClicked]);
+    context.showModal(MODAL_TYPES.PIN_PAD, {
+      onComplete: (pinCode) => {
+        dispatch(hideGlobalModal());
+        dispatch(setNetworkSettingsStatus({ status: NETWORK_SETTINGS_STATUS.LOADING }));
+        dispatch(networkSettingsRequestUpdate(NETWORK_SETTINGS['mainnet'], pinCode));
+      },
+      onCancel: () => {
+        dispatch(hideGlobalModal());
+      }
+    });
+  }, [dispatch]);
 
   const reset = useCallback((e) => {
     e.preventDefault();
@@ -61,22 +53,6 @@ export default function LoadFailed(props) {
   }, [dispatch]);
 
   const isLoading = networkSettings.status === NETWORK_SETTINGS_STATUS.LOADING;
-
-  const renderConditionalComponent = () => {
-    if (!isHardwareWallet && !connectToMainnetClicked) {
-      return <a onClick={connectToMainnet} href='true'>{t`Connect to mainnet`}</a>;
-    }
-
-    if (connectToMainnetClicked) {
-      return (
-        <div className="d-flex flex-row align-items-center justify-content-end">
-          <input required ref={pinRef} type="password" pattern='[0-9]{6}' inputMode='numeric' autoComplete="off" placeholder={t`PIN`} className="form-control col-4 mr-3" />
-          <button onClick={executeConnectToMainnet} disabled={isLoading} type="button" className="btn btn-hathor mr-3">{t`Connect`}</button>
-          {isLoading && <ReactLoading type='spin' color={colors.purpleHathor} width={24} height={24} delay={200} />}
-        </div>
-      );
-    }
-  }
 
   return (
     <div className="outside-content-wrapper">
@@ -94,7 +70,7 @@ export default function LoadFailed(props) {
           </p>
           <div className="d-flex flex-row justify-content-around mt-5 align-items-center">
             <a onClick={reset} href='true'>{t`Reset wallet`}</a>
-            {renderConditionalComponent()}
+            {!isHardwareWallet && <a onClick={connectToMainnet} href='true'>{t`Connect to mainnet`}</a>}
           </div>
           <p className="text-danger mt-3">{networkSettings.status === NETWORK_SETTINGS_STATUS.ERROR && networkSettings.error}</p>
         </div>


### PR DESCRIPTION
### Acceptance Criteria
- Use PinPad modal for the pin of the mainnet connection in the wallet load error screen

https://github.com/user-attachments/assets/4e30753a-3e50-4b7c-90ed-593e0e638615

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
