### PR TITLE
fix: prevent feature flag context leak between networks

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -70,6 +70,7 @@ export const types = {
   NETWORKSETTINGS_UPDATED: 'NETWORKSETTINGS_UPDATED',
   NETWORKSETTINGS_UPDATE_SUCCESS: 'NETWORKSETTINGS_UPDATE_SUCCESS',
   NETWORKSETTINGS_SET_STATUS: 'NETWORKSETTINGS_SET_STATUS',
+  UNLEASH_CONTEXT_UPDATED: 'UNLEASH_CONTEXT_UPDATED',
   REOWN_SET_CLIENT: 'REOWN_SET_CLIENT',
   REOWN_SET_MODAL: 'REOWN_SET_MODAL',
   REOWN_SET_SESSIONS: 'REOWN_SET_SESSIONS',
@@ -749,6 +750,18 @@ export const networkSettingsRequestUpdate = (data, pin) => ({
  */
 export const networkSettingsUpdateSuccess = () => ({
   type: types.NETWORKSETTINGS_UPDATE_SUCCESS,
+});
+
+/**
+ * Signals that the Unleash client context has been refreshed and
+ * state.featureToggles reflects the current network. Dispatched by the
+ * NETWORKSETTINGS_UPDATE_SUCCESS listener after updateUnleashClientContext
+ * completes (success or failure). Consumers that need synchronous ordering
+ * with the refresh (e.g. executeNetworkSettingsUpdate before restarting the
+ * wallet) should `take` this action.
+ */
+export const unleashContextUpdated = () => ({
+  type: types.UNLEASH_CONTEXT_UPDATED,
 });
 
 /**

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1152,8 +1152,9 @@ export const onStartWalletFailed = (state) => ({
  * - ledgerWasClosed: Ledger device state persists across wallet instances
  * - featureTogglesInitialized: Unleash client runs independently
  *
- * Note: networkSettings is intentionally reset because the onWalletReset saga
- * resets localStorage and reloads default network settings before this reducer runs.
+ * Note: networkSettings is reset to initialState; onWalletReset calls
+ * helpers.loadStorageState() after this reducer to repopulate it and trigger
+ * the Unleash refresh listener.
  *
  * Note 2: The default values to preserve are the same from `onCleanData()`
  */

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -596,8 +596,6 @@ const onCleanData = (state) => {
     loadingAddresses: state.loadingAddresses,
     ledgerWasClosed: state.ledgerWasClosed,
     featureTogglesInitialized: state.featureTogglesInitialized,
-    // Must be preserved together with featureTogglesInitialized — see onStartWalletReset.
-    featureToggles: state.featureToggles,
   });
 };
 
@@ -1153,13 +1151,6 @@ export const onStartWalletFailed = (state) => ({
  * - isVersionAllowed: API version check is independent of wallet data
  * - ledgerWasClosed: Ledger device state persists across wallet instances
  * - featureTogglesInitialized: Unleash client runs independently
- * - featureToggles: must be preserved together with the initialized flag,
- *   otherwise checkForFeatureFlag (which skips waiting when
- *   featureTogglesInitialized is true) reads the defaults and the next
- *   startWallet picks the wrong values for any flag that has divergent
- *   values per network at the Unleash client. The onWalletReset saga
- *   calls updateUnleashClientContext before dispatching START_WALLET_RESET,
- *   so the value preserved here already reflects the post-reset network.
  *
  * Note: networkSettings is intentionally reset because the onWalletReset saga
  * resets localStorage and reloads default network settings before this reducer runs.
@@ -1172,7 +1163,6 @@ export const onStartWalletReset = (state) => ({
   isVersionAllowed: state.isVersionAllowed,
   ledgerWasClosed: state.ledgerWasClosed,
   featureTogglesInitialized: state.featureTogglesInitialized,
-  featureToggles: state.featureToggles,
   // Explicitly ensure these states are cleared
   walletStartState: null,
   loadingAddresses: false,

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -596,6 +596,8 @@ const onCleanData = (state) => {
     loadingAddresses: state.loadingAddresses,
     ledgerWasClosed: state.ledgerWasClosed,
     featureTogglesInitialized: state.featureTogglesInitialized,
+    // Must be preserved together with featureTogglesInitialized — see onStartWalletReset.
+    featureToggles: state.featureToggles,
   });
 };
 
@@ -1151,6 +1153,13 @@ export const onStartWalletFailed = (state) => ({
  * - isVersionAllowed: API version check is independent of wallet data
  * - ledgerWasClosed: Ledger device state persists across wallet instances
  * - featureTogglesInitialized: Unleash client runs independently
+ * - featureToggles: must be preserved together with the initialized flag,
+ *   otherwise checkForFeatureFlag (which skips waiting when
+ *   featureTogglesInitialized is true) reads the defaults and the next
+ *   startWallet picks the wrong values for any flag that has divergent
+ *   values per network at the Unleash client. The onWalletReset saga
+ *   calls updateUnleashClientContext before dispatching START_WALLET_RESET,
+ *   so the value preserved here already reflects the post-reset network.
  *
  * Note: networkSettings is intentionally reset because the onWalletReset saga
  * resets localStorage and reloads default network settings before this reducer runs.
@@ -1163,6 +1172,7 @@ export const onStartWalletReset = (state) => ({
   isVersionAllowed: state.isVersionAllowed,
   ledgerWasClosed: state.ledgerWasClosed,
   featureTogglesInitialized: state.featureTogglesInitialized,
+  featureToggles: state.featureToggles,
   // Explicitly ensure these states are cleared
   walletStartState: null,
   loadingAddresses: false,

--- a/src/sagas/featureToggle.js
+++ b/src/sagas/featureToggle.js
@@ -110,7 +110,15 @@ export function* updateUnleashClientContext(networkSettings = null) {
     },
   };
 
-  yield call(() => unleashClient.updateContext(options));
+  // updateContext refetches toggles for the new context. Once the promise
+  // resolves, unleashClient.toggles already reflects the new network.
+  // Sync redux synchronously here so consumers reading state.featureToggles
+  // immediately after (e.g. startWallet -> checkForFeatureFlag) see the
+  // post-context values, not the previous network's stale values.
+  yield call([unleashClient, unleashClient.updateContext], options);
+
+  const featureToggles = mapFeatureToggles(unleashClient.toggles);
+  yield put(setFeatureToggles(featureToggles));
 }
 
 export function* monitorFeatureFlags(currentRetry = 0) {
@@ -229,7 +237,7 @@ export function* setupUnleashListeners(unleashClient) {
   }
 }
 
-function mapFeatureToggles(toggles) {
+export function mapFeatureToggles(toggles) {
   console.log('feature toggles', toggles);
   return toggles.reduce((acc, toggle) => {
     acc[toggle.name] = get(

--- a/src/sagas/networkSettings.js
+++ b/src/sagas/networkSettings.js
@@ -1,5 +1,13 @@
-import { NETWORK_SETTINGS_STATUS } from '../constants';
-import { types, isVersionAllowedUpdate, selectToken, setNetworkSettingsStatus, serverInfoUpdated } from '../actions';
+import { FEATURE_TOGGLE_DEFAULTS, NETWORK_SETTINGS_STATUS } from '../constants';
+import {
+  types,
+  isVersionAllowedUpdate,
+  selectToken,
+  setFeatureToggles,
+  setNetworkSettingsStatus,
+  serverInfoUpdated,
+  unleashContextUpdated,
+} from '../actions';
 import { all, call, fork, join, put, select, take, takeEvery } from 'redux-saga/effects';
 import hathorLib from '@hathor/wallet-lib';
 import { getGlobalWallet } from '../modules/wallet';
@@ -93,10 +101,34 @@ export function* changeNetworkSettings({ data, pin }) {
 }
 
 /**
- * This method returns when a NETWORKSETTINGS_UPDATE_SUCCESS event arrives
+ * This method returns when an UNLEASH_CONTEXT_UPDATED event arrives.
+ *
+ * UNLEASH_CONTEXT_UPDATED is dispatched by onNetworkSettingsUpdateSuccess after
+ * updateUnleashClientContext finishes, so waiting for it implicitly waits for
+ * both the NETWORKSETTINGS_UPDATE_SUCCESS dispatch and the Unleash refresh —
+ * giving us synchronous ordering before the wallet restart.
  */
-function* waitForUpdateSuccess() {
-  yield take('NETWORKSETTINGS_UPDATE_SUCCESS');
+function* waitForUnleashContextUpdated() {
+  yield take(types.UNLEASH_CONTEXT_UPDATED);
+}
+
+/**
+ * Single reaction point for network changes: refreshes the Unleash context and
+ * emits UNLEASH_CONTEXT_UPDATED when done. Both the regular network-change flow
+ * and the wallet-reset flow reach this listener through helpers.updateNetworkSettings.
+ *
+ * On Unleash failure we write FEATURE_TOGGLE_DEFAULTS so consumers don't keep
+ * reading the previous network's values. UNLEASH_CONTEXT_UPDATED is always
+ * emitted (success or failure) so callers waiting on it never hang.
+ */
+export function* onNetworkSettingsUpdateSuccess() {
+  try {
+    yield call(updateUnleashClientContext);
+  } catch (e) {
+    console.error('Failed to refresh unleash context after network change', e);
+    yield put(setFeatureToggles(FEATURE_TOGGLE_DEFAULTS));
+  }
+  yield put(unleashContextUpdated());
 }
 
 /**
@@ -120,14 +152,13 @@ function* executeNetworkSettingsUpdate(networkSettings, pin) {
   const networkSettingsRedux = yield select((state) => state.networkSettings);
   const networkSettingsBackup = { ...networkSettingsRedux };
   try {
-    // Start waiting for the success in parallel
-    const waitTask = yield fork(waitForUpdateSuccess);
-    // Call the function that dispatches the action (e.g., makes API call)
+    // Fork before the dispatch: updateNetworkSettings dispatches synchronously,
+    // so a `take` placed after it would miss the action.
+    const waitTask = yield fork(waitForUnleashContextUpdated);
     helpers.updateNetworkSettings(networkSettings);
-    // Wait for the success to actually happen
+    // Block until the Unleash refresh finishes. The wallet restart below reads
+    // state.featureToggles via checkForFeatureFlag, which must reflect the new network.
     yield join(waitTask);
-    // Update unleash client context
-    yield call(updateUnleashClientContext, networkSettings);
     // Forces the re-validation of the allowed version after server change
     yield put(isVersionAllowedUpdate({ allowed: undefined }));
     yield put(selectToken(hathorLib.constants.NATIVE_TOKEN_UID));
@@ -136,9 +167,10 @@ function* executeNetworkSettingsUpdate(networkSettings, pin) {
     yield put(serverInfoUpdated());
   } catch (e) {
     console.error(e);
-    // Restores storage and states as it was before
+    // Restores storage and states as it was before. The listener will refresh
+    // Unleash for the restored network asynchronously; we don't await it here
+    // because the saga is exiting on error.
     helpers.updateNetworkSettings(networkSettingsBackup);
-    yield call(updateUnleashClientContext, networkSettingsBackup);
     yield put(setNetworkSettingsStatus({ status: NETWORK_SETTINGS_STATUS.ERROR, error: t`Error updating network settings.` }));
   }
   yield put(setNetworkSettingsStatus({ status: NETWORK_SETTINGS_STATUS.SUCCESS }));
@@ -147,5 +179,6 @@ function* executeNetworkSettingsUpdate(networkSettings, pin) {
 export function* saga() {
   yield all([
     takeEvery(types.NETWORKSETTINGS_UPDATE_REQUESTED, changeNetworkSettings),
+    takeEvery(types.NETWORKSETTINGS_UPDATE_SUCCESS, onNetworkSettingsUpdateSuccess),
   ]);
 }

--- a/src/sagas/wallet.js
+++ b/src/sagas/wallet.js
@@ -28,7 +28,6 @@ import {
   WALLET_SERVICE_FEATURE_TOGGLE,
   ATOMIC_SWAP_SERVICE_FEATURE_TOGGLE,
   IGNORE_WS_TOGGLE_FLAG,
-  FEATURE_TOGGLE_DEFAULTS,
 } from '../constants';
 import {
   types,
@@ -61,7 +60,6 @@ import {
   addRegisteredTokens,
   startWalletSuccess,
   startWalletReset,
-  setFeatureToggles,
   newUnknownTokensFound,
 } from '../actions';
 import {
@@ -71,7 +69,6 @@ import {
   dispatchLedgerTokenSignatureVerification,
 } from './helpers';
 import { fetchTokenData, restoreTokensForNetwork } from './tokens';
-import { updateUnleashClientContext } from './featureToggle';
 import walletUtils from '../utils/wallet';
 import tokensUtils from '../utils/tokens';
 import nanoUtils from '../utils/nanoContracts';
@@ -786,21 +783,6 @@ export function* onWalletReset() {
   config.setNetwork('mainnet');
   // This will update the lib config and redux state with the default network settings
   helpersUtils.loadStorageState();
-
-  // Sync the unleash client + redux feature toggles with the post-reset network
-  // (mainnet defaults). Without this, state.featureToggles would still reflect
-  // the network the user was on before the reset, and the next startWallet would
-  // read stale flags. Errors here must not block the reset (it is irreversible
-  // from the user's perspective); on failure we explicitly write
-  // FEATURE_TOGGLE_DEFAULTS so checkForFeatureFlag (which reads via lodash.get
-  // with a per-key default) doesn't return the previous network's stale values
-  // — the defaults only kick in for missing keys, not pre-existing stale ones.
-  try {
-    yield call(updateUnleashClientContext);
-  } catch (e) {
-    console.error('Failed to refresh unleash context after wallet reset', e);
-    yield put(setFeatureToggles(FEATURE_TOGGLE_DEFAULTS));
-  }
 
   if (wallet) {
     yield call([wallet, wallet.stop], { cleanStorage: true, cleanAddresses: true });

--- a/src/sagas/wallet.js
+++ b/src/sagas/wallet.js
@@ -69,6 +69,7 @@ import {
   dispatchLedgerTokenSignatureVerification,
 } from './helpers';
 import { fetchTokenData, restoreTokensForNetwork } from './tokens';
+import { updateUnleashClientContext } from './featureToggle';
 import walletUtils from '../utils/wallet';
 import tokensUtils from '../utils/tokens';
 import nanoUtils from '../utils/nanoContracts';
@@ -783,6 +784,18 @@ export function* onWalletReset() {
   config.setNetwork('mainnet');
   // This will update the lib config and redux state with the default network settings
   helpersUtils.loadStorageState();
+
+  // Sync the unleash client + redux feature toggles with the post-reset network
+  // (mainnet defaults). Without this, state.featureToggles would still reflect
+  // the network the user was on before the reset, and the next startWallet would
+  // read stale flags. Errors here must not block the reset (it is irreversible
+  // from the user's perspective); FEATURE_TOGGLE_DEFAULTS covers the degraded case.
+  try {
+    yield call(updateUnleashClientContext);
+  } catch (e) {
+    console.error('Failed to refresh unleash context after wallet reset', e);
+  }
+
   if (wallet) {
     yield call([wallet, wallet.stop], { cleanStorage: true, cleanAddresses: true });
   }

--- a/src/sagas/wallet.js
+++ b/src/sagas/wallet.js
@@ -781,14 +781,18 @@ export function* onWalletReset() {
   // We must set the lib config network to mainnet because it's the default network
   // XXX we should have a method in the config to reset all configs
   config.setNetwork('mainnet');
-  // This will update the lib config and redux state with the default network settings
-  helpersUtils.loadStorageState();
 
   if (wallet) {
     yield call([wallet, wallet.stop], { cleanStorage: true, cleanAddresses: true });
   }
 
+  // Wipe redux to initialState first, then push fresh defaults via loadStorageState.
+  // loadStorageState dispatches NETWORKSETTINGS_UPDATE_SUCCESS, which triggers the
+  // listener that refreshes Unleash and writes setFeatureToggles. Doing the wipe
+  // first guarantees that setFeatureToggles is the final write to state.featureToggles,
+  // not something the wipe clobbers.
   yield put(startWalletReset());
+  helpersUtils.loadStorageState();
 
   yield put(setNavigateTo('/welcome'));
 }

--- a/src/sagas/wallet.js
+++ b/src/sagas/wallet.js
@@ -28,6 +28,7 @@ import {
   WALLET_SERVICE_FEATURE_TOGGLE,
   ATOMIC_SWAP_SERVICE_FEATURE_TOGGLE,
   IGNORE_WS_TOGGLE_FLAG,
+  FEATURE_TOGGLE_DEFAULTS,
 } from '../constants';
 import {
   types,
@@ -60,6 +61,7 @@ import {
   addRegisteredTokens,
   startWalletSuccess,
   startWalletReset,
+  setFeatureToggles,
   newUnknownTokensFound,
 } from '../actions';
 import {
@@ -789,11 +791,15 @@ export function* onWalletReset() {
   // (mainnet defaults). Without this, state.featureToggles would still reflect
   // the network the user was on before the reset, and the next startWallet would
   // read stale flags. Errors here must not block the reset (it is irreversible
-  // from the user's perspective); FEATURE_TOGGLE_DEFAULTS covers the degraded case.
+  // from the user's perspective); on failure we explicitly write
+  // FEATURE_TOGGLE_DEFAULTS so checkForFeatureFlag (which reads via lodash.get
+  // with a per-key default) doesn't return the previous network's stale values
+  // — the defaults only kick in for missing keys, not pre-existing stale ones.
   try {
     yield call(updateUnleashClientContext);
   } catch (e) {
     console.error('Failed to refresh unleash context after wallet reset', e);
+    yield put(setFeatureToggles(FEATURE_TOGGLE_DEFAULTS));
   }
 
   if (wallet) {


### PR DESCRIPTION
## Summary

`state.featureToggles` retained values from the previous network after a network switch (Settings → Network) and after Reset All Data. Any consumer of `checkForFeatureFlag` (which reads `state.featureToggles[<flag>]`) saw stale values, affecting every flag read through that path: `WALLET_SERVICE_FEATURE_TOGGLE`, `ATOMIC_SWAP_SERVICE_FEATURE_TOGGLE`, `REOWN_FEATURE_TOGGLE`, `NANO_CONTRACTS_FEATURE_TOGGLE`, `FEE_TOKEN_FEATURE_TOGGLE`.

The bug was uncovered during QA of #861 (single address mode), where the new flag had clearly divergent values per network and made the leak observable. The other flags were either uniformly configured across networks or had silent effects, so the issue went unnoticed.

## Root cause

`updateUnleashClientContext` called `unleashClient.updateContext(...)` (which refetches toggles for the new context), but redux was updated **asynchronously** via the `UPDATE` event → `eventChannel` → `FEATURE_TOGGLE_UPDATE` action → `handleToggleUpdate` (`takeEvery`). Consumers calling `checkForFeatureFlag` immediately after read `state.featureToggles` before the update reached redux. `waitForFeatureToggleInitialization` didn't help — `featureTogglesInitialized` was already `true` since boot.

In `onWalletReset` the problem was even more direct: the saga **never called** `updateUnleashClientContext`, so the unleash client kept the pre-reset network context.

Additionally, the reducer (`onStartWalletReset` and `onCleanData`) wiped `state.featureToggles` to defaults via `...initialState` while keeping `featureTogglesInitialized` set, so even when the saga wrote the right values first, the reducer immediately reset them — and `checkForFeatureFlag` skipped the wait and read the defaults.

## Out of scope

- `IGNORE_WS_TOGGLE_FLAG` (`localStorage['featureFlags:ignoreWalletServiceFlag']`) — same structural pattern (no per-network namespace) but a different layer; tracked in a separate issue.
- Single address mode and related changes from #861.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Feature toggles now reliably refresh after wallet resets, wallet switches, and network setting changes so the app shows current feature availability instead of stale values.
  * Improved sequencing during resets and network updates to prevent outdated feature states from being restored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->