### PR TITLE
fix: clear registered tokens and nano contracts when exiting a hardware wallet

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -375,8 +375,9 @@ function DefaultComponent({ children }) {
   // If this is a hardware wallet that has been locked, navigate to the "Wallet Type" screen
   if (isLockedScreen &&
     LOCAL_STORE.isHardwareWallet()) {
+    // This exit path bypasses resetStorage, so clear the registered data too.
+    LOCAL_STORE.cleanWallet({ cleanRegisteredData: true });
     // This will redirect the page to Wallet Type screen
-    LOCAL_STORE.cleanWallet();
     return <Navigate to={'/wallet_type/'} />;
   }
 

--- a/src/storage.js
+++ b/src/storage.js
@@ -271,12 +271,23 @@ export class LocalStorageStore {
   }
 
   /**
-   * Clean wallet metadata
+   * Clean wallet metadata.
+   *
+   * @param {Object} [options]
+   * @param {boolean} [options.cleanRegisteredData=false] Also drop the
+   *   wallet-scoped registered tokens, nano contracts and Ledger token
+   *   signatures. Used by exit paths that bypass resetStorage, so this data
+   *   doesn't leak into the next wallet.
    */
-  cleanWallet() {
+  cleanWallet({ cleanRegisteredData = false } = {}) {
     this.removeItem(IS_HARDWARE_KEY);
     this.removeItem(CLOSED_KEY);
     this.removeItem(ACCESS_DATA_KEY);
+    if (cleanRegisteredData) {
+      this.removeItem(REGISTERED_TOKENS_KEY);
+      this.removeItem(REGISTERED_NANOCONTRACTS_KEY);
+      this.removeItem(TOKEN_SIGNATURES_KEY);
+    }
     delete this._storage;
     this._storage = null;
   }


### PR DESCRIPTION
### Acceptance Criteria
- Exiting a hardware wallet and importing a software wallet in the same session no longer keeps the hardware wallet's registered tokens.
- The nano contract "Caller Address" no longer stays stuck on the previous hardware wallet's address.
- Addresses the "Hardware wallet data kept between sessions" item from QA report HathorNetwork/internal-issues#540.

### Root cause (from the QA flow)
Repro: open a hardware (Ledger) wallet → quit the Hathor app on the device → without closing the desktop app, import a software wallet. The hardware wallet's custom tokens are still shown, and a nano contract tx keeps the old caller address.

When a hardware wallet is locked, `App.js` sends it to the Wallet Type screen via `LOCAL_STORE.cleanWallet()`. That method cleared only the wallet-identity keys (`IS_HARDWARE_KEY`, `CLOSED_KEY`, `ACCESS_DATA_KEY`) and left the wallet-scoped `REGISTERED_TOKENS_KEY`, `REGISTERED_NANOCONTRACTS_KEY` and `TOKEN_SIGNATURES_KEY` in localStorage. Unlike the software "reset all data" flow (which calls `resetStorage` and clears every key), this hardware path skips `resetStorage`, so the next wallet re-reads the stale registered data. The stuck caller address is the leftover registered nano contract's stored `address`.

### Proposed solution
Add an opt-in `cleanRegisteredData` flag to `cleanWallet` and set it on the hardware-exit branch, clearing those three wallet-scoped keys at the wallet switch. The redux token/nano-contract state is repopulated from the now-empty keys when the next wallet loads. Other `cleanWallet` callers keep their current behavior (the flag defaults to `false`), so the passphrase and logout flows are unchanged.

No new dependencies.

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
