### PR TITLE
fix: RC regressions (address mode, import banner, explorer link, send PIN)

### DIFF
--- a/src/components/ModalTokenImport.js
+++ b/src/components/ModalTokenImport.js
@@ -14,6 +14,7 @@ import { GlobalModalContext, MODAL_TYPES } from './GlobalModal';
 import { tokenRegisterRequested } from '../actions/index';
 import { getGlobalWallet } from '../modules/wallet';
 import walletUtils from '../utils/wallet';
+import helpers from '../utils/helpers';
 import { colors } from '../constants';
 
 /**
@@ -337,7 +338,10 @@ export default function ModalTokenImport({ onClose, manageDomLifecycle }) {
               <a
                 className="token-uid"
                 href={explorerLink}
-                target="_blank"
+                onClick={(e) => {
+                  e.preventDefault();
+                  helpers.openExternalURL(explorerLink);
+                }}
                 rel="noopener noreferrer"
                 title={uid}
               >

--- a/src/components/ModalTransactionOverview.js
+++ b/src/components/ModalTransactionOverview.js
@@ -15,6 +15,7 @@ import { useSelector } from 'react-redux';
 import helpers from '../utils/helpers';
 import { TOKEN_FEE_RFC_URL, colors } from '../constants';
 import SendTxHandler from './SendTxHandler';
+import { getGlobalWallet } from '../modules/wallet';
 
 const MODAL_ID = 'transactionOverviewModal';
 
@@ -39,6 +40,7 @@ function ModalTransactionOverview({
   const [pin, setPin] = useState('');
   const [phase, setPhase] = useState('review');
   const [errorMessage, setErrorMessage] = useState('');
+  const [pinError, setPinError] = useState('');
   const [preparedTx, setPreparedTx] = useState(null);
   const pinInputRef = useRef(null);
   const tokenMetadata = useSelector((state) => state.tokenMetadata);
@@ -108,10 +110,28 @@ function ModalTransactionOverview({
   const handleCancel = () => {
     $(`#${MODAL_ID}`).modal('hide');
     setPin('');
+    setPinError('');
     onCancel();
   };
 
   const handleConfirm = async () => {
+    // Validate the PIN before attempting the send so a wrong PIN surfaces as
+    // "Invalid PIN" on the review phase instead of a generic send failure. A
+    // missing wallet or a checkPin failure is a real error, not a wrong PIN, so
+    // route it to the error phase instead of leaving the rejection unhandled.
+    try {
+      const wallet = getGlobalWallet();
+      if (!await wallet.checkPin(pin)) {
+        setPinError(t`Invalid PIN`);
+        return;
+      }
+    } catch (e) {
+      setErrorMessage(e.message || t`Error validating PIN.`);
+      setPhase('error');
+      return;
+    }
+
+    setPinError('');
     setPhase('sending');
     setErrorMessage('');
 
@@ -142,6 +162,7 @@ function ModalTransactionOverview({
   const handleRetry = () => {
     setPreparedTx(null);
     setErrorMessage('');
+    setPinError('');
     setPin('');
     setPhase('review');
   };
@@ -149,6 +170,7 @@ function ModalTransactionOverview({
   const handlePinChange = (e) => {
     const value = e.target.value.replace(/\D/g, '').slice(0, 6);
     setPin(value);
+    setPinError('');
   };
 
   // --- Render helpers for the review phase ---
@@ -314,6 +336,7 @@ function ModalTransactionOverview({
           autoFocus
           autoComplete="off"
         />
+        {pinError && <p className="text-danger mt-2 mb-0">{pinError}</p>}
       </div>
     </>
   );

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -670,18 +670,23 @@ const removeTokenMetadata = (state, action) => {
     delete newMeta[uid];
   }
 
-  // If the token has zero balance we should remove the balance data
+  // Drop a zero-balance unregistered token from allTokens and tokensBalance
+  // together (fetchUnknownTokens reads tokensBalance[uid].data for every allTokens
+  // entry): a leftover keeps the "Import Tokens" banner advertising a token the
+  // modal can't resolve. Tokens with a balance stay, still re-importable.
   const newBalance = Object.assign({}, state.tokensBalance);
-  if (uid in newBalance && (!!newBalance[uid].data)) {
-    const balance = newBalance[uid].data;
-    if ((balance.available + balance.locked) === 0n) {
-      delete newBalance[uid];
-    }
+  const newAllTokens = Object.assign({}, state.allTokens);
+  const balance = newBalance[uid]?.data;
+  if (balance && (balance.available + balance.locked) === 0n) {
+    delete newBalance[uid];
+    delete newAllTokens[uid];
   }
 
   return {
     ...state,
     tokenMetadata: newMeta,
+    tokensBalance: newBalance,
+    allTokens: newAllTokens,
   };
 };
 

--- a/src/sagas/featureToggle.js
+++ b/src/sagas/featureToggle.js
@@ -250,7 +250,14 @@ export function mapFeatureToggles(toggles) {
   }, {});
 }
 
-export function* handleToggleUpdate() {
+/**
+ * Re-hydrate state.featureToggles from the Unleash singleton after clean_data
+ * wipes it, so a post-restart checkForFeatureFlag read isn't stale.
+ *
+ * Doesn't dispatch FEATURE_TOGGLE_UPDATED — it can reload the wallet, unsafe
+ * from inside startWallet.
+ */
+export function* syncFeatureTogglesFromClient() {
   const unleashClient = getUnleashClient();
   const featureTogglesInitialized = yield select((state) => state.featureTogglesInitialized);
 
@@ -258,10 +265,12 @@ export function* handleToggleUpdate() {
     return;
   }
 
-  const { toggles } = unleashClient;
-  const featureToggles = mapFeatureToggles(toggles);
-
+  const featureToggles = mapFeatureToggles(unleashClient.toggles);
   yield put(setFeatureToggles(featureToggles));
+}
+
+export function* handleToggleUpdate() {
+  yield call(syncFeatureTogglesFromClient);
   yield put({ type: 'FEATURE_TOGGLE_UPDATED' });
 }
 

--- a/src/sagas/wallet.js
+++ b/src/sagas/wallet.js
@@ -75,7 +75,7 @@ import {
   dispatchLedgerTokenSignatureVerification,
 } from './helpers';
 import { fetchTokenData, restoreTokensForNetwork } from './tokens';
-import { updateUnleashClientContext } from './featureToggle';
+import { updateUnleashClientContext, syncFeatureTogglesFromClient } from './featureToggle';
 import walletUtils from '../utils/wallet';
 import tokensUtils from '../utils/tokens';
 import nanoUtils from '../utils/nanoContracts';
@@ -158,6 +158,11 @@ export function* startWallet(action) {
   let xpriv = null;
 
   yield put(loadingAddresses(true));
+
+  // Refresh the mirror before the checkForFeatureFlag reads below: the passphrase
+  // flow reaches startWallet right after clean_data wiped it, which would make the
+  // single-address read fall back to multi.
+  yield call(syncFeatureTogglesFromClient);
 
   if (hardware) {
     // We need to ensure that the hardware wallet storage is always generated here since we may be


### PR DESCRIPTION
UX regressions from `0.35.0-rc.1..3` ([internal-issues#540](https://github.com/HathorNetwork/internal-issues/issues/540)).

## Fixes

- **Passphrase no longer flips the address mode.** The passphrase flow's `clean_data` reset `state.featureToggles` to defaults while `featureTogglesInitialized` stayed `true`, so `startWallet` read a stale `single-address=false` and forced multi. It now re-syncs the toggles from the live Unleash singleton before any flag read — covering every restart trigger, not just this one.

- **No more phantom "Import Tokens" banner.** Unregistering a no-history/zero-balance token left it in `allTokens`/`tokensBalance`, so `fetchUnknownTokens` kept reporting a token the modal couldn't resolve. `removeTokenMetadata` now drops both slices together (they must stay consistent — `fetchUnknownTokens` reads `tokensBalance[uid].data` per `allTokens` entry). Tokens with a balance stay.

- **"Open in Explorer" opens the system browser** via `helpers.openExternalURL`, instead of a bare `target="_blank"` that Electron opens in a new window.

- **Send confirmation validates the PIN.** `handleConfirm` calls `wallet.checkPin` first and shows "Invalid PIN" inline, instead of attempting the send and failing with a generic "Transaction failed".

### Acceptance Criteria
- Passphrase add/remove keeps the single/multi-address setting.
- No "Import Tokens" banner for a registered-then-unregistered no-history token.
- "Open in Explorer" opens the system browser.
- Wrong PIN on send shows "Invalid PIN", not "Transaction failed".

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us. *(No new dependencies added.)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Feature flags now refresh earlier during wallet startup, helping the app use the latest available settings sooner.

* **Bug Fixes**
  * Token links in the token list now open reliably through the app’s external link handler.
  * PIN errors in transaction review now show directly under the PIN field, making validation feedback clearer.
  * Zero-balance unregistered tokens are now fully removed from token lists, preventing leftover entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->