### PR TITLE
fix: keep address and value fields when changing token in Send Tokens

### DIFF
--- a/src/screens/SendTokens.js
+++ b/src/screens/SendTokens.js
@@ -84,6 +84,9 @@ function SendTokens() {
   // Create refs
   const formSendTokensRef = useRef();
   const references = useRef([React.createRef()]);
+  // Stable row id: keying by token uid would remount the row on token
+  // change and wipe its uncontrolled address/value inputs.
+  const rowIds = useRef([uniqueId('send_token_row')]);
   /**
    * Instance of SendTransaction containing tx data specifically for Ledger signing
    * @type MutableRefObject<SendTransaction>
@@ -686,6 +689,7 @@ function SendTokens() {
     });
 
     references.current.push(React.createRef());
+    rowIds.current.push(uniqueId('send_token_row'));
     setTxTokens([...txTokens, newToken]);
   }
 
@@ -723,6 +727,7 @@ function SendTokens() {
     newTxTokens.splice(index, 1);
     setTxTokens(newTxTokens);
     references.current.splice(index, 1);
+    rowIds.current.splice(index, 1);
   }
 
   /**
@@ -770,7 +775,7 @@ function SendTokens() {
     return txTokens.map((token, index) => {
       return (
         <SendTokensOne
-          key={`${token.uid}-${index}`}
+          key={rowIds.current[index]}
           ref={references.current[index]}
           config={token}
           index={index}


### PR DESCRIPTION
### Acceptance Criteria
- On the Send Tokens screen, changing a row's token keeps the address and value already filled in.
- Addresses the "Send Tokens Screen" item from QA report HathorNetwork/internal-issues#540.

### Root cause (from the QA flow)
Repro: fill the address + value on a Send row, then change that row's token → every field is erased.

Each row was keyed by its token uid — `key={`${token.uid}-${index}`}` in `renderOnePage`. Changing the token changed the key, so React unmounted and remounted the whole row. The address (`OutputsWrapper`) and value (`InputNumber`) inputs are uncontrolled, so the remount reset them to empty.

### Proposed solution
Key each row by a stable id assigned once at creation (`uniqueId('send_token_row')`) instead of by the token uid. Switching the token now updates the row in place and keeps the filled inputs — the parent still updates the row's token config and the child recomputes its selection and fees, so the remount was never needed. The same stable id also removes an existing remount-and-wipe when a middle row is removed.

Known minor residual (out of scope): switching between an NFT and a non-NFT token still clears the value field, because its `InputNumber` is separately keyed by `isNFT`. The address is always preserved.

No new dependencies — `uniqueId` was already imported from lodash.

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
