### PR TITLE
fix: prevent Send screen crash on LavaMoat production build

### DIFF
--- a/lavamoat/webpack/policy-override.json
+++ b/lavamoat/webpack/policy-override.json
@@ -1,5 +1,11 @@
 {
   "resources": {
+    "cypress>lodash": {
+      "globals": {
+        "setTimeout": true,
+        "clearTimeout": true
+      }
+    },
     "bootstrap": {
       "globals": {
         "document": true,


### PR DESCRIPTION
### Summary

Send Tokens crashed only on the LavaMoat/SES production build (`ft.setTimeout is not a function`), never in dev. `SendTokensOne` uses `_.debounce`; under LavaMoat lodash reads `root.setTimeout`, where `root = Function('return this')()` returns the compartment global — which doesn't expose the granted `setTimeout`.

Fix: grant `setTimeout`/`clearTimeout` to lodash in the policy override. No app code change; SES lockdown not weakened. Verified on the packaged production `.app`.

### Acceptance Criteria

- [x] Send renders and works on the LavaMoat production build
- [x] Debounce intact (`cancel()` / `flush()`)
- [x] Minimal grant; no `evalTaming` relaxation

### Security Checklist

- [x] No new dependencies
- [x] Grant scoped to one package and two timer globals — narrower than relaxing `evalTaming`

### Why the resource id is `cypress>lodash`

The `cypress>` prefix is **not** about cypress running — no cypress code ships in the app. Webpack only bundles what `src/` imports; lodash is in the bundle because ~12 app files `import { get } from 'lodash'`. The prefix is only LavaMoat's canonical name for the single hoisted `node_modules/lodash`.

LavaMoat must give that one physical package a canonical name, and picks it from the *declared* dependency graph via `comparePreferredPackageName` (`@lavamoat/aa`): shortest path wins, ties broken by shortest parent name, then alphabetical. Three packages declare lodash — `@hathor/wallet-lib`, `@ledgerhq/hw-transport-node-hid`, `cypress` — all length-2 paths, so `cypress` (7 chars) wins the tie-break. It's a label-picking heuristic, nothing more.

### Follow-up (stability)

The name only routes through a devDependency because the app never declares lodash itself — a phantom dependency. If those declared paths change (a declarer removed/updated), the canonical name changes and this grant silently stops applying (the crash returns). Fix: add `lodash` to `dependencies` — root's length-1 edge always beats length-2, so the canonical name becomes plain `lodash`, stable regardless of hoisting; the override key is renamed to match.