### PR TITLE
chore: bump to v0.35.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hathor-wallet",
-  "version": "0.35.0-rc.4",
+  "version": "0.35.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hathor-wallet",
-      "version": "0.35.0-rc.4",
+      "version": "0.35.0",
       "hasInstallScript": true,
       "dependencies": {
         "@hathor/hathor-rpc-handler": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "productName": "Hathor Wallet",
   "description": "Light wallet for Hathor Network",
   "author": "Hathor Labs <contact@hathor.network> (https://hathor.network/)",
-  "version": "0.35.0-rc.4",
+  "version": "0.35.0",
   "engines": {
     "node": ">=22.0.0",
     "npm": ">=10.0.0"


### PR DESCRIPTION
### Acceptance Criteria
- Promote `release-candidate` (v0.35.0-rc.4) to public release **v0.35.0**

### Behavior Changes
- NFT PDF preview removed — PDF media now shows "Preview Unavailable" (#851). Images, videos, and audio remain supported.

### What's included

| PR | Type | Title |
|---|---|---|
| #855 | feat | Create fee token flow |
| #858 | feat | Send fee tokens flow |
| #856 | feat | "About my token" screen and token version setup |
| #859 | feat | Easy token import banner and modal |
| #861 | feat | Single address mode |
| #853 | feat | Persist registered tokens across network changes |
| #851 | feat | Remove PDF render for NFTs |
| #881 | fix | RC regressions (address mode, import banner, explorer link, send PIN) |
| #878 | fix | Restore lost UX in Send Tokens flow (PIN focus and Close returns Home) |
| #876 | fix | Prevent Send screen crash on LavaMoat production build |
| #868 | fix | Upgrade wallet lib to v3.1.1 |
| #865 | fix | Prevent feature flag context leak between networks |
| #863 | fix | Token import modal never reaching success/loading screens |
| #860 | fix | Reset hardware wallet crash |
| #848 | fix | Registered tokens kept on wallet reset |
| #857 | test | Create token screen tests |
| #864 | chore | Bump @hathor/hathor-rpc-handler to 4.4.0 |
| #867 | chore | Bump to 0.35.0-rc.1 |
| #877 | chore | Bump to 0.35.0-rc.2 |
| #880 | chore | Bump to 0.35.0-rc.3 |
| #882 | chore | Bump to 0.35.0-rc.4 |

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.

**Full Changelog**: https://github.com/HathorNetwork/hathor-wallet/compare/v0.34.0...v0.35.0
