### PR TITLE
feat: handle unregistered tokens actions properly and ask user to register them

### DIFF
--- a/locale/texts.pot
+++ b/locale/texts.pot
@@ -528,7 +528,7 @@ msgstr ""
 #: src/components/ModalPin.js:134
 #: src/components/ModalUnregisteredTokenInfo.js:128
 #: src/components/PinPad.js:235
-#: src/components/Reown/modals/BaseNanoContractModal.js:275
+#: src/components/Reown/modals/BaseNanoContractModal.js:276
 #: src/components/atomic-swap/ModalAtomicReceive.js:129
 #: src/components/atomic-swap/ModalAtomicSend.js:365
 #: src/components/nano-contract/ModalChangeAddress.js:153
@@ -560,7 +560,8 @@ msgstr ""
 #: src/components/ModalError.js:45
 #: src/components/ModalLedgerResetTokenSignatures.js:122
 #: src/components/ModalLedgerSignToken.js:243
-#: src/components/Reown/FeedbackModal.js:89
+#: src/components/Reown/FeedbackModal.js:93
+#: src/components/Reown/NanoContractFeedbackModal.js:80
 #: src/screens/SendTokens.js:157
 #: src/screens/SendTokens.js:293
 #: src/screens/SendTokens.js:466
@@ -945,6 +946,7 @@ msgstr ""
 msgid "Unknown Tokens"
 msgstr ""
 
+#: src/components/Reown/NanoContractFeedbackModal.js:83
 #: src/screens/UnknownTokens.js:294
 msgid "Register Tokens"
 msgstr ""
@@ -1487,12 +1489,16 @@ msgstr ""
 msgid "Error updating network settings."
 msgstr ""
 
-#: src/sagas/reown.js:473
+#: src/sagas/reown.js:475
 msgid "Insufficient funds to complete the transaction."
 msgstr ""
 
 #: src/sagas/tokens.js:372
 msgid "An error occurred while fetching this token data"
+msgstr ""
+
+#: src/sagas/tokens.js:404
+msgid "Fail to download unregistered tokens data."
 msgstr ""
 
 #: src/components/AddressList.js:165
@@ -1954,7 +1960,7 @@ msgid "Home"
 msgstr ""
 
 #: src/components/ModalUnhandledError.js:98
-#: src/components/Reown/FeedbackModal.js:73
+#: src/components/Reown/FeedbackModal.js:75
 msgid "Dismiss"
 msgstr ""
 
@@ -2869,7 +2875,7 @@ msgstr ""
 msgid "Sign Data"
 msgstr ""
 
-#: src/components/Reown/modals/BaseNanoContractModal.js:265
+#: src/components/Reown/modals/BaseNanoContractModal.js:266
 #: src/components/nano-contract/ModalSelectAddressToSignTx.js:49
 msgid "Select the address that will be used to sign the transaction"
 msgstr ""
@@ -3038,7 +3044,7 @@ msgstr ""
 msgid "The operation completed successfully."
 msgstr ""
 
-#: src/components/Reown/FeedbackModal.js:76
+#: src/components/Reown/FeedbackModal.js:78
 msgid "Retry"
 msgstr ""
 
@@ -3147,32 +3153,49 @@ msgstr ""
 msgid "Address to send authority:"
 msgstr ""
 
-#: src/components/Reown/NanoContractFeedbackModal.js:28
+#: src/components/Reown/NanoContractActions.js:264
+msgid "Loading token actions data..."
+msgstr ""
+
+#: src/components/Reown/NanoContractFeedbackModal.js:53
+#, javascript-format
+msgid ""
+"There are ${ unregisteredTokensList.length } unregistered tokens in this "
+"transaction. Do you want to register them?"
+msgstr ""
+
+#: src/components/Reown/NanoContractFeedbackModal.js:54
+msgid ""
+"There is 1 unregistered token in this transaction. Do you want to register "
+"it?"
+msgstr ""
+
+#: src/components/Reown/NanoContractFeedbackModal.js:97
 #: src/components/Reown/TransactionFeedbackModal.js:28
 msgid "Processing Transaction"
 msgstr ""
 
-#: src/components/Reown/NanoContractFeedbackModal.js:29
+#: src/components/Reown/NanoContractFeedbackModal.js:98
 #: src/components/Reown/TransactionFeedbackModal.js:29
 msgid "Transaction Failed"
 msgstr ""
 
-#: src/components/Reown/NanoContractFeedbackModal.js:30
+#: src/components/Reown/NanoContractFeedbackModal.js:99
 #: src/components/Reown/TransactionFeedbackModal.js:30
 msgid "Transaction Successful"
 msgstr ""
 
-#: src/components/Reown/NanoContractFeedbackModal.js:33
+#: src/components/Reown/NanoContractFeedbackModal.js:102
 msgid "Processing nano contract transaction..."
 msgstr ""
 
-#: src/components/Reown/NanoContractFeedbackModal.js:34
+#: src/components/Reown/NanoContractFeedbackModal.js:103
 msgid ""
 "There was an error sending the nano contract transaction. Would you like to "
 "try again?"
 msgstr ""
 
-#: src/components/Reown/NanoContractFeedbackModal.js:35
+#: src/components/Reown/NanoContractFeedbackModal.js:104
 msgid "The nano contract transaction was sent successfully."
 msgstr ""
 
@@ -3268,7 +3291,7 @@ msgid "Caller"
 msgstr ""
 
 #: src/components/Reown/modals/BaseNanoContractModal.js:125
-#: src/components/Reown/modals/BaseNanoContractModal.js:259
+#: src/components/Reown/modals/BaseNanoContractModal.js:260
 msgid "Select Address"
 msgstr ""
 
@@ -3304,16 +3327,16 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: src/components/Reown/modals/BaseNanoContractModal.js:293
+#: src/components/Reown/modals/BaseNanoContractModal.js:294
 msgid "Review your transaction from this dApp"
 msgstr ""
 
-#: src/components/Reown/modals/BaseNanoContractModal.js:294
+#: src/components/Reown/modals/BaseNanoContractModal.js:295
 #: src/components/Reown/modals/SignOracleDataModal.js:26
 msgid "Stay vigilant and protect your data from potential phishing attempts."
 msgstr ""
 
-#: src/components/Reown/modals/BaseNanoContractModal.js:320
+#: src/components/Reown/modals/BaseNanoContractModal.js:321
 msgid "Action List"
 msgstr ""
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -119,6 +119,7 @@ export const types = {
   UNREGISTERED_TOKENS_DOWNLOAD_SUCCESS: 'UNREGISTERED_TOKENS_DOWNLOAD_SUCCESS',
   UNREGISTERED_TOKENS_DOWNLOAD_FAILED: 'UNREGISTERED_TOKENS_DOWNLOAD_FAILED',
   UNREGISTERED_TOKENS_DOWNLOAD_END: 'UNREGISTERED_TOKENS_DOWNLOAD_END',
+  UNREGISTERED_TOKENS_CLEAN: 'UNREGISTERED_TOKENS_CLEAN',
 };
 
 /**
@@ -1018,4 +1019,11 @@ export const unregisteredTokensDownloadFailed = (error) => ({
  */
 export const unregisteredTokensDownloadEnd = () => ({
   type: types.UNREGISTERED_TOKENS_DOWNLOAD_END,
+});
+
+/**
+ * Clean unregistered tokens state to its default value
+ */
+export const unregisteredTokensClean = () => ({
+  type: types.UNREGISTERED_TOKENS_CLEAN,
 });

--- a/src/components/Reown/FeedbackModal.js
+++ b/src/components/Reown/FeedbackModal.js
@@ -15,11 +15,11 @@ import { colors } from '../../constants';
  * Generic component that shows a modal with feedback for various operations
  * Shows loading, success or error message and provides retry option on failure
  */
-export function FeedbackModal({ 
+export function FeedbackModal({
   modalId,
-  isError, 
-  isLoading = true, 
-  onClose, 
+  isError,
+  isLoading = true,
+  onClose,
   manageDomLifecycle,
   titles = {
     loading: t`Processing`,
@@ -32,7 +32,9 @@ export function FeedbackModal({
     success: t`The operation completed successfully.`
   },
   retryAction,
-  retryDismissAction
+  retryDismissAction,
+  extraComponent,
+  customButtons
 }) {
   const dispatch = useDispatch();
 
@@ -83,11 +85,14 @@ export function FeedbackModal({
     <>
       <div className="modal-body">
         <p>{messages.success}</p>
+        {extraComponent && extraComponent}
       </div>
       <div className="modal-footer">
-        <button type="button" className="btn btn-hathor" onClick={handleDismiss}>
-          {t`Close`}
-        </button>
+        {customButtons ? customButtons : (
+          <button type="button" className="btn btn-hathor" onClick={handleDismiss}>
+            {t`Close`}
+          </button>
+        )}
       </div>
     </>
   );

--- a/src/components/Reown/NanoContractActions.js
+++ b/src/components/Reown/NanoContractActions.js
@@ -254,7 +254,7 @@ export function NanoContractActions({ ncActions }) {
 
   // A callback to retrieve the action title by its token symbol or hash
   const getTitle = useCallback(
-    (action) => getActionTitle({...unregisteredTokens, ...registeredMap}, action),
+    (action) => getActionTitle({...unregisteredTokens.tokensMap, ...registeredMap}, action),
     [registeredTokens, unregisteredTokens]
   );
 

--- a/src/components/Reown/NanoContractFeedbackModal.js
+++ b/src/components/Reown/NanoContractFeedbackModal.js
@@ -23,10 +23,8 @@ export function NanoContractFeedbackModal({ isError, isLoading = true, onClose, 
   const dispatch = useDispatch();
   const unregisteredTokens = useSelector((state) => state.unregisteredTokens);
 
-  // Get unregistered tokens excluding metadata fields
-  const unregisteredTokensList = Object.keys(unregisteredTokens)
-    .filter(key => key !== 'isLoading' && key !== 'error')
-    .map(uid => unregisteredTokens[uid]);
+  // Get unregistered tokens from tokensMap
+  const unregisteredTokensList = Object.values(unregisteredTokens.tokensMap || {});
 
   const hasUnregisteredTokens = !isLoading && !isError && unregisteredTokensList.length > 0;
 

--- a/src/components/Reown/NanoContractFeedbackModal.js
+++ b/src/components/Reown/NanoContractFeedbackModal.js
@@ -7,8 +7,11 @@
 
 import React from 'react';
 import { t } from 'ttag';
-import { types } from '../../actions';
+import { useSelector, useDispatch } from 'react-redux';
+import { types, unregisteredTokensClean } from '../../actions';
 import { FeedbackModal } from './FeedbackModal';
+import { constants } from '@hathor/wallet-lib';
+import tokens from '../../utils/tokens';
 
 export const MODAL_ID = 'nanoContractFeedbackModal';
 
@@ -17,12 +20,77 @@ export const MODAL_ID = 'nanoContractFeedbackModal';
  * Shows loading, success or error message and provides retry option on failure
  */
 export function NanoContractFeedbackModal({ isError, isLoading = true, onClose, manageDomLifecycle }) {
+  const dispatch = useDispatch();
+  const unregisteredTokens = useSelector((state) => state.unregisteredTokens);
+
+  // Get unregistered tokens excluding metadata fields
+  const unregisteredTokensList = Object.keys(unregisteredTokens)
+    .filter(key => key !== 'isLoading' && key !== 'error')
+    .map(uid => unregisteredTokens[uid]);
+
+  const hasUnregisteredTokens = !isLoading && !isError && unregisteredTokensList.length > 0;
+
+  const handleRegisterTokens = () => {
+    // Register all unregistered tokens
+    unregisteredTokensList.forEach(token => {
+      tokens.addToken(token.uid, token.name, token.symbol);
+    });
+
+    // Clean unregistered tokens state
+    dispatch(unregisteredTokensClean());
+    onClose();
+  };
+
+  const handleClose = () => {
+    // Clean unregistered tokens state
+    dispatch(unregisteredTokensClean());
+    onClose();
+  };
+
+  const renderUnregisteredTokensComponent = () => {
+    if (!hasUnregisteredTokens) return null;
+
+    const many = unregisteredTokensList.length > 1;
+
+    return (
+      <div className="mt-3 p-3 border rounded bg-light">
+        <p className="text-muted small mb-3">
+          {t`There ${many ? `are ${unregisteredTokensList.length}` : 'is 1'} unregistered token${many ? 's' : ''} in this transaction. Do you want to register ${many ? 'them' : 'it'}?`}
+        </p>
+        {unregisteredTokensList.map(token => (
+          <div key={token.uid} className="mb-2 p-2 border rounded bg-white">
+            <div className="font-weight-bold">{token.name}</div>
+            <div className="text-muted small">{token.symbol}</div>
+            <div className="text-monospace small" style={{ fontSize: '0.8rem' }}>
+              {token.uid}
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  };
+
+  const renderCustomButtons = () => {
+    if (!hasUnregisteredTokens) return null;
+
+    return (
+      <>
+        <button type="button" className="btn btn-secondary" onClick={handleClose}>
+          {t`Close`}
+        </button>
+        <button type="button" className="btn btn-hathor" onClick={handleRegisterTokens}>
+          {t`Register Tokens`}
+        </button>
+      </>
+    );
+  };
+
   return (
     <FeedbackModal
       modalId={MODAL_ID}
       isError={isError}
       isLoading={isLoading}
-      onClose={onClose}
+      onClose={hasUnregisteredTokens ? handleClose : onClose}
       manageDomLifecycle={manageDomLifecycle}
       titles={{
         loading: t`Processing Transaction`,
@@ -36,6 +104,8 @@ export function NanoContractFeedbackModal({ isError, isLoading = true, onClose, 
       }}
       retryAction={types.REOWN_NEW_NANOCONTRACT_RETRY}
       retryDismissAction={types.REOWN_NEW_NANOCONTRACT_RETRY_DISMISS}
+      extraComponent={renderUnregisteredTokensComponent()}
+      customButtons={renderCustomButtons()}
     />
   );
 } 

--- a/src/components/Reown/NanoContractFeedbackModal.js
+++ b/src/components/Reown/NanoContractFeedbackModal.js
@@ -49,11 +49,14 @@ export function NanoContractFeedbackModal({ isError, isLoading = true, onClose, 
     if (!hasUnregisteredTokens) return null;
 
     const many = unregisteredTokensList.length > 1;
+    const message = many
+      ? t`There are ${unregisteredTokensList.length} unregistered tokens in this transaction. Do you want to register them?`
+      : t`There is 1 unregistered token in this transaction. Do you want to register it?`;
 
     return (
       <div className="mt-3 p-3 border rounded bg-light">
         <p className="text-muted small mb-3">
-          {t`There ${many ? `are ${unregisteredTokensList.length}` : 'is 1'} unregistered token${many ? 's' : ''} in this transaction. Do you want to register ${many ? 'them' : 'it'}?`}
+          {message}
         </p>
         {unregisteredTokensList.map(token => (
           <div key={token.uid} className="mb-2 p-2 border rounded bg-white">

--- a/src/components/Reown/modals/BaseNanoContractModal.js
+++ b/src/components/Reown/modals/BaseNanoContractModal.js
@@ -182,6 +182,7 @@ export function BaseNanoContractModal({
   const decimalPlaces = useSelector((state) => state.serverInfo.decimalPlaces);
   const firstAddress = useSelector((state) => state.reown.firstAddress);
   const registeredTokens = useSelector((state) => state.tokens);
+  const unregisteredTokens = useSelector((state) => state.unregisteredTokens);
 
   // Local state
   const [selectedAddress, setSelectedAddress] = useState(firstAddress);
@@ -320,8 +321,6 @@ export function BaseNanoContractModal({
             <h6 className="font-weight-bold mb-3">{t`Action List`}</h6>
             <NanoContractActions
               ncActions={nanoContract.actions}
-              tokens={nanoContract.tokens}
-              error={nanoContract.tokens?.error}
             />
           </div>
         )}
@@ -339,6 +338,7 @@ export function BaseNanoContractModal({
         </button>
         <button
           type="button"
+          disabled={unregisteredTokens.isLoading || unregisteredTokens.error}
           className="btn btn-hathor"
           onClick={handleAccept}
         >

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -94,18 +94,21 @@ const initialState = {
    *
    * @example
    * {
-   *   '000003a3b261e142d3dfd84970d3a50a93b5bc3a66a3b6ba973956148a3eb824': {
-   *     name: 'YanCoin',
-   *     symbol: 'YAN',
-   *     uid: '000003a3b261e142d3dfd84970d3a50a93b5bc3a66a3b6ba973956148a3eb824',
-   *   },
    *   isLoading: false,
    *   error: null,
+   *   tokensMap: {
+   *     '000003a3b261e142d3dfd84970d3a50a93b5bc3a66a3b6ba973956148a3eb824': {
+   *       name: 'YanCoin',
+   *       symbol: 'YAN',
+   *       uid: '000003a3b261e142d3dfd84970d3a50a93b5bc3a66a3b6ba973956148a3eb824',
+   *     },
+   *   }
    * }
    */
   unregisteredTokens: {
     isLoading: false,
     error: null,
+    tokensMap: {},
   },
   // If is in the proccess of loading addresses transactions from the full node
   // When the request to load addresses fails this variable can continue true
@@ -1554,7 +1557,10 @@ export const onUnregisteredTokensDownloadSuccess = (state, action) => {
     ...state,
     unregisteredTokens: {
       ...state.unregisteredTokens,
-      ...tokens
+      tokensMap: {
+        ...state.unregisteredTokens.tokensMap,
+        ...tokens
+      }
     },
   };
 };
@@ -1614,6 +1620,7 @@ export const onUnregisteredTokensClean = (state) => {
     unregisteredTokens: {
       isLoading: false,
       error: null,
+      tokensMap: {},
     },
   };
 };

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -87,6 +87,26 @@ const initialState = {
    * @example { 00: "00", abc123: "abc123" }
    */
   allTokens: {},
+  /**
+   * Remarks
+   * We use the map of tokens to collect token details for tokens
+   * used in nano contract actions but not registered by the user.
+   *
+   * @example
+   * {
+   *   '000003a3b261e142d3dfd84970d3a50a93b5bc3a66a3b6ba973956148a3eb824': {
+   *     name: 'YanCoin',
+   *     symbol: 'YAN',
+   *     uid: '000003a3b261e142d3dfd84970d3a50a93b5bc3a66a3b6ba973956148a3eb824',
+   *   },
+   *   isLoading: false,
+   *   error: null,
+   * }
+   */
+  unregisteredTokens: {
+    isLoading: false,
+    error: null,
+  },
   // If is in the proccess of loading addresses transactions from the full node
   // When the request to load addresses fails this variable can continue true
   loadingAddresses: false,
@@ -463,6 +483,13 @@ const rootReducer = (state = initialState, action) => {
     case types.UNREGISTERED_TOKENS_DOWNLOAD_SUCCESS:
       return onUnregisteredTokensDownloadSuccess(state, action);
     case types.UNREGISTERED_TOKENS_DOWNLOAD_FAILED:
+      return onUnregisteredTokensDownloadFailed(state, action);
+    case types.UNREGISTERED_TOKENS_DOWNLOAD_REQUESTED:
+      return onUnregisteredTokensDownloadRequested(state);
+    case types.UNREGISTERED_TOKENS_DOWNLOAD_END:
+      return onUnregisteredTokensDownloadEnd(state);
+    case types.UNREGISTERED_TOKENS_CLEAN:
+      return onUnregisteredTokensClean(state);
     default:
       return state;
   }
@@ -1522,15 +1549,72 @@ export const onUpdateNetworkSettings = (state, { payload }) => {
  */
 export const onUnregisteredTokensDownloadSuccess = (state, action) => {
   const { tokens } = action.payload;
-  const newTokens = Object.values(tokens).map(token => ({
-    uid: token.uid,
-    name: token.name,
-    symbol: token.symbol
-  }));
 
   return {
     ...state,
-    tokens: [...state.tokens, ...newTokens],
+    unregisteredTokens: {
+      ...state.unregisteredTokens,
+      ...tokens
+    },
+  };
+};
+
+/**
+ * Handle error when downloading unregistered token details
+ * @param {Object} state Current state
+ * @param {Object} action Action with token details
+ * @param {string} action.payload.error Error message
+ */
+export const onUnregisteredTokensDownloadFailed = (state, action) => {
+  const { error } = action.payload;
+
+  return {
+    ...state,
+    unregisteredTokens: {
+      ...state.unregisteredTokens,
+      isLoading: false,
+      error,
+    },
+  };
+};
+
+/**
+ * Handle begin of unregistered tokens downloads
+ */
+export const onUnregisteredTokensDownloadRequested = (state) => {
+  return {
+    ...state,
+    unregisteredTokens: {
+      ...state.unregisteredTokens,
+      isLoading: true,
+      error: null,
+    },
+  };
+};
+
+/**
+ * Handle end of unregistered tokens downloads
+ */
+export const onUnregisteredTokensDownloadEnd = (state) => {
+  return {
+    ...state,
+    unregisteredTokens: {
+      ...state.unregisteredTokens,
+      isLoading: false,
+    },
+  };
+};
+
+/**
+ * Clean unregistered tokens state to its default value
+ */
+export const onUnregisteredTokensClean = (state) => {
+  return {
+    ...state,
+    unregisteredTokens: {
+      isLoading: false,
+      error: null,
+    },
   };
 };
 

--- a/src/sagas/reown.js
+++ b/src/sagas/reown.js
@@ -58,6 +58,7 @@ import {
   showGlobalModal,
   hideGlobalModal,
   setReownFirstAddress,
+  unregisteredTokensClean,
 } from '../actions';
 import { checkForFeatureFlag, getNetworkSettings, retryHandler } from './helpers';
 import { logger } from '../utils/logger';
@@ -433,6 +434,7 @@ export function* processRequest(action) {
     switch (e.constructor) {
       case SendNanoContractTxError: {
         yield put(setNewNanoContractStatusFailure());
+        yield put(unregisteredTokensClean());
         yield put(showGlobalModal(MODAL_TYPES.NANO_CONTRACT_FEEDBACK, { isLoading: false, isError: true }));
 
         const retry = yield call(
@@ -500,6 +502,7 @@ export function* processRequest(action) {
       } break;
       case CreateNanoContractCreateTokenTxError: {
         yield put(setNewNanoContractStatusFailure());
+        yield put(unregisteredTokensClean());
         yield put(showGlobalModal(MODAL_TYPES.NANO_CONTRACT_FEEDBACK, { isLoading: false, isError: true }));
 
         const retry = yield call(

--- a/src/sagas/tokens.js
+++ b/src/sagas/tokens.js
@@ -398,13 +398,10 @@ export function* getTokenDetails(wallet, uid) {
   try {
     const { tokenInfo: { symbol, name } } = yield call([wallet, wallet.getTokenDetails], uid);
     
-    // Register the token in the wallet storage
-    yield call([wallet.storage, wallet.storage.registerToken], { uid, name, symbol });
-    
     yield put(unregisteredTokensDownloadSuccess({ [uid]: { uid, symbol, name } }));
   } catch (e) {
     log.error(`Fail getting token data for token ${uid}.`, e);
-    yield put(unregisteredTokensDownloadFailed('Some tokens could not be loaded'));
+    yield put(unregisteredTokensDownloadFailed(t`Fail to download unregistered tokens data.`));
   }
 }
 


### PR DESCRIPTION
### Acceptance Criteria
- We shouldn't register action tokens as soon as a Reown request arrives.
- We should download data and store in a separate redux state to be used by the component to show the symbol
- We should ask the user to register the unregistered tokens after the tx is sent successfully.

In the video we have the tokens not registered in the first request. The actions show the symbol correctly and we ask if the user wants to register them. In the second request we don't ask anything because the tokens are already registered, and the symbol appears in the actions list as well.

https://github.com/user-attachments/assets/7700ad34-d116-441d-bd81-8362b014de43

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
