### PR TITLE
fix: restore lost UX in Send Tokens flow (PIN focus and Close returns Home)

### DIFF
--- a/src/components/ModalTransactionOverview.js
+++ b/src/components/ModalTransactionOverview.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { t } from 'ttag';
 import $ from 'jquery';
 import PropTypes from 'prop-types';
@@ -40,11 +40,24 @@ function ModalTransactionOverview({
   const [phase, setPhase] = useState('review');
   const [errorMessage, setErrorMessage] = useState('');
   const [preparedTx, setPreparedTx] = useState(null);
+  const pinInputRef = useRef(null);
   const tokenMetadata = useSelector((state) => state.tokenMetadata);
 
   useEffect(() => {
     manageDomLifecycle(`#${MODAL_ID}`);
   }, [manageDomLifecycle]);
+
+  // Focus the PIN field after the modal finishes fading in. `autoFocus` alone
+  // fails on first open: the input mounts while the modal is still `display:none`,
+  // so the browser drops the focus. `autoFocus` is still kept — it covers the
+  // error -> "Try again" -> review remount, where the modal is already visible.
+  useEffect(() => {
+    const onShown = () => pinInputRef.current?.focus();
+    $(`#${MODAL_ID}`).on('shown.bs.modal.focuspin', onShown);
+    return () => {
+      $(`#${MODAL_ID}`).off('shown.bs.modal.focuspin', onShown);
+    };
+  }, []);
 
   const fee = typeof totalFee === 'bigint' ? totalFee : BigInt(totalFee || 0);
   const hasAnyFee = fee > 0n;
@@ -291,6 +304,7 @@ function ModalTransactionOverview({
       <div className="form-group">
         <label htmlFor="pinInput">{t`Pin* (6 digit password)`}</label>
         <input
+          ref={pinInputRef}
           type="password"
           className="form-control"
           id="pinInput"

--- a/src/screens/SendTokens.js
+++ b/src/screens/SendTokens.js
@@ -522,7 +522,7 @@ function SendTokens() {
       decimalPlaces,
       onClose: () => {
         globalModalContext.hideModal();
-        resetForm();
+        navigate('/wallet/');
       },
       onViewDetails: () => {
         console.log('View tx details:', tx.hash, tx);
@@ -594,20 +594,6 @@ function SendTokens() {
       const { [tokenUid]: removed, ...rest } = prev;
       return rest;
     });
-  };
-
-  /**
-   * Reset form to initial state after successful send
-   */
-  const resetForm = () => {
-    setTxTokens([...getSelectedToken()]);
-    setDataOutputs([]);
-    setTokenFees({});
-    setTokenChangeOutputs({});
-    setFeeError('');
-    setErrorMessage('');
-    references.current = [React.createRef()];
-    dataOutputRefs.current = {};
   };
 
   /**


### PR DESCRIPTION
### Acceptance Criteria
- When the PIN confirmation modal opens in the **Send Tokens** flow, the PIN input is focused automatically so the user can start typing right away (regression from the fee-token send refactor #858).
- After a transaction is sent, the success modal's **Close** button and top-right **×** return the user to the wallet home (`/wallet/`), restoring the pre-refactor behavior. **View transaction details** still opens the transaction page.

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. **No dependencies or configuration were changed** — the PR modifies two source files only.

### Video
https://github.com/user-attachments/assets/50439dd0-3a30-42a5-908f-c1e43fcf6cbb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The PIN field in the transaction overview now focuses automatically when the modal opens, making it faster to enter your PIN.
  * After a successful token send, closing the success message now takes you back to the wallet view.

* **Bug Fixes**
  * Improved modal behavior so PIN entry is more reliable and consistent.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->