### PR TITLE
fix(qa): run large-values network on hathor-core 0.70

### DIFF
--- a/qa/large-values-network/docker-compose.yml
+++ b/qa/large-values-network/docker-compose.yml
@@ -14,8 +14,8 @@ services:
       "--test-mode-tx-weight",
       "--wallet-index",
       "--allow-mining-without-peers",
-      "--unsafe-mode", "testnet-golf",
-      "--memory-storage",
+      "--unsafe-mode", "privatenet",
+      "--temp-data",
       "--config-yaml", "privnet/conf/privnet.yml"
     ]
     ports:

--- a/qa/large-values-network/privnet.yml
+++ b/qa/large-values-network/privnet.yml
@@ -8,6 +8,11 @@
 
 extends: testnet.yml
 
+# hathor-core >=0.70 forbids --test-mode-tx-weight on production network names
+# (mainnet/testnet-*); test mode is only allowed on 'privatenet'/'unittests'.
+# This is an ephemeral private QA network, so name it accordingly.
+NETWORK_NAME: privatenet
+
 BOOTSTRAP_DNS: []
 
 # Genesis stuff


### PR DESCRIPTION
## Summary

The `qa/large-values-network` compose pulls `hathornetwork/hathor-core` **unpinned** (`:latest`) on purpose, so the manual QA fails loudly when upstream ships a breaking change. `:latest` reached **v0.70.0**, which broke the network three ways:

| Breaking change in v0.70.0 | Fix |
|---|---|
| testnet renamed `golf`→`india`; `--unsafe-mode` must match the network name | name the net `privatenet` (`NETWORK_NAME` + `--unsafe-mode privatenet`) |
| `--test-mode-tx-weight` now rejected on production network names (allowed only on `privatenet`/`unittests`) | ↑ same change satisfies it |
| `--memory-storage` flag removed | replace with `--temp-data` |

Migrated the config **forward** rather than pinning the image, keeping the fail-loud behaviour. The custom ~2⁶³ HTR genesis (the "large values" under test) is **preserved unchanged** — genesis hashes don't depend on the network name, so no `gen_genesis` recompute was needed.

## Acceptance criteria

- `npm run qa_network_up` brings up fullnode + tx-mining-service + cpuminer with no crash loop; fullnode reaches `READY` on `http://localhost:8083/v1a/status/` (network `privatenet`) and blocks are mined.
- `GET /v1a/thin_wallet/token?id=00` serves the near-int64-max HTR supply (`total` ≥ `9223372036854775800`); `npm run qa_network_down` tears it down cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated private QA network startup settings to use the correct private-network mode.
  * Replaced the removed memory storage option with temporary data storage.
  * Added explicit network naming and clarified test-mode restrictions for safer network configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->