### PR TITLE
feat(amount): route remaining display sites through the amount layer

### DIFF
--- a/docs/superpowers/plans/2026-07-22-amount-format-pr2.md
+++ b/docs/superpowers/plans/2026-07-22-amount-format-pr2.md
@@ -1,0 +1,377 @@
+# Amount Format — PR2 Implementation Plan (Convert remaining call sites)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Convert every remaining direct `numberUtils.prettyValue` call to the shared amount layer, so the user's format preference applies consistently across the whole wallet.
+
+**Architecture:** No new abstractions. PR1 built `formatAmount` / `resolveAmountFormat` (`src/utils/amount.js`), `useAmountFormat` (`src/hooks/`) and `<Amount>` (`src/components/`). This PR is a mechanical sweep onto them. Behaviour is unchanged while the feature flag is off, which it is by default.
+
+**Tech Stack:** React 17 (mixed function + class components), Redux, `@hathor/wallet-lib`.
+
+**Spec:** `docs/superpowers/specs/2026-07-21-amount-format-design.md`
+**Depends on:** PR1 (`raul-oliveira/feat/amount-format`) — branch from it, not from `master`.
+
+---
+
+## Working agreement
+
+- **Do not commit per task.** Accumulate in the working tree; the controller commits once at the end.
+- **Do not write render tests.** Jest 27 cannot parse `axios@1.7.7`'s ESM entry, so any test importing `@hathor/wallet-lib` fails; 7 of 9 suites already fail on `master`. Unit tests for pure functions are fine.
+- **Test command:** `CI=true npx react-app-rewired test --watchAll=false 2>&1 | grep -E "^(PASS|FAIL)|^Test Suites:|^Tests:"`. Never pipe jest to `tail` and read `$?` — a pipeline returns the last command's exit code and falsely reports success.
+- **Build/lint gate:** `npm run build` (plain, never `CI=true npm run build` — that fails on a pre-existing LavaMoat policy drift).
+- **Baseline to match:** `7 failed, 4 passed, 11 total` / `33 passed, 33 total`.
+- **`src/components/InputNumber.js` is never touched.** Editable inputs are always expanded.
+
+---
+
+## The three APIs
+
+| API | Import | Use when | Returns |
+| --- | --- | --- | --- |
+| `<Amount value symbol isNFT />` | `src/components/Amount.js` | The result is rendered as a React child | element |
+| `useAmountFormat()` → `formatValue(v, {isNFT})` | `src/hooks/useAmountFormat.js` | **Function** component needing a string | string |
+| `formatAmount(v, {decimalPlaces, isNFT, amountFormat})` | `src/utils/amount.js` | **Class** component or plain module needing a string | string |
+
+**Class components must mask the flag.** Add to `mapStateToProps`:
+
+```js
+  amountFormat: resolveAmountFormat(
+    state.amountFormat,
+    state.featureToggles[AMOUNT_FORMAT_FEATURE_TOGGLE]
+  ),
+```
+importing `resolveAmountFormat` from `../utils/amount` and `AMOUNT_FORMAT_FEATURE_TOGGLE` from `../constants`. Never pass `state.amountFormat` raw — that bypasses the feature flag and was a real bug caught in PR1 review.
+
+**Putting a `<Amount>` element into a template literal renders `[object Object]`.** Every site below is pre-classified; trust the classification but sanity-check the surrounding line before editing.
+
+---
+
+## Task 1: Reown components (JSX-rendered strings)
+
+All five are **function** components; the helper lives inside the component, so use the hook.
+
+**Files:** `src/components/Reown/TransactionFees.js`, `Reown/NanoContractActions.js`, `Reown/modals/SendTransactionModal.js`, `Reown/modals/GetUtxosModal.js`, `Reown/modals/BaseNanoContractModal.js`
+
+- [ ] **Step 1: `TransactionFees.js`**
+
+Line 23 assigns `const formattedFee = numberUtils.prettyValue(fee);` and line 35 renders `<span>{formattedFee} {symbol}</span>`. Delete line 23 and replace line 35's content with:
+
+```jsx
+          <span><Amount value={fee} symbol={symbol} /></span>
+```
+
+Import `Amount from '../Amount'`. Note the original called `prettyValue(fee)` with **no** decimal-places argument, so it used the lib default; `<Amount>` uses the wallet's configured `decimalPlaces` from redux. That is the intended correction — call it out in your report.
+
+- [ ] **Step 2: `NanoContractActions.js`**
+
+Add `import { useAmountFormat } from '../../hooks/useAmountFormat';` and `const formatValue = useAmountFormat();` at the top of the component body. Replace the body of `formatAmount` (line ~91-93) so it returns:
+
+```js
+      return formatValue(amount, { isNFT: isNft });
+```
+
+Keep the existing `isNft` variable exactly as it is computed today.
+
+- [ ] **Step 3: `SendTransactionModal.js`**
+
+Same pattern. Replace line ~119 inside `formatValue` with the hook's formatter — rename the local helper if it now collides with the hook result (e.g. call the hook result `formatAmountValue`). Preserve the existing `isNFT` computation.
+
+- [ ] **Step 4: `GetUtxosModal.js`**
+
+Same pattern for the `formatAmount` helper at line ~63-67, preserving its `isNFT` computation.
+
+- [ ] **Step 5: `BaseNanoContractModal.js`**
+
+Line 114 assigns into the `let displayValue` chain that other branches fill with template strings and which is rendered at line 137 as `{displayValue}`. It must stay a **string**. Add the hook and replace line 114 with:
+
+```js
+      displayValue = formatValue(value);
+```
+
+- [ ] **Step 6: Verify**
+
+Run the test suite and `npm run build`. Confirm the baseline is unchanged and no warning names these files.
+
+---
+
+## Task 2: Reown `CreateTokenRequestData.js` (module-level helper — needs restructuring)
+
+**Files:** `src/components/Reown/CreateTokenRequestData.js`
+
+`formatAmount` is defined at **module scope** (line 17), outside the component, so it cannot call a hook. Its results feed template literals at lines 181 and 187, so it must keep returning a string.
+
+- [ ] **Step 1: Move the helper inside the component**
+
+Delete the module-level `const formatAmount = (amount) => {...}` at line 17. Inside the component body add:
+
+```js
+  const formatValue = useAmountFormat();
+```
+importing `useAmountFormat` from `../../hooks/useAmountFormat`.
+
+- [ ] **Step 2: Update the three call sites**
+
+- Line ~118: `<TokenParameter label={t\`Amount\`} value={formatValue(data.amount)} />`
+- Line ~181: `` value={`${formatValue(data.deposit)} ${DEFAULT_TOKEN_SYMBOL}`} ``
+- Line ~187: `` value={data.fee ? `${formatValue(data.fee)} ${DEFAULT_TOKEN_SYMBOL}` : '-'} ``
+
+If any of these sit outside the component body after the move, STOP and report — the restructuring assumption is wrong.
+
+- [ ] **Step 3: Verify** — suite + build unchanged.
+
+---
+
+## Task 3: Atomic swap and nano contract screens (pure JSX)
+
+**Files:** `src/screens/atomic-swap/EditSwap.js`, `src/components/atomic-swap/ProposalBalanceTable.js`, `src/components/atomic-swap/ModalAtomicSend.js`, `src/screens/nano-contract/NanoContractDetail.js`
+
+- [ ] **Step 1: `EditSwap.js`** — two JSX sites.
+
+Line 137 → `<Amount value={input.value} />`
+Line 156 → `<td className="text-right"><Amount value={output.value} /></td>`
+
+Import `Amount from '../../components/Amount'`.
+
+- [ ] **Step 2: `ProposalBalanceTable.js`** — line 31 is JSX:
+
+```jsx
+            return <span><Amount value={amount} /> <b>{symbol}</b></span>
+```
+
+Keep the symbol in its existing `<b>` rather than moving it into `<Amount>`; the bold styling is deliberate.
+
+- [ ] **Step 3: `ModalAtomicSend.js`** — line 66 is a **STRING** (it feeds `setAmount`, component state). Use the hook:
+
+```js
+        setAmount(formatValue(newAmount));
+```
+
+- [ ] **Step 4: `NanoContractDetail.js`** — line 162 is JSX:
+
+```jsx
+          <p><strong>Amount: </strong><Amount value={typeof amount.value === 'bigint' ? amount.value : BigInt(amount.value)} /></p>
+```
+
+- [ ] **Step 5: Verify** — suite + build unchanged.
+
+---
+
+## Task 4: `NFTListElement.js` (class component, JSX)
+
+**Files:** `src/components/NFTListElement.js`
+
+Line 102 renders inside a conditional. NFT balances are integer-valued and the original hardcodes `0` decimal places, so pass `isNFT`:
+
+```jsx
+              { this.props.nftElement.balance.status === TOKEN_DOWNLOAD_STATUS.READY && <Amount value={this.props.nftElement.balance.data.available} isNFT /> }
+```
+
+- [ ] **Step 1:** Make the edit, importing `Amount from './Amount'`.
+- [ ] **Step 2:** Verify — suite + build unchanged. No `mapStateToProps` change needed; `<Amount>` reads redux itself.
+
+---
+
+## Task 5: `ModalTokenImport.js` (STRING)
+
+**Files:** `src/components/ModalTokenImport.js`
+
+`ModalTokenImport` is a **function** component (`export default function ModalTokenImport({ onClose, manageDomLifecycle })`, line 59) and the balance helper containing line 271 is defined inside it, so the hook applies.
+
+- [ ] **Step 1: Add the hook**
+
+```js
+import { useAmountFormat } from '../hooks/useAmountFormat';
+```
+and in the component body, next to the existing `useSelector` calls:
+
+```js
+  const formatValue = useAmountFormat();
+```
+
+- [ ] **Step 2: Replace the return at line ~271**
+
+```js
+    return `${formatValue(total)} ${symbol}`;
+```
+
+The existing `const decimalPlaces = useSelector((state) => state.serverInfo.decimalPlaces);` at line 67 becomes unused if nothing else in the file references it — check, and remove it only if fully unused.
+
+- [ ] **Step 3:** Verify — suite + build unchanged.
+
+---
+
+## Task 6: `tokens/TokenMint.js` and `tokens/TokenMelt.js` (class components, STRING)
+
+Both are class components whose values feed user-facing message strings.
+
+**Files:** `src/components/tokens/TokenMint.js`, `src/components/tokens/TokenMelt.js`
+
+- [ ] **Step 1: Add masked `amountFormat` to both `mapStateToProps`**
+
+Using the `resolveAmountFormat` snippet from the top of this plan.
+
+- [ ] **Step 2: Add a `formatValue` instance method to each class**
+
+```js
+  formatValue = (value) => formatAmount(value, {
+    decimalPlaces: this.props.decimalPlaces,
+    isNFT: this.isNFT(),
+    amountFormat: this.props.amountFormat,
+  });
+```
+
+- [ ] **Step 3: `TokenMint.js`**
+
+Line 97 → `const prettyAmountValue = this.formatValue(this.state.amount);`
+
+Line 205 contains **two** amounts inside one template literal. The `getDepositAmount(...)` call is handled in Task 7; the second is the HTR balance, which is **HTR, not the token** — it must NOT receive the token's `isNFT`. Replace it with a bare `formatAmount` call:
+
+```js
+formatAmount(this.props.htrBalance, { decimalPlaces: this.props.decimalPlaces, amountFormat: this.props.amountFormat })
+```
+
+- [ ] **Step 4: `TokenMelt.js`**
+
+Line 90 → `const prettyAmountValue = this.formatValue(this.state.amount);`
+Line 104 → `const prettyWalletAmount = this.formatValue(walletAmount);`
+
+- [ ] **Step 5: Verify** — suite + build unchanged.
+
+---
+
+## Task 7: `utils/tokens.js` — thread the format through a plain module
+
+**Files:** `src/utils/tokens.js`, `src/screens/CreateToken.js`, `src/components/tokens/TokenMint.js`
+
+`getDepositAmount(mintAmount, depositPercent, decimalPlaces)` is a plain module function returning a **string**, consumed by template literals at `CreateToken.js:330` and `TokenMint.js:205`. It cannot read redux, so the caller must pass the format.
+
+- [ ] **Step 1: Add the parameter**
+
+```js
+  getDepositAmount(mintAmount, depositPercent, decimalPlaces, amountFormat) {
+    if (mintAmount) {
+      const deposit = hathorLib.tokensUtils.getDepositAmount(mintAmount, depositPercent);
+      return formatAmount(deposit, { decimalPlaces, amountFormat });
+    }
+    return '0';
+  },
+```
+
+Import `formatAmount` from `./amount`. Update the JSDoc to document `amountFormat`. Note the deposit is always HTR, so no `isNFT`.
+
+Making `amountFormat` the last parameter keeps it optional — omitting it falls back to `AMOUNT_FORMAT_DEFAULT` (expanded), so any caller you miss degrades safely rather than crashing.
+
+- [ ] **Step 2: `CreateToken.js:330`** — a function component that already calls `useAmountFormat`. It needs the raw preference value, not the bound formatter, so read it alongside:
+
+```js
+  const amountFormat = useSelector(state => resolveAmountFormat(
+    state.amountFormat,
+    state.featureToggles[AMOUNT_FORMAT_FEATURE_TOGGLE]
+  ));
+```
+
+then pass `amountFormat` as the fourth argument.
+
+- [ ] **Step 3: `TokenMint.js:205`** — pass `this.props.amountFormat` (already masked by Task 6 Step 1) as the fourth argument.
+
+- [ ] **Step 4: Verify** — suite + build unchanged.
+
+---
+
+## Task 8: `utils/nanoContracts.js` (returns mixed string | JSX)
+
+**Files:** `src/utils/nanoContracts.js`
+
+The enclosing function already returns JSX from a sibling branch (`<SignedDataDisplay value={value} />` at line ~96), so its consumers must already render JSX. The Amount branch can therefore return an element.
+
+- [ ] **Step 1:** Replace line 92 with:
+
+```jsx
+      return <Amount value={value} />;
+```
+
+importing `Amount from '../components/Amount'`. The `decimalPlaces` parameter may become unused in this function — leave the signature alone, later cleanup removes it.
+
+- [ ] **Step 2: Confirm the assumption**
+
+Grep this function's call sites and verify every consumer renders the result as JSX. If **any** consumer puts it in a string, revert to threading `amountFormat` through as a parameter like Task 7 and report the deviation.
+
+- [ ] **Step 3: Verify** — suite + build unchanged.
+
+---
+
+## Task 9: `screens/SendTokens.js` (STRING)
+
+**Files:** `src/screens/SendTokens.js`
+
+Line 147 builds `requiredAmount` for a user-facing message. Function component → use the hook. The amount is HTR (a fee total), so no `isNFT`:
+
+```js
+        const requiredAmount = formatValue(totalFee + outgoingHTR);
+```
+
+- [ ] **Step 1:** Add `useAmountFormat` and make the edit.
+- [ ] **Step 2: Verify** — suite + build unchanged.
+
+---
+
+## Task 10: Final sweep and verification
+
+- [ ] **Step 1: Confirm nothing is left behind**
+
+Run: `grep -rn "prettyValue" src/ | grep -v "InputNumber.js" | grep -v "__tests__" | grep -v "utils/amount.js"`
+
+Expected: **no output**. `src/utils/amount.js` legitimately retains the single wrapped call plus doc comments; `InputNumber.js` is intentionally excluded.
+
+- [ ] **Step 2: Confirm no raw preference reads**
+
+Run: `grep -rn "state.amountFormat" src/`
+
+Every hit must be inside `useAmountFormat.js`, wrapped in `resolveAmountFormat(...)`, in `Settings.js` (safe — gated at render), or in a test.
+
+- [ ] **Step 3: Remove dead imports**
+
+For every file touched, check whether `numberUtils` / `hathorLib` is still referenced. Remove the import only if fully unused; leave it otherwise. `npm run build` surfaces unused-variable warnings — treat any naming a touched file as a defect.
+
+- [ ] **Step 4: Full verification**
+
+Test suite: `7 failed, 4 passed, 11 total` / `33 passed, 33 total`, with the same 7 pre-existing failures.
+Build: `Compiled with warnings.`, no warning naming a touched file.
+`git status --short`: `package.json`, `package-lock.json`, `src/storage.js`, `src/components/InputNumber.js` all unmodified.
+
+- [ ] **Step 5: Extract strings**
+
+Run `make update_pot`. Expect little or no change — this PR adds no new user-facing strings. Report anything unexpected.
+
+---
+
+## Call-site inventory (pre-classified)
+
+| File:line | Kind | Context | API | Notes |
+| --- | --- | --- | --- | --- |
+| `Reown/TransactionFees.js:23` | fn | JSX | `<Amount>` | had no decimalPlaces arg |
+| `Reown/NanoContractActions.js:93` | fn | JSX-rendered string | hook | keep `isNft` |
+| `Reown/modals/SendTransactionModal.js:119` | fn | JSX-rendered string | hook | keep `isNFT` |
+| `Reown/modals/GetUtxosModal.js:66` | fn | JSX-rendered string | hook | keep `isNFT` |
+| `Reown/modals/BaseNanoContractModal.js:114` | fn | STRING | hook | shared `let displayValue` |
+| `Reown/CreateTokenRequestData.js:20` | module-level helper | STRING | hook, after moving inside | feeds template literals |
+| `screens/atomic-swap/EditSwap.js:137,156` | fn | JSX | `<Amount>` | |
+| `atomic-swap/ProposalBalanceTable.js:31` | fn | JSX | `<Amount>` | keep `<b>{symbol}</b>` |
+| `atomic-swap/ModalAtomicSend.js:66` | fn | STRING | hook | feeds `setAmount` |
+| `screens/nano-contract/NanoContractDetail.js:162` | fn | JSX | `<Amount>` | |
+| `NFTListElement.js:102` | class | JSX | `<Amount isNFT>` | hardcoded 0 decimals today |
+| `ModalTokenImport.js:271` | fn | STRING | hook | helper is inside the component |
+| `tokens/TokenMint.js:97` | class | STRING | `this.formatValue` | |
+| `tokens/TokenMint.js:205` | class | STRING | bare `formatAmount` | **HTR balance — no isNFT** |
+| `tokens/TokenMelt.js:90,104` | class | STRING | `this.formatValue` | |
+| `utils/tokens.js:122` | module | STRING | param-threaded | **HTR deposit — no isNFT** |
+| `utils/nanoContracts.js:92` | module | JSX | `<Amount>` | sibling branch returns JSX |
+| `screens/SendTokens.js:147` | fn | STRING | hook | **HTR fee — no isNFT** |
+
+---
+
+## Out of scope
+
+- `src/components/InputNumber.js` — always expanded, never migrated.
+- Removing now-unused `decimalPlaces` props and `mapStateToProps` entries — a later cleanup.
+- Any layout or wrapping change — PRs 4–6.

--- a/docs/superpowers/plans/2026-07-22-amount-format-pr3.md
+++ b/docs/superpowers/plans/2026-07-22-amount-format-pr3.md
@@ -1,0 +1,611 @@
+# Amount Format — PR3 Implementation Plan (Shared Radio components + Address Mode restyle)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task.
+
+**Goal:** Extract the duplicated radio-selector and save-button markup from the Amount Format and Address Mode modals into shared components, then restyle Address Mode onto them — without changing any of its behaviour.
+
+**Architecture:** Four new presentational components under `src/components/Radio/` plus `PreferenceSaveButton`, mirroring the decomposition shipped in wallet-mobile#893 but adapted to desktop React + SCSS + Bootstrap. Both modals become thin: they own state and behaviour, the shared components own presentation.
+
+**Spec:** `docs/superpowers/specs/2026-07-21-amount-format-design.md`
+**Depends on:** PR2. Branch from it.
+
+---
+
+## Working agreement
+
+- **Do not commit per task.** The controller commits once at the end.
+- **Do not write render tests** — Jest 27 cannot parse `axios@1.7.7`'s ESM entry; 7 of 9 suites already fail on `master`.
+- **Test command:** `CI=true npx react-app-rewired test --watchAll=false 2>&1 | grep -E "^(PASS|FAIL)|^Test Suites:|^Tests:"`. Never pipe jest to `tail` and read `$?`.
+- **Build gate:** `npm run build` (plain, never `CI=true`).
+- **Baseline:** `7 failed, 4 passed, 11 total` / `33 passed, 33 total`.
+- **SCSS:** edit only `src/index.module.scss`, then `npm run build-css`. Never hand-edit `src/index.css`.
+- **This is a refactor.** Amount Format must look pixel-identical afterwards. Address Mode changes appearance but **not behaviour**.
+
+---
+
+## Reference: the mobile decomposition (wallet-mobile#893)
+
+Adapt this API; do not copy the React Native implementation.
+
+```
+RadioGroup({ value, onChange, options })
+  options: Array<{ value, title, description?, hint?, badge?, disabled? }>
+  → a bordered card; renders a divider between consecutive options
+
+RadioOption({ selected, onPress, disabled, title, badge, description, hint })
+  → radio circle + title row (title + optional badge pill) + optional description + optional italic hint
+
+RadioButton({ selected, disabled })
+  → just the circle
+
+PreferenceSaveButton({ title, onPress, disabled })
+  → the full-width primary save button
+```
+
+Desktop adaptations: `onPress` → `onClick`; RN `StyleSheet` → SCSS classes; `TouchableOpacity`/`View`/`Text` → `div`/`span`/`p`; the radio circle stays a real `<input type="radio">` styled with `appearance: none` (as both modals already do) so keyboard and screen-reader behaviour is preserved.
+
+---
+
+## Task 1: `RadioButton`
+
+**Files:** Create `src/components/Radio/RadioButton.js`
+
+- [ ] **Step 1: Write the component**
+
+```jsx
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * The radio circle itself. A real input so keyboard and assistive tech work;
+ * `appearance: none` in SCSS replaces the native rendering.
+ *
+ * @memberof Components
+ */
+function RadioButton({ id, name, selected, disabled, onChange }) {
+  return (
+    <input
+      type="radio"
+      id={id}
+      name={name}
+      className="radio-button"
+      checked={selected}
+      disabled={disabled}
+      onChange={onChange}
+    />
+  );
+}
+
+RadioButton.propTypes = {
+  id: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  selected: PropTypes.bool.isRequired,
+  disabled: PropTypes.bool,
+  onChange: PropTypes.func.isRequired,
+};
+
+RadioButton.defaultProps = {
+  disabled: false,
+};
+
+export default RadioButton;
+```
+
+---
+
+## Task 2: `RadioOption`
+
+**Files:** Create `src/components/Radio/RadioOption.js`
+
+- [ ] **Step 1: Write the component**
+
+```jsx
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import RadioButton from './RadioButton';
+
+/**
+ * A selectable row: radio circle, a title row carrying an optional badge pill,
+ * an optional description and an optional muted italic hint.
+ *
+ * @memberof Components
+ */
+function RadioOption({ name, value, selected, disabled, onSelect, title, badge, description, hint }) {
+  const inputId = `${name}-${value}`;
+  const handleSelect = () => {
+    if (!disabled) {
+      onSelect(value);
+    }
+  };
+
+  const renderBadge = () => {
+    if (!badge) {
+      return null;
+    }
+    return <span className="radio-option-badge">{badge}</span>;
+  };
+
+  const renderDescription = () => {
+    if (!description) {
+      return null;
+    }
+    return <p className="radio-option-description">{description}</p>;
+  };
+
+  const renderHint = () => {
+    if (!hint) {
+      return null;
+    }
+    return <span className="radio-option-hint">{hint}</span>;
+  };
+
+  return (
+    <div
+      className={`radio-option ${disabled ? 'radio-option--disabled' : ''}`}
+      onClick={handleSelect}
+    >
+      <RadioButton
+        id={inputId}
+        name={name}
+        selected={selected}
+        disabled={disabled}
+        onChange={handleSelect}
+      />
+      <div className="radio-option-body">
+        <div className="radio-option-header">
+          <label className="radio-option-title" htmlFor={inputId}>{title}</label>
+          {renderBadge()}
+        </div>
+        {renderDescription()}
+        {renderHint()}
+      </div>
+    </div>
+  );
+}
+
+RadioOption.propTypes = {
+  name: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired,
+  selected: PropTypes.bool.isRequired,
+  disabled: PropTypes.bool,
+  onSelect: PropTypes.func.isRequired,
+  title: PropTypes.node.isRequired,
+  badge: PropTypes.node,
+  description: PropTypes.node,
+  hint: PropTypes.node,
+};
+
+RadioOption.defaultProps = {
+  disabled: false,
+  badge: null,
+  description: null,
+  hint: null,
+};
+
+export default RadioOption;
+```
+
+Note the render helpers rather than inline ternaries — a project convention (`CLAUDE.md`: "Nas funcoes que renderizam JSX, evite usar if ternarios, prefira funcoes para isso").
+
+---
+
+## Task 3: `RadioGroup` and the barrel
+
+**Files:** Create `src/components/Radio/RadioGroup.js`, `src/components/Radio/index.js`
+
+- [ ] **Step 1: `RadioGroup.js`**
+
+```jsx
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import RadioOption from './RadioOption';
+
+/**
+ * A bordered card grouping radio options, separated by dividers. Controlled:
+ * the caller owns the selected value and receives it back through onChange.
+ *
+ * @memberof Components
+ */
+function RadioGroup({ name, value, onChange, options }) {
+  return (
+    <div className="radio-group">
+      {options.map((option, index) => (
+        <React.Fragment key={option.value}>
+          {index > 0 && <hr className="radio-group-divider" />}
+          <RadioOption
+            name={name}
+            value={option.value}
+            selected={value === option.value}
+            disabled={option.disabled}
+            onSelect={onChange}
+            title={option.title}
+            badge={option.badge}
+            description={option.description}
+            hint={option.hint}
+          />
+        </React.Fragment>
+      ))}
+    </div>
+  );
+}
+
+RadioGroup.propTypes = {
+  name: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  options: PropTypes.arrayOf(PropTypes.shape({
+    value: PropTypes.string.isRequired,
+    title: PropTypes.node.isRequired,
+    description: PropTypes.node,
+    hint: PropTypes.node,
+    badge: PropTypes.node,
+    disabled: PropTypes.bool,
+  })).isRequired,
+};
+
+export default RadioGroup;
+```
+
+- [ ] **Step 2: `index.js`**
+
+```js
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export { default as RadioButton } from './RadioButton';
+export { default as RadioOption } from './RadioOption';
+export { default as RadioGroup } from './RadioGroup';
+```
+
+---
+
+## Task 4: `PreferenceSaveButton`
+
+**Files:** Create `src/components/PreferenceSaveButton.js`
+
+- [ ] **Step 1: Write the component**
+
+```jsx
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * The primary save button shared by the preference modals. Renders only the
+ * button; the caller supplies its own container and spacing.
+ *
+ * @memberof Components
+ */
+function PreferenceSaveButton({ title, onClick, disabled }) {
+  return (
+    <button
+      type="button"
+      className={`preference-save-btn ${disabled ? '' : 'preference-save-btn--active'}`}
+      disabled={disabled}
+      onClick={onClick}
+    >
+      {title}
+    </button>
+  );
+}
+
+PreferenceSaveButton.propTypes = {
+  title: PropTypes.node.isRequired,
+  onClick: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
+};
+
+PreferenceSaveButton.defaultProps = {
+  disabled: false,
+};
+
+export default PreferenceSaveButton;
+```
+
+---
+
+## Task 5: Shared SCSS
+
+**Files:** Modify `src/index.module.scss`
+
+The `.amount-format-*` and `.address-mode-*` blocks currently duplicate the radio circle, option card, option typography and save button almost line for line. Hoist those into shared blocks.
+
+- [ ] **Step 1: Add the shared blocks**
+
+```scss
+/* Shared radio selector, used by the preference modals */
+.radio-group {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 16px;
+  padding: 24px 16px;
+
+  &-divider {
+    margin: 24px 0;
+    border-top: 1px solid #e5e7eb;
+  }
+}
+
+.radio-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+  cursor: pointer;
+
+  &--disabled {
+    cursor: default;
+
+    .radio-option-title {
+      color: #c4c4c4;
+      cursor: default;
+    }
+
+    .radio-option-description,
+    .radio-option-hint {
+      color: #b0b0b0;
+    }
+
+    .radio-option-hint {
+      font-style: normal;
+    }
+  }
+
+  &-body {
+    flex: 1;
+    min-width: 0;
+  }
+
+  &-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 8px;
+  }
+
+  &-title {
+    font-size: 16px;
+    font-weight: 600;
+    line-height: 20px;
+    color: #000;
+    margin-bottom: 4px;
+    cursor: pointer;
+  }
+
+  &-description {
+    font-size: 12px;
+    line-height: 20px;
+    color: #979797;
+    margin-bottom: 0;
+  }
+
+  &-hint {
+    font-size: 12px;
+    line-height: 20px;
+    font-style: italic;
+    color: #57606a;
+  }
+
+  &-badge {
+    background: #f2f3f5;
+    border-radius: 8px;
+    width: 69px;
+    height: 23px;
+    font-size: 12px;
+    line-height: 20px;
+    color: #6b7280;
+    text-align: center;
+    flex-shrink: 0;
+    padding: 2px 0;
+  }
+}
+
+.radio-button {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 26px;
+  height: 26px;
+  border: 2px solid #c4c4c4;
+  border-radius: 50%;
+  margin: 0;
+  cursor: pointer;
+  position: relative;
+  flex-shrink: 0;
+
+  &:checked {
+    border-color: $purpleHathor;
+
+    &::after {
+      content: "";
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      width: 13px;
+      height: 13px;
+      border-radius: 50%;
+      background: $purpleHathor;
+    }
+  }
+
+  &:disabled {
+    border-color: #e0e0e0;
+    cursor: default;
+  }
+}
+
+.preference-save-btn {
+  background: #e5e5e5;
+  border: none;
+  border-radius: 8px;
+  padding: 16px;
+  width: 226px;
+  color: #b0b0b0;
+  font-weight: 600;
+  font-size: 14px;
+  text-transform: uppercase;
+  cursor: default;
+
+  &--active {
+    background: $purpleHathor;
+    color: white;
+    cursor: pointer;
+
+    &:hover {
+      background: $purpleHathorHover;
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Delete the superseded declarations**
+
+Remove from the `.amount-format` block: `&-card`, `&-divider`, `&-option` (and all its nested rules including the `input[type=radio]` styling), `&-tag`, `&-save-btn`. **Keep** `&-modal .modal-dialog`, `&-description`, `&-preview-label`, `&-preview` and its children — those are Amount-Format-specific.
+
+Remove from the `.address-mode-*` rules: `.address-mode-option` (and its `input[type=radio]` styling and `--disabled` variants), `.address-mode-label`, `.address-mode-description`, `.address-mode-hint`, `.address-mode-save-btn` (and `--active`). **Keep** `.address-mode-alert` — the warning banner is unique to Address Mode.
+
+- [ ] **Step 3: Rebuild** — `npm run build-css`, then confirm `.radio-group`, `.radio-option`, `.radio-button` and `.preference-save-btn` are present in `src/index.css` and the deleted classes are gone.
+
+---
+
+## Task 6: Recompose `ModalAmountFormat` — zero visual change
+
+**Files:** Modify `src/components/ModalAmountFormat.js`
+
+- [ ] **Step 1: Replace the hand-rolled options with `RadioGroup`**
+
+Delete the local `renderOption` helper. Import `RadioGroup from './Radio/RadioGroup'` and `PreferenceSaveButton from './PreferenceSaveButton'`, then render:
+
+```jsx
+            <RadioGroup
+              name="amountFormat"
+              value={selectedFormat}
+              onChange={setSelectedFormat}
+              options={[
+                {
+                  value: AMOUNT_FORMAT.EXPANDED,
+                  title: t`Expanded`,
+                  badge: t`Default`,
+                  description: t`Standard notation. Leading zeros are written out in full (ex: 0.0000005195).`,
+                },
+                {
+                  value: AMOUNT_FORMAT.COMPRESSED,
+                  title: t`Compressed`,
+                  description: t`Compresses leading zeros into a subscript count for shorter, easier-to-read small values (ex: 0.0₆5195).`,
+                },
+              ]}
+            />
+```
+
+- [ ] **Step 2: Replace the save button**
+
+```jsx
+            <PreferenceSaveButton
+              title={t`Save preferences`}
+              disabled={!hasChanged}
+              onClick={() => onSave(selectedFormat)}
+            />
+```
+
+- [ ] **Step 3: Verify no visual change**
+
+The PREVIEW block, the description paragraph and the modal lifecycle stay exactly as they are. Compare against the Figma frame `318:2469` — spacing, the `Default` pill, the divider and the radio circle must be unchanged.
+
+---
+
+## Task 7: Restyle `ModalAddressMode` — zero behaviour change
+
+**Files:** Modify `src/components/ModalAddressMode.js`
+
+This modal's behaviour is load-bearing. **Preserve all of it:**
+- the `hasTxOutsideFirstAddress()` check on mount, and the `loading` state while it resolves
+- `isSingleDisabled = (loading || hasTxOutside) && currentMode !== ADDRESS_MODE.SINGLE`
+- the `.address-mode-alert` warning banner, shown only when `hasTxOutside`, including its `Learn more` link opened via `helpers.openExternalURL`
+- save disabled unless `hasChanged && !loading`
+- `onSave(selectedMode)` triggering the wallet reload in `Settings.js`
+
+- [ ] **Step 1: Replace the two hand-rolled option blocks with `RadioGroup`**
+
+```jsx
+              <RadioGroup
+                name="addressMode"
+                value={selectedMode}
+                onChange={setSelectedMode}
+                options={[
+                  {
+                    value: ADDRESS_MODE.SINGLE,
+                    title: t`Single Address`,
+                    disabled: isSingleDisabled,
+                    description: t`Your wallet will use only one address (index 0).`,
+                    hint: t`Easier to manage and compatible with all dApps.`,
+                  },
+                  {
+                    value: ADDRESS_MODE.MULTI,
+                    title: t`Multi Address`,
+                    description: t`Your wallet will let you generate multiple addresses.`,
+                    hint: t`Useful for advanced users.`,
+                  },
+                ]}
+              />
+```
+
+The warning banner stays **below** the group, rendered by its existing conditional.
+
+- [ ] **Step 2: Replace the save button** with `PreferenceSaveButton`, keeping `disabled={!hasChanged || loading}`.
+
+- [ ] **Step 3: Replace the remaining inline styles**
+
+Delete the `style={{...}}` attributes the file currently uses for layout (the `display: flex` wrapper, the `marginBottom: 40` intro paragraph, the footer's `borderTop: 'none', marginTop: 12`) in favour of the shared classes plus a small `.address-mode-*` block for what remains unique. Do not introduce new inline styles.
+
+- [ ] **Step 4: Verify behaviour by reading**
+
+Re-read the file and confirm every behaviour in the list above still holds. Report each one explicitly.
+
+---
+
+## Task 8: Verification
+
+- [ ] **Step 1: Suite and build** — baseline unchanged, no warning naming a touched file.
+- [ ] **Step 2: `make update_pot`** — the strings are unchanged in wording, so expect only line-reference churn. Report anything else.
+- [ ] **Step 3: Manual QA** (a human runs this; list it in the PR body)
+  - Amount Format modal is pixel-identical to before this PR.
+  - Address Mode: with a wallet that has transactions outside the first address, Single is disabled and greyed, the warning banner shows, and Save stays disabled.
+  - Address Mode: with a fresh wallet, Single is selectable, Save enables on change, and saving reloads the wallet into single-address mode.
+  - Keyboard: both modals are operable with Tab and the arrow keys, and the label click-target selects the option.
+
+---
+
+## Out of scope
+
+- The `manageDomLifecycle` gap. **Both** modals currently call `$('#id').modal('show')` directly rather than using `GlobalModal`'s `manageDomLifecycle`, so Bootstrap's defaults apply and the modal can be dismissed by Escape or an outside click, silently discarding a selection. This predates the feature and now affects both. It is a reasonable follow-up but is deliberately not bundled here, to keep this PR a pure refactor. Raise it as a separate issue.
+- Any amount-formatting change — done in PRs 1 and 2.

--- a/docs/superpowers/plans/2026-07-22-amount-format-pr4.md
+++ b/docs/superpowers/plans/2026-07-22-amount-format-pr4.md
@@ -1,0 +1,170 @@
+# Amount Format — PR4 Implementation Plan (Home / dashboard wrapping)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task.
+
+**Goal:** Make long amounts on the dashboard wrap onto additional lines instead of clipping or overflowing — in the balance block and in the transaction history `Value` column.
+
+**Architecture:** Layout only. `<Amount>` already carries `overflow-wrap: anywhere`; what is missing is containers that allow the wrap and produce the hanging indent from the design. No formatting logic changes.
+
+**Figma:** [Home / dashboard, node `372:1822`](https://www.figma.com/design/2xRserWXaSJAgkbiQlPzhr/Amounts-Update?node-id=372-1822)
+**Depends on:** PR3. Branch from it.
+
+---
+
+## Working agreement
+
+- **Do not commit per task.** The controller commits once at the end.
+- **No render tests** — Jest 27 cannot parse `axios@1.7.7`'s ESM entry; 7 of 9 suites already fail on `master`.
+- **Test command:** `CI=true npx react-app-rewired test --watchAll=false 2>&1 | grep -E "^(PASS|FAIL)|^Test Suites:|^Tests:"`. Never pipe jest to `tail` and read `$?`.
+- **Build gate:** `npm run build` (plain, never `CI=true`).
+- **Baseline:** `7 failed, 4 passed, 11 total` / `33 passed, 33 total`.
+- **SCSS:** edit only `src/index.module.scss`, then `npm run build-css`.
+
+---
+
+## Design values (measured from Figma — do not invent)
+
+**Balance rows** (`372:1845`–`372:1857`): each row is an independent flex row with `gap: 8px`. Label is `20px` weight 700, `line-height: 22px`, `#000`, `white-space: nowrap`. Value is `20px` weight 400, `line-height: 22px`, `#000`. The value box hugs its content — **no explicit max-width**.
+
+The hanging indent (continuation line aligning under the value's first character, not under the label) is a **free consequence of flex layout**: both lines live inside one flex item that begins after the label plus gap. Do not add an explicit indent or margin.
+
+**History `Value` column** (`372:2193`/`372:2195`): `20px` regular, `line-height: 22px`, `text-align: right`. Both lines of a wrapped value sit flush to the same right edge.
+
+**Two important caveats about the mock:**
+
+1. The wrapped values in Figma are **hand-authored line breaks** — two separate `<p>` nodes, each `white-space: nowrap`. The designer chose the break point to illustrate the effect; it is **not** a specification of where CSS should break. Implement live wrapping and let the break fall where the container width dictates.
+2. The table's header columns and body columns are laid out independently in the mock (header pitch 334px; body columns content-hugged and differing per row). **Do not lift a fixed column width from Figma** — the design never committed to one.
+
+**Confirmed:** no `text-overflow`, no truncation, no reduced font size anywhere in the frame at any content length. The ellipsis in the ID column is literal text typed by the designer, not a CSS pattern to copy.
+
+---
+
+## Explicitly out of scope
+
+The Figma frame also differs from the shipped app in ways this PR must **not** change:
+
+- Figma renders history values at `20px` in the default sans font; the app uses `font-family: monospace; font-size: 1.2rem` (`src/index.css`, `#token-history .value`).
+- Figma uses `#41A922` / `#A92224` for received/sent; the app uses `#28a745` / `#dc3545`.
+
+The brief for this screen is wrapping only. Leave the font and colours alone and note the divergence in the PR description so the designer can confirm.
+
+---
+
+## Task 1: Balance block wrapping
+
+**Files:** Modify `src/components/WalletBalance.js`, `src/index.module.scss`
+
+Today each row is `<p><strong>Total:</strong> <Amount ... /></p>`. In a plain paragraph the continuation line wraps back to the paragraph's left edge — under the label — instead of under the value.
+
+- [ ] **Step 1: Make each row a flex row**
+
+In `src/components/WalletBalance.js`, replace the three rows inside `renderBalance` with:
+
+```jsx
+        <div className="wallet-balance-row">
+          <strong className="wallet-balance-label">{t`Total:`}</strong>
+          <Amount value={balance.available + balance.locked} symbol={symbol} isNFT={isNFT} />
+        </div>
+        <div className="wallet-balance-row">
+          <strong className="wallet-balance-label">{t`Available:`}</strong>
+          <Amount value={balance.available} symbol={symbol} isNFT={isNFT} />
+        </div>
+        <div className="wallet-balance-row">
+          <strong className="wallet-balance-label">{t`Locked:`}</strong>
+          <Amount value={balance.locked} symbol={symbol} isNFT={isNFT} />
+        </div>
+```
+
+- [ ] **Step 2: Add the SCSS**
+
+Append to `src/index.module.scss`:
+
+```scss
+/* Dashboard balance rows */
+.wallet-balance {
+  &-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    // Bootstrap's paragraph spacing used to provide this; the rows are divs now.
+    margin-bottom: 1rem;
+
+    // The value is the flex item, so its wrapped continuation lines align under
+    // the value's first character rather than under the label. This is the
+    // hanging indent from the design — it needs no explicit indent.
+    .amount {
+      min-width: 0;
+    }
+  }
+
+  &-label {
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+}
+```
+
+- [ ] **Step 3: Rebuild** — `npm run build-css`, confirm `.wallet-balance-row` is in `src/index.css`.
+
+- [ ] **Step 4: Check the spacing did not regress**
+
+The previous `<p>` elements inherited Bootstrap's `margin-bottom: 1rem`. The `margin-bottom` above restores it. Compare the rendered spacing against `master` and report any difference.
+
+---
+
+## Task 2: History `Value` column wrapping
+
+**Files:** Modify `src/index.module.scss`
+
+The `Value` cell already renders `<Amount>`, which carries `overflow-wrap: anywhere`. Two things can still defeat it: the cell collapsing to an unusably narrow width, and the table forcing a single line.
+
+- [ ] **Step 1: Add the column rules**
+
+Append to `src/index.module.scss`:
+
+```scss
+/* Transaction history value column */
+#token-history .value {
+  // Long amounts wrap onto a second line, right-aligned, and are never
+  // shrunk or ellipsized. min-width stops the column collapsing so far that
+  // the value breaks earlier than it needs to.
+  min-width: 12rem;
+  white-space: normal;
+}
+```
+
+Do **not** set an explicit `width` — the Figma columns are content-hugged and vary per row, so a fixed width would be inventing a value the design never specified.
+
+`text-align: right` and the monospace font are already applied by the existing `#token-history .value` rule in `src/index.css`; that rule is compiled from `src/index.module.scss`, so check whether the block already exists there and extend it rather than adding a duplicate selector.
+
+- [ ] **Step 2: Rebuild and confirm** — `npm run build-css`, then verify there is exactly one `#token-history .value` rule in the compiled output, with the merged declarations.
+
+---
+
+## Task 3: Verification
+
+- [ ] **Step 1: Suite and build** — baseline unchanged, no warning naming a touched file.
+
+- [ ] **Step 2: Confirm no truncation remains**
+
+Run: `grep -rn "text-overflow\|white-space: *nowrap" src/index.module.scss`
+
+Review every hit. None may apply to an element that renders an amount. `.wallet-balance-label` legitimately uses `nowrap` — that is the label, not the value.
+
+- [ ] **Step 3: Manual QA** (a human runs this; list it in the PR body)
+
+Use a wallet holding a very large balance, or temporarily stub one, so values reach roughly `123,456,789,012,345,678.12345678`.
+
+  - Dashboard `Total` / `Available` / `Locked`: the value wraps to a second line, and the second line starts under the **value**, not under the label.
+  - Narrow the window to roughly 900px: values still wrap, never clip, never ellipsize, never shrink.
+  - History `Value` column: long values wrap to two lines, both flush right, and the column does not collapse.
+  - Short values are unchanged from `master`.
+  - Row spacing in the balance block matches `master`.
+
+---
+
+## Out of scope
+
+- Font family, font size and colour of history values (see above).
+- The transaction overview modal — PR5.
+- Deposit and fee labels — PR6.

--- a/docs/superpowers/plans/2026-07-22-amount-format-pr5.md
+++ b/docs/superpowers/plans/2026-07-22-amount-format-pr5.md
@@ -1,0 +1,134 @@
+# Amount Format — PR5 Implementation Plan (Transaction overview wrapping)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task.
+
+**Goal:** Stop the transaction overview modal clipping long amounts. Per-output amounts and the "You will pay" total wrap instead of being forced onto one line.
+
+**Architecture:** Layout only, on the modal's **current** structure. No formatting logic changes, no structural redesign.
+
+**Figma:** [as-is `318:4172`](https://www.figma.com/design/2xRserWXaSJAgkbiQlPzhr/Amounts-Update?node-id=318-4172) / [to-be `323:196`](https://www.figma.com/design/2xRserWXaSJAgkbiQlPzhr/Amounts-Update?node-id=323-196)
+**Depends on:** PR4. Branch from it.
+
+---
+
+## ⚠️ Read this before starting: one requirement is parked
+
+The original brief asked for the value font size to "adapt based on what the wallet-mobile does". Figma defines that precisely — but on an element the desktop modal **does not have**.
+
+Measured from Figma:
+
+| Element | as-is | to-be |
+| --- | --- | --- |
+| Headline amount (`323:193` / `323:249`) | **24px** SF Pro Text Heavy, black, centered | **16px**, same weight and colour |
+| `available` sub-line (`323:194` / `323:250`) | 12px SF Pro Text Semibold, `#8E8E93` | unchanged |
+| Total value (`323:291`) | 14px, single line | **14px, wraps to two lines — never shrinks** |
+
+So the design shrinks **only** a headline amount, 24px → 16px, and never shrinks the total. The shipped desktop modal (`src/components/ModalTransactionOverview.js`) has no headline amount — it opens straight into the per-output list — so those two numbers have nothing to apply to.
+
+**Decision pending.** Until it is made, this PR ships **wrapping only** and adds no adaptive font sizing. The three candidate resolutions are recorded in the "Open questions" section of `docs/superpowers/specs/2026-07-21-amount-format-design.md`. Do not invent a base/floor pair for the per-output rows.
+
+If you are executing this plan and the decision has since been made, stop and ask for an updated plan rather than improvising.
+
+---
+
+## Working agreement
+
+- **Do not commit per task.** The controller commits once at the end.
+- **No render tests** — Jest 27 cannot parse `axios@1.7.7`'s ESM entry.
+- **Test command:** `CI=true npx react-app-rewired test --watchAll=false 2>&1 | grep -E "^(PASS|FAIL)|^Test Suites:|^Tests:"`. Never pipe jest to `tail` and read `$?`.
+- **Build gate:** `npm run build` (plain, never `CI=true`).
+- **Baseline:** `7 failed, 4 passed, 11 total` / `33 passed, 33 total`.
+- **Do not restructure the modal.** No headline amount, no `To:` row, no collapsible fee breakdown, no `Privacy fee` line — the last implies a feature that does not exist on desktop.
+
+---
+
+## Task 1: Per-output amounts wrap
+
+**Files:** Modify `src/components/ModalTransactionOverview.js`
+
+The output rows render an address on the left and an amount plus a direction arrow on the right. The amount `<span>` sets `whiteSpace: 'nowrap'`, which is what clips long values today.
+
+- [ ] **Step 1: Locate the row**
+
+Find the amount `<span>` inside `renderOutput` — it is the one carrying `fontWeight: 500, color: '#404040', marginLeft: '12px', whiteSpace: 'nowrap', fontSize: '14px'`. Line numbers have shifted across PRs 1–4; locate by content.
+
+- [ ] **Step 2: Let it wrap**
+
+Remove `whiteSpace: 'nowrap'` from that span's style object and add `overflowWrap: 'anywhere'` plus `minWidth: 0`. Keep every other declaration.
+
+The address span beside it already has `wordBreak: 'break-all', minWidth: 0, flex: 1`. Give the amount span a `flexShrink: 0` **only if** testing shows the address squeezing the amount to nothing; otherwise leave the flex behaviour alone and say so.
+
+- [ ] **Step 3: Keep the arrow on the last line**
+
+The direction arrow `<i>` sits inside the same span. Confirm that when the amount wraps, the arrow stays adjacent to the final line rather than being orphaned. If it detaches badly, wrap the numeric part in its own `<span>` and leave the arrow as a sibling — report if you needed this.
+
+---
+
+## Task 2: "You will pay" total wraps
+
+**Files:** Modify `src/components/ModalTransactionOverview.js`
+
+Figma node `323:291` gives exact values for this element, and confirms it does **not** shrink:
+
+| Property | Value |
+| --- | --- |
+| font-size | `14px` |
+| font-weight | `500` (semibold) |
+| colour | `#404040` |
+| line-height | `20px` |
+| text-align | `right` |
+| wrapping | `word-break: break-word`, wraps to as many lines as needed |
+
+- [ ] **Step 1: Update the value span**
+
+In `renderTotalPayment`, the value span currently sets `fontSize: '14px', fontWeight: 500, color: '#404040'`. Add `lineHeight: '20px'`, `textAlign: 'right'`, `overflowWrap: 'anywhere'` and `minWidth: 0`.
+
+- [ ] **Step 2: Let the flex row give it room**
+
+The wrapper is `<div className="d-flex justify-content-between mb-4">`. A flex item will not shrink below its content width by default, which would push the row wider than the modal. Give the label span `flexShrink: 0` and the value span `minWidth: 0` so the value is the element that wraps.
+
+- [ ] **Step 3: Check for a clipping ancestor**
+
+Figma's equivalent container (`323:290`) sets `overflow-clip`. **Do not reproduce that** — a clipping parent defeats wrapping entirely. Verify no ancestor of this row in the modal sets `overflow: hidden`; if one does, report it rather than changing shared modal CSS unilaterally.
+
+---
+
+## Task 3: Network fee row
+
+**Files:** Modify `src/components/ModalTransactionOverview.js`
+
+`renderNetworkFeeValue` returns a span with `fontSize: '14px', fontWeight: 500, color: '#404040'`. It has no `nowrap`, so it should already wrap — but its flex row needs the same treatment as Task 2.
+
+- [ ] **Step 1:** Confirm the fee row's label has `flexShrink: 0` and the value has `minWidth: 0`. Add them if missing.
+- [ ] **Step 2:** Leave the "No fee" pill alone — it is a fixed-width badge, not an amount.
+
+---
+
+## Task 4: Verification
+
+- [ ] **Step 1: Suite and build** — baseline unchanged, no warning naming this file.
+
+- [ ] **Step 2: Confirm no `nowrap` remains on an amount**
+
+Run: `grep -n "nowrap" src/components/ModalTransactionOverview.js`
+
+Any remaining hit must be on a non-amount element. Report each with its purpose.
+
+- [ ] **Step 3: Manual QA** (a human runs this; list it in the PR body)
+
+Trigger the modal from Send Tokens with an amount near `123,456,789,012,345,678.12345678`:
+
+  - The per-output amount wraps rather than clipping, and the direction arrow stays with the final line.
+  - "You will pay" wraps across lines, right-aligned, and does not widen the modal.
+  - With multiple tokens plus a fee, the joined total (`"… AAA + … HTR"`) wraps sensibly.
+  - The modal does not grow wider than its `modal-dialog` and no horizontal scrollbar appears.
+  - Short amounts look identical to `master`.
+  - The PIN field, Cancel and Confirm are unaffected.
+
+---
+
+## Out of scope
+
+- **Adaptive font sizing** — parked, see the top of this plan.
+- Any structural change to the modal.
+- The `Privacy fee` line from the mock — no such feature on desktop.

--- a/docs/superpowers/plans/2026-07-22-amount-format-pr6.md
+++ b/docs/superpowers/plans/2026-07-22-amount-format-pr6.md
@@ -1,0 +1,139 @@
+# Amount Format — PR6 Implementation Plan (Deposit / fee labels)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task.
+
+**Goal:** Stop the read-only amount labels on Create Deposit Token, Create Fee Token, Create NFT and Send Tokens from overflowing their containers when the amount is long.
+
+**Architecture:** Layout only. The amounts already route through `<Amount>` / `formatAmount` from PR1. This PR gives their containers permission to wrap. **The editable amount input is not touched.**
+
+**Figma:** [Create deposit token / Send tokens, node `326:3120`](https://www.figma.com/design/2xRserWXaSJAgkbiQlPzhr/Amounts-Update?node-id=326-3120)
+**Depends on:** PR5. Branch from it.
+
+---
+
+## Working agreement
+
+- **Do not commit per task.** The controller commits once at the end.
+- **No render tests** — Jest 27 cannot parse `axios@1.7.7`'s ESM entry.
+- **Test command:** `CI=true npx react-app-rewired test --watchAll=false 2>&1 | grep -E "^(PASS|FAIL)|^Test Suites:|^Tests:"`. Never pipe jest to `tail` and read `$?`.
+- **Build gate:** `npm run build` (plain, never `CI=true`).
+- **Baseline:** `7 failed, 4 passed, 11 total` / `33 passed, 33 total`.
+
+---
+
+## `src/components/InputNumber.js` is not modified
+
+Decided during design and unchanged: `InputNumber` accumulates keystrokes as BigInt and has no `maxLength`, so it **already** accepts any number of decimal places — the "support 8 decimal places in the inputs" requirement is functionally met today.
+
+A long typed value can overflow the field visually, but `<input>` is single-line by definition and the caret is already pinned to the end (`InputNumber.updateCaretPosition`), so the digits being typed stay visible. Widening the field, shrinking the font and capping the length were all considered and rejected. **Only read-only labels are in scope.**
+
+For context, Figma's Amount input (`326:3146`) is `381px × 38px`, `1px solid #B7BFC7`, `border-radius: 4px`. Recorded so nobody re-derives it; not a change to make.
+
+---
+
+## Design values (measured from Figma)
+
+The `Deposit: … HTR (20.00 HTR available)` label (`326:3153`): `16px`, `line-height: 22px`, colour `#000`, container hugs to `620px` inside a `716px` parent.
+
+**Caveat:** the mock shows this label as `white-space: nowrap`, on one line. That is not a specification that it must never wrap — it simply reflects the short sample value the designer used, which fits in the available width. With a realistic maximum it would overflow the card. Implement wrapping; the mock is consistent with that because at its sample length no wrap occurs.
+
+Two other frames in that Figma file sit loose on the canvas rather than inside the card's auto-layout (`326:3156`, `326:3159`, `326:3160`) and are designer scratch. Ignore them.
+
+---
+
+## Task 1: Create Token / Create Fee Token labels
+
+**Files:** Modify `src/screens/CreateToken.js`, `src/index.module.scss`
+
+`CreateToken.js` builds `infoLabel` as a template string combining the deposit amount and the available balance, then renders it. The string itself is fine; the container must be allowed to wrap.
+
+- [ ] **Step 1: Find the label element**
+
+Locate where `infoLabel` (and the `requiredFeeAmountText` / `availableBalanceText` values) are rendered. Note the class or inline style on the containing element.
+
+- [ ] **Step 2: Give it a wrapping class**
+
+Add `className="amount-label"` to the element that renders the label text. If it already has classes, append rather than replace.
+
+- [ ] **Step 3: Add the SCSS**
+
+Append to `src/index.module.scss`:
+
+```scss
+/* Read-only amount labels beside inputs (deposit, fee, available balance) */
+.amount-label {
+  // The label embeds amounts inside a sentence, so the break can land at a
+  // space normally; `anywhere` is the fallback for a single very long number
+  // that exceeds the container on its own.
+  overflow-wrap: anywhere;
+  white-space: normal;
+  max-width: 100%;
+}
+```
+
+- [ ] **Step 4: Rebuild** — `npm run build-css`, confirm `.amount-label` is present in `src/index.css`.
+
+---
+
+## Task 2: Create NFT labels
+
+**Files:** Modify `src/screens/CreateNFT.js`
+
+This screen renders three `<p>` rows — `<symbol> available:`, `Deposit:` and `Total:` — each already using `<Amount>`, plus an `nftFee` string.
+
+- [ ] **Step 1:** Add `className="amount-label"` to each of those three `<p>` elements and to the element rendering `nftFee`.
+
+- [ ] **Step 2:** Confirm none of them sits inside a container with a fixed width or `overflow: hidden`. Report if one does.
+
+---
+
+## Task 3: Send Tokens labels
+
+**Files:** Modify `src/components/SendTokensOne.js`
+
+Three read-only amount labels: the network fee row, the available-balance readout beside the token selector, and the "You'll pay" summary line built as a template string.
+
+- [ ] **Step 1:** Add `className="amount-label"` to each of the three containing elements.
+
+- [ ] **Step 2:** The available-balance readout sits next to the token `<select>` in a flex or inline row. Confirm the amount can wrap without pushing the select off-screen; if the row needs `flex-wrap: wrap` or the label needs `min-width: 0`, add it and say so.
+
+---
+
+## Task 4: Token Mint / Melt deposit labels
+
+**Files:** Modify `src/components/tokens/TokenMint.js`, `src/components/tokens/TokenMelt.js`
+
+`TokenMint` passes a `deposit={...}` template string containing two amounts down to a child component. `TokenMelt` builds similar message strings.
+
+- [ ] **Step 1:** Find where each string is rendered — it may be inside a shared child component rather than in these files. Add `className="amount-label"` at the render site.
+
+- [ ] **Step 2:** If the render site is a shared component used by callers outside this feature, do **not** hardcode the class there. Either accept a `className` prop or add the class at each caller. Report which approach you took and why.
+
+---
+
+## Task 5: Verification
+
+- [ ] **Step 1: Suite and build** — baseline unchanged, no warning naming a touched file.
+
+- [ ] **Step 2: `InputNumber` untouched**
+
+Run: `git diff --stat src/components/InputNumber.js`
+Expected: **no output**.
+
+- [ ] **Step 3: Manual QA** (a human runs this; list it in the PR body)
+
+  - **Create Deposit Token:** type an amount long enough to make the deposit label exceed the card width. The label wraps within the card; it does not overflow, get clipped, or push the card wider. The input itself is unchanged — it scrolls horizontally as before, with the caret pinned to the end.
+  - **Create Fee Token:** same, for the network-fee label.
+  - **Create NFT:** available / deposit / total all wrap.
+  - **Send Tokens:** the fee row, available balance and "You'll pay" line all wrap; the token select stays usable.
+  - **Token Mint / Melt:** the deposit label wraps.
+  - Narrow the window to roughly 900px and repeat — nothing clips.
+  - Short amounts render identically to `master`.
+
+---
+
+## Out of scope
+
+- `src/components/InputNumber.js` and any editable input behaviour.
+- Any layout change beyond letting labels wrap — the brief is explicit that this screen gets no other restyling.
+- The Figma frame's input dimensions and card layout.

--- a/src/components/ModalTokenImport.js
+++ b/src/components/ModalTokenImport.js
@@ -9,13 +9,13 @@ import React, { useState, useEffect, useContext, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { t } from 'ttag';
 import ReactLoading from 'react-loading';
-import hathorLib from '@hathor/wallet-lib';
 import { GlobalModalContext, MODAL_TYPES } from './GlobalModal';
 import { tokenRegisterRequested } from '../actions/index';
 import { getGlobalWallet } from '../modules/wallet';
 import walletUtils from '../utils/wallet';
 import helpers from '../utils/helpers';
 import { colors } from '../constants';
+import { useAmountFormat } from '../hooks/useAmountFormat';
 
 /**
  * States the modal can be in.
@@ -64,7 +64,7 @@ export default function ModalTokenImport({ onClose, manageDomLifecycle }) {
   const registeredTokens = useSelector((state) => state.tokens);
   const tokensBalance = useSelector((state) => state.tokensBalance);
   const explorerUrl = useSelector((state) => state.networkSettings.data.explorer);
-  const decimalPlaces = useSelector((state) => state.serverInfo.decimalPlaces);
+  const formatValue = useAmountFormat();
 
   const hideZeroBalance = walletUtils.areZeroBalanceTokensHidden();
   const unknownTokens = useMemo(
@@ -268,7 +268,7 @@ export default function ModalTokenImport({ onClose, manageDomLifecycle }) {
     const available = balanceData.available ?? 0n;
     const locked = balanceData.locked ?? 0n;
     const total = available + locked;
-    return `${hathorLib.numberUtils.prettyValue(total, decimalPlaces)} ${symbol}`;
+    return `${formatValue(total)} ${symbol}`;
   };
 
   const renderZeroBalanceAlert = () => {

--- a/src/components/NFTListElement.js
+++ b/src/components/NFTListElement.js
@@ -15,7 +15,7 @@ import {
 import { TOKEN_DOWNLOAD_STATUS } from '../sagas/tokens';
 import helpers from '../utils/helpers';
 import Loading from '../components/Loading';
-import { numberUtils } from '@hathor/wallet-lib';
+import Amount from './Amount';
 
 
 /**
@@ -99,7 +99,7 @@ class NFTListElement extends React.Component {
             </figure>
             <p>
               <strong>Balance: </strong>
-              { this.props.nftElement.balance.status === TOKEN_DOWNLOAD_STATUS.READY && numberUtils.prettyValue(this.props.nftElement.balance.data.available, 0) }
+              { this.props.nftElement.balance.status === TOKEN_DOWNLOAD_STATUS.READY && <Amount value={this.props.nftElement.balance.data.available} isNFT /> }
               { this.props.nftElement.balance.status === TOKEN_DOWNLOAD_STATUS.LOADING && (
                 <Loading />
               )}

--- a/src/components/Reown/CreateTokenRequestData.js
+++ b/src/components/Reown/CreateTokenRequestData.js
@@ -8,22 +8,9 @@
 import React from 'react';
 import { t } from 'ttag';
 import hathorLib from '@hathor/wallet-lib';
+import { useAmountFormat } from '../../hooks/useAmountFormat';
 
 const DEFAULT_TOKEN_SYMBOL = hathorLib.constants.DEFAULT_NATIVE_TOKEN_CONFIG.symbol;
-
-/**
- * Format token amount with proper decimal places
- */
-const formatAmount = (amount) => {
-  try {
-    if (amount === undefined || amount === null) return null;
-    return hathorLib.numberUtils.prettyValue(amount);
-  } catch (error) {
-    console.error('Error formatting amount:', error);
-    return amount.toString();
-  }
-};
-
 
 /**
  * Renders translated values for token version
@@ -86,6 +73,28 @@ const TokenParameter = ({ label, value, isAddress = false, isBoolean = false }) 
  * @param {Object} data The token data to be displayed
  */
 export default function CreateTokenRequestData({ data }) {
+  const formatValue = useAmountFormat();
+
+  /**
+   * Format an amount from an external dApp payload.
+   *
+   * The request is not under our control, so a missing or malformed amount must
+   * render as nothing rather than throwing during render — prettyValue coerces
+   * with BigInt(), which raises on null, undefined or a non-numeric value.
+   */
+  const renderAmount = (amount) => {
+    if (amount === undefined || amount === null) {
+      return null;
+    }
+
+    try {
+      return formatValue(amount);
+    } catch (error) {
+      console.error('Error formatting amount:', error);
+      return String(amount);
+    }
+  };
+
   /**
    * Check if token has mint authority
    */
@@ -115,7 +124,7 @@ export default function CreateTokenRequestData({ data }) {
       {/* Basic Token Information */}
       <TokenParameter label={t`Name`} value={data.name} />
       <TokenParameter label={t`Symbol`} value={data.symbol} />
-      <TokenParameter label={t`Amount`} value={formatAmount(data.amount)} />
+      <TokenParameter label={t`Amount`} value={renderAmount(data.amount)} />
       <TokenParameter label={t`Type`} value={formatTokenVersion(data.version)} />
 
       {/* Authority Settings */}
@@ -178,13 +187,13 @@ export default function CreateTokenRequestData({ data }) {
       {data.deposit && (
         <TokenParameter
           label={t`Deposit`}
-          value={`${formatAmount(data.deposit)} ${DEFAULT_TOKEN_SYMBOL}`}
+          value={`${renderAmount(data.deposit)} ${DEFAULT_TOKEN_SYMBOL}`}
         />
       )}
       {data.fee !== undefined && data.fee !== null && (
         <TokenParameter
           label={t`Network Fee`}
-          value={data.fee ? `${formatAmount(data.fee)} ${DEFAULT_TOKEN_SYMBOL}` : '-'}
+          value={data.fee ? `${renderAmount(data.fee)} ${DEFAULT_TOKEN_SYMBOL}` : '-'}
         />
       )}
     </div>

--- a/src/components/Reown/NanoContractActions.js
+++ b/src/components/Reown/NanoContractActions.js
@@ -9,8 +9,8 @@ import React, { useCallback } from 'react';
 import { t } from 'ttag';
 import { useSelector } from 'react-redux';
 import helpers from '../../utils/helpers';
-import hathorLib from '@hathor/wallet-lib';
 import { constants, NanoContractActionType } from '@hathor/wallet-lib';
+import { useAmountFormat } from '../../hooks/useAmountFormat';
 const { DEFAULT_NATIVE_TOKEN_CONFIG, NATIVE_TOKEN_UID } = constants;
 
 /**
@@ -86,11 +86,11 @@ const getActionTitle = (tokens, registeredTokens, action) => {
  * Component that displays a single action item
  */
 const ActionItem = ({ action, isNft, title }) => {
-  const decimalPlaces = useSelector((state) => state.serverInfo.decimalPlaces);
+  const formatValue = useAmountFormat();
 
   const formatAmount = (amount) => {
     try {
-      return hathorLib.numberUtils.prettyValue(amount, isNft ? 0 : decimalPlaces);
+      return formatValue(amount, { isNFT: isNft });
     } catch (error) {
       console.warn('Error formatting amount:', amount, error);
       return '';

--- a/src/components/Reown/TransactionFees.js
+++ b/src/components/Reown/TransactionFees.js
@@ -7,7 +7,8 @@
 
 import React from 'react';
 import { t } from 'ttag';
-import { constants, numberUtils } from '@hathor/wallet-lib';
+import { constants } from '@hathor/wallet-lib';
+import Amount from '../Amount';
 
 /**
  * Component for displaying network fee information
@@ -20,7 +21,6 @@ export const TransactionFees = ({ fee }) => {
     return null;
   }
 
-  const formattedFee = numberUtils.prettyValue(fee);
   const symbol = constants.DEFAULT_NATIVE_TOKEN_CONFIG.symbol;
 
   return (
@@ -32,7 +32,7 @@ export const TransactionFees = ({ fee }) => {
             <i className="fa fa-arrow-up text-danger mr-2" />
             <strong>{symbol}</strong>
           </span>
-          <span>{formattedFee} {symbol}</span>
+          <span><Amount value={fee} symbol={symbol} /></span>
         </div>
       </div>
     </div>

--- a/src/components/Reown/modals/BaseNanoContractModal.js
+++ b/src/components/Reown/modals/BaseNanoContractModal.js
@@ -12,10 +12,11 @@ import { types, unregisteredTokensStoreSuccess } from '../../../actions';
 import { NanoContractActions } from '../NanoContractActions';
 import AddressList from '../../AddressList';
 import { NANO_UPDATE_ADDRESS_LIST_COUNT } from '../../../constants';
-import { constants, numberUtils, dateUtils, scriptsUtils, bufferUtils, bigIntUtils } from '@hathor/wallet-lib';
+import { constants, dateUtils, scriptsUtils, bufferUtils, bigIntUtils } from '@hathor/wallet-lib';
 import { DAppInfo } from '../DAppInfo';
 import { SignedDataDisplay } from '../SignedDataDisplay';
 import { TransactionFees } from '../TransactionFees';
+import { useAmountFormat } from '../../../hooks/useAmountFormat';
 
 /**
  * Parse script data from hex string
@@ -93,7 +94,9 @@ const BlueprintInfoCard = ({ nanoContract, blueprintInfo }) => (
 /**
  * Component for Arguments Table
  */
-const ArgumentsTable = ({ args, decimalPlaces, tokens, network }) => {
+const ArgumentsTable = ({ args, tokens, network }) => {
+  const formatValue = useAmountFormat();
+
   if (!args || !args.length) return null;
 
   /**
@@ -111,7 +114,7 @@ const ArgumentsTable = ({ args, decimalPlaces, tokens, network }) => {
     let displayValue = value;
 
     if (type === 'Amount') {
-      displayValue = numberUtils.prettyValue(value, decimalPlaces);
+      displayValue = formatValue(value);
     } else if (type === 'Timestamp') {
       displayValue = dateUtils.parseTimestamp(value);
     } else if (type === 'TxOutputScript') {
@@ -240,7 +243,6 @@ export function BaseNanoContractModal({
   // Redux selectors
   const blueprintInfo = useSelector((state) => state.blueprintsData[nanoContract.blueprintId]);
   const nanoContracts = useSelector((state) => state.nanoContracts);
-  const decimalPlaces = useSelector((state) => state.serverInfo.decimalPlaces);
   const firstAddress = useSelector((state) => state.reown.firstAddress);
   const registeredTokens = useSelector((state) => state.tokens);
   const network = useSelector((state) => state.serverInfo.network);
@@ -377,7 +379,6 @@ export function BaseNanoContractModal({
 
         <ArgumentsTable
           args={nanoContract.parsedArgs}
-          decimalPlaces={decimalPlaces}
           tokens={registeredTokens.reduce((acc, token) => {
             acc[token.uid] = token;
             return acc;

--- a/src/components/Reown/modals/GetUtxosModal.js
+++ b/src/components/Reown/modals/GetUtxosModal.js
@@ -11,16 +11,17 @@ import { useSelector } from 'react-redux';
 import { DAppInfo } from '../DAppInfo';
 import hathorLib from '@hathor/wallet-lib';
 import helpers from '../../../utils/helpers';
+import { useAmountFormat } from '../../../hooks/useAmountFormat';
 
 /**
  * Modal for confirming UTXO access requests from dApps.
  * Shows the filter parameters and UTXO summary, asks for user confirmation.
  */
 export function GetUtxosModal({ data, onAccept, onReject }) {
-  const { tokenMetadata, decimalPlaces } = useSelector((state) => ({
+  const { tokenMetadata } = useSelector((state) => ({
     tokenMetadata: state.tokenMetadata,
-    decimalPlaces: state.serverInfo.decimalPlaces
   }));
+  const formatValue = useAmountFormat();
 
   // The RPC handler transforms params and may use snake_case keys
   const rawParams = data.params || {};
@@ -63,7 +64,7 @@ export function GetUtxosModal({ data, onAccept, onReject }) {
   const formatAmount = (amount, tokenId) => {
     if (amount === undefined || amount === null) return null;
     const isNFT = tokenId && helpers.isTokenNFT(tokenId, tokenMetadata);
-    return hathorLib.numberUtils.prettyValue(amount, isNFT ? 0 : decimalPlaces);
+    return formatValue(amount, { isNFT });
   };
 
   /**

--- a/src/components/Reown/modals/SendTransactionModal.js
+++ b/src/components/Reown/modals/SendTransactionModal.js
@@ -8,11 +8,12 @@
 import React, { useEffect } from 'react';
 import { t } from 'ttag';
 import { useSelector, useDispatch } from 'react-redux';
-import { constants, numberUtils } from '@hathor/wallet-lib';
+import { constants } from '@hathor/wallet-lib';
 import { unregisteredTokensStoreSuccess } from '../../../actions';
 import { CopyButton } from '../../CopyButton';
 import helpers from '../../../utils/helpers';
 import { TransactionFees } from '../TransactionFees';
+import { useAmountFormat } from '../../../hooks/useAmountFormat';
 
 export function SendTransactionModal({ data, onAccept, onReject }) {
   const dispatch = useDispatch();
@@ -20,11 +21,11 @@ export function SendTransactionModal({ data, onAccept, onReject }) {
   const params = data?.params || {};
   const { inputs = [], outputs = [] } = params;
 
-  const { tokenMetadata, tokens: registeredTokens, decimalPlaces } = useSelector((state) => ({
+  const { tokenMetadata, tokens: registeredTokens } = useSelector((state) => ({
     tokenMetadata: state.tokenMetadata,
     tokens: state.tokens,
-    decimalPlaces: state.serverInfo.decimalPlaces
   }));
+  const formatAmountValue = useAmountFormat();
 
   useEffect(() => {
     // Collect unregistered tokens from tokenDetails Map
@@ -116,7 +117,7 @@ export function SendTransactionModal({ data, onAccept, onReject }) {
     // Check if the token is an NFT using the helpers utility
     const isNFT = tokenId && helpers.isTokenNFT(tokenId, tokenMetadata);
 
-    return numberUtils.prettyValue(value, isNFT ? 0 : decimalPlaces);
+    return formatAmountValue(value, { isNFT });
   };
 
   const truncateTxId = (txId) => {

--- a/src/components/atomic-swap/ModalAtomicSend.js
+++ b/src/components/atomic-swap/ModalAtomicSend.js
@@ -8,20 +8,21 @@
 import React, { useEffect, useRef, useState } from "react";
 import { t } from "ttag";
 import InputNumber from "../InputNumber";
-import { Address, numberUtils } from "@hathor/wallet-lib";
+import { Address } from "@hathor/wallet-lib";
 import { translateTxToProposalUtxo } from "../../utils/atomicSwap";
 import { TOKEN_DOWNLOAD_STATUS } from "../../sagas/tokens";
 import { get } from 'lodash';
 import Loading from "../Loading";
 import walletUtils from '../../utils/wallet';
 import { useSelector } from 'react-redux';
+import { useAmountFormat } from '../../hooks/useAmountFormat';
 
 function UtxoRow ({ wallet, utxo, token, utxoChanged, showAddButton, addButtonHandler, setErrMessage }) {
     const [txId, setTxId] = useState(utxo.tx_id || '');
     const [outputIndex, setOutputIndex] = useState(utxo.index || '');
     const [amount, setAmount] = useState('');
     const [isInvalid, setIsInvalid] = useState(false);
-    const decimalPlaces = useSelector(state => state.serverInfo.decimalPlaces);
+    const formatValue = useAmountFormat();
 
     const raiseInvalidInputError = () => {
         setAmount('');
@@ -63,7 +64,7 @@ function UtxoRow ({ wallet, utxo, token, utxoChanged, showAddButton, addButtonHa
         }
 
         const newAmount = validUtxo.amount;
-        setAmount(numberUtils.prettyValue(newAmount, decimalPlaces));
+        setAmount(formatValue(newAmount));
         setIsInvalid(false);
         setErrMessage('');
         utxoChanged(validUtxo);

--- a/src/components/atomic-swap/ProposalBalanceTable.js
+++ b/src/components/atomic-swap/ProposalBalanceTable.js
@@ -7,8 +7,7 @@
 
 import React from "react";
 import { t } from 'ttag';
-import { numberUtils } from '@hathor/wallet-lib';
-import { useSelector } from 'react-redux';
+import Amount from '../Amount';
 
 /**
  * @param {PartialTx} partialTx
@@ -21,14 +20,13 @@ export function ProposalBalanceTable ({ partialTx, wallet, balance }) {
     const sendingBalances = balance.filter(b => {
         return b.sending >= 0;
     });
-    const decimalPlaces = useSelector((state) => state.serverInfo.decimalPlaces);
 
     const renderRows = () => {
         const renderOne = (amount, symbol) => {
             if (!amount && !symbol) {
                 return '';
             }
-            return <span>{numberUtils.prettyValue(amount, decimalPlaces)} <b>{symbol}</b></span>
+            return <span><Amount value={amount} /> <b>{symbol}</b></span>
         }
 
         if (sendingBalances.length === 0 && receivingBalances.length === 0) {

--- a/src/components/tokens/TokenMelt.js
+++ b/src/components/tokens/TokenMelt.js
@@ -16,14 +16,19 @@ import ReactLoading from 'react-loading';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 import { TOKEN_DOWNLOAD_STATUS } from '../../sagas/tokens';
-import { colors } from '../../constants';
+import { colors, AMOUNT_FORMAT_FEATURE_TOGGLE } from '../../constants';
 import { getGlobalWallet } from "../../modules/wallet";
+import { formatAmount, resolveAmountFormat } from '../../utils/amount';
 
 const mapStateToProps = (state) => {
   return {
     tokenMetadata: state.tokenMetadata,
     useWalletService: state.useWalletService,
     decimalPlaces: state.serverInfo.decimalPlaces,
+    amountFormat: resolveAmountFormat(
+      state.amountFormat,
+      state.featureToggles[AMOUNT_FORMAT_FEATURE_TOGGLE]
+    ),
   };
 };
 
@@ -84,10 +89,20 @@ class TokenMelt extends React.Component {
   }
 
   /**
+   * Format an amount using the token's decimal places and NFT status,
+   * respecting the user's amount format preference.
+   */
+  formatValue = (value) => formatAmount(value, {
+    decimalPlaces: this.props.decimalPlaces,
+    isNFT: this.isNFT(),
+    amountFormat: this.props.amountFormat,
+  });
+
+  /**
    * Return a message to be shown in case of success
    */
   getSuccessMessage = () => {
-    const prettyAmountValue = hathorLib.numberUtils.prettyValue(this.state.amount, this.isNFT() ? 0 : this.props.decimalPlaces);
+    const prettyAmountValue = this.formatValue(this.state.amount);
     return t`${prettyAmountValue} ${this.props.token.symbol} melted!`;
   }
 
@@ -101,7 +116,7 @@ class TokenMelt extends React.Component {
     const walletAmount = get(this.props.tokenBalance, 'data.available', 0);
 
     if (this.state.amount > walletAmount) {
-      const prettyWalletAmount = hathorLib.numberUtils.prettyValue(walletAmount, this.isNFT() ? 0 : this.props.decimalPlaces);
+      const prettyWalletAmount = this.formatValue(walletAmount);
       return t`The total amount you have is only ${prettyWalletAmount}.`;
     }
   }

--- a/src/components/tokens/TokenMint.js
+++ b/src/components/tokens/TokenMint.js
@@ -17,6 +17,8 @@ import InputNumber from '../InputNumber';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
 import { getGlobalWallet } from "../../modules/wallet";
+import { formatAmount, resolveAmountFormat } from '../../utils/amount';
+import { AMOUNT_FORMAT_FEATURE_TOGGLE } from '../../constants';
 
 const mapStateToProps = (state) => {
   return {
@@ -24,6 +26,10 @@ const mapStateToProps = (state) => {
     tokenMetadata: state.tokenMetadata,
     useWalletService: state.useWalletService,
     decimalPlaces: state.serverInfo.decimalPlaces,
+    amountFormat: resolveAmountFormat(
+      state.amountFormat,
+      state.featureToggles[AMOUNT_FORMAT_FEATURE_TOGGLE]
+    ),
   };
 };
 
@@ -91,10 +97,20 @@ class TokenMint extends React.Component {
   }
 
   /**
+   * Format an amount using the token's decimal places and NFT status,
+   * respecting the user's amount format preference.
+   */
+  formatValue = (value) => formatAmount(value, {
+    decimalPlaces: this.props.decimalPlaces,
+    isNFT: this.isNFT(),
+    amountFormat: this.props.amountFormat,
+  });
+
+  /**
    * Return a message to be shown in case of success
    */
   getSuccessMessage = () => {
-    const prettyAmountValue = hathorLib.numberUtils.prettyValue(this.state.amount, this.isNFT() ? 0 : this.props.decimalPlaces);
+    const prettyAmountValue = this.formatValue(this.state.amount);
     return t`${prettyAmountValue} ${this.props.token.symbol} minted!`;
   }
 
@@ -202,7 +218,7 @@ class TokenMint extends React.Component {
        renderForm={renderForm}
        title={t`Mint tokens`}
        subtitle={`A deposit of ${depositPercent * 100}% in ${nativeTokenConfig.symbol} of the mint amount is required`}
-       deposit={`Deposit: ${tokens.getDepositAmount(getAmountToCalculateDeposit(), depositPercent, this.props.decimalPlaces)} ${nativeTokenConfig.symbol} (${hathorLib.numberUtils.prettyValue(this.props.htrBalance, this.props.decimalPlaces)} ${nativeTokenConfig.symbol} available)`}
+       deposit={`Deposit: ${tokens.getDepositAmount(getAmountToCalculateDeposit(), depositPercent, this.props.decimalPlaces, this.props.amountFormat)} ${nativeTokenConfig.symbol} (${formatAmount(this.props.htrBalance, { decimalPlaces: this.props.decimalPlaces, amountFormat: this.props.amountFormat })} ${nativeTokenConfig.symbol} available)`}
        buttonName={t`Go`}
        validateForm={this.mint}
        getSuccessMessage={this.getSuccessMessage}

--- a/src/screens/CreateToken.js
+++ b/src/screens/CreateToken.js
@@ -17,12 +17,13 @@ import tokens from '../utils/tokens';
 import SpanFmt from '../components/SpanFmt';
 import BackButton from '../components/BackButton';
 import helpers from '../utils/helpers';
-import { TOKEN_DEPOSIT_RFC_URL, TOKEN_FEE_RFC_URL } from '../constants';
+import { TOKEN_DEPOSIT_RFC_URL, TOKEN_FEE_RFC_URL, AMOUNT_FORMAT_FEATURE_TOGGLE } from '../constants';
 import InputNumber from '../components/InputNumber';
 import { GlobalModalContext, MODAL_TYPES } from '../components/GlobalModal';
 import { useNavigate, useParams } from "react-router-dom";
 import { getGlobalWallet } from "../modules/wallet";
 import { useAmountFormat } from '../hooks/useAmountFormat';
+import { resolveAmountFormat } from '../utils/amount';
 
 /**
  * Create a new token
@@ -38,6 +39,10 @@ function CreateToken() {
   }));
   const wallet = getGlobalWallet();
   const formatValue = useAmountFormat();
+  const amountFormat = useSelector(state => resolveAmountFormat(
+    state.amountFormat,
+    state.featureToggles[AMOUNT_FORMAT_FEATURE_TOGGLE]
+  ));
 
   // Get TokenVersion enum from wallet-lib
   const { TokenVersion } = hathorLib;
@@ -327,7 +332,7 @@ function CreateToken() {
   const renderFeeModelInfo = () => {
     let infoLabel = `${t`Network fee`}: ${requiredFeeAmountText} (${availableBalanceText})`;
     if (isDepositToken) {
-      infoLabel = `${t`Deposit:`} ${tokens.getDepositAmount(amount, depositPercent, decimalPlaces)} ${nativeTokenConfig.symbol} (${availableBalanceText})`;
+      infoLabel = `${t`Deposit:`} ${tokens.getDepositAmount(amount, depositPercent, decimalPlaces, amountFormat)} ${nativeTokenConfig.symbol} (${availableBalanceText})`;
     }
     return <p className="mb-0">{infoLabel}</p>;
   }

--- a/src/screens/SendTokens.js
+++ b/src/screens/SendTokens.js
@@ -26,6 +26,7 @@ import { OutputType } from '@hathor/wallet-lib';
 import { SendDataOutputOne } from '../components/SendDataOutputOne';
 import { uniqueId } from 'lodash';
 import { useTokensDetails } from '../hooks/useTokenDetails';
+import { useAmountFormat } from '../hooks/useAmountFormat';
 
 /** @typedef {0|1} LEDGER_MODAL_STATE */
 const LEDGER_MODAL_STATE = {
@@ -58,6 +59,7 @@ function SendTokens() {
       };
     });
   const wallet = getGlobalWallet();
+  const formatValue = useAmountFormat();
   /**
    * Get the full object for the selected token on the TokenBar.
    *
@@ -144,13 +146,13 @@ function SendTokens() {
       }
 
       if (htrBalance < totalFee + outgoingHTR) {
-        const requiredAmount = hathorLib.numberUtils.prettyValue(totalFee + outgoingHTR, decimalPlaces);
+        const requiredAmount = formatValue(totalFee + outgoingHTR);
         return t`Insufficient HTR balance to complete the transaction. It requires ${requiredAmount} for outputs and network fee`;
       }
     }
 
     return '';
-  }, [tokenFees, tokensBalance, dataOutputs]);
+  }, [tokenFees, tokensBalance, dataOutputs, formatValue]);
 
   /**
    * Check if user has enough HTR to pay total fee

--- a/src/screens/atomic-swap/EditSwap.js
+++ b/src/screens/atomic-swap/EditSwap.js
@@ -21,7 +21,8 @@ import {
 } from "../../utils/atomicSwap";
 import { ProposalBalanceTable } from "../../components/atomic-swap/ProposalBalanceTable";
 import { GlobalModalContext, MODAL_TYPES } from '../../components/GlobalModal';
-import { PartialTxProposal, PartialTx, numberUtils } from "@hathor/wallet-lib";
+import Amount from '../../components/Amount';
+import { PartialTxProposal, PartialTx } from "@hathor/wallet-lib";
 import { cloneDeep, get } from 'lodash';
 import { TOKEN_DOWNLOAD_STATUS } from "../../sagas/tokens";
 import Loading from "../../components/Loading";
@@ -41,11 +42,9 @@ export default function EditSwap(props) {
     /**
      * @type Object
      * @property {ReduxProposalData} proposal
-     * @property {number} decimalPlaces
      */
-    const { proposal, decimalPlaces } = useSelector(state => ({
+    const { proposal } = useSelector(state => ({
       proposal: state.proposals[proposalId],
-      decimalPlaces: state.serverInfo.decimalPlaces,
     }));
     /** @type HathorWallet */
     const wallet = getGlobalWallet();
@@ -134,7 +133,7 @@ export default function EditSwap(props) {
                             title={t`This input is signed`}></i>}
                     </td>
                     <td className="text-right">
-                        {numberUtils.prettyValue(input.value, decimalPlaces)}
+                        <Amount value={input.value} />
                     </td>
                     <td className="text-right">
                         {input.index}
@@ -153,7 +152,7 @@ export default function EditSwap(props) {
             return outputs.map((output,index) => {
                 return <tr key={`${output.address}-${index}`}>
                     <td>{output.address}</td>
-                    <td className="text-right">{numberUtils.prettyValue(output.value, decimalPlaces)}</td>
+                    <td className="text-right"><Amount value={output.value} /></td>
                     <td className="text-center">
                         {output.isMine && output.isChange && <i
                             className="fa fa-check ml-1"

--- a/src/screens/nano-contract/NanoContractDetail.js
+++ b/src/screens/nano-contract/NanoContractDetail.js
@@ -15,6 +15,7 @@ import helpers from '../../utils/helpers';
 import nanoUtils from '../../utils/nanoContracts';
 import hathorLib from '@hathor/wallet-lib';
 import path from 'path-browserify';
+import Amount from '../../components/Amount';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
 import { nanoContractDetailRequest, nanoContractDetailSetStatus, nanoContractUnregister } from '../../actions';
@@ -159,7 +160,7 @@ function NanoContractDetail() {
       return (
         <div key={tokenUid} className="d-flex flex-column nc-token-balance">
           <p><strong>Token: </strong>{tokenUid === hathorLib.constants.NATIVE_TOKEN_UID ? tokenUid : <a href="true" onClick={(e) => goToExplorer(e, tokenUid)}>{tokenUid}</a>}</p>
-          <p><strong>Amount: </strong>{hathorLib.numberUtils.prettyValue(typeof amount.value === 'bigint' ? amount.value : BigInt(amount.value), decimalPlaces)}</p>
+          <p><strong>Amount: </strong><Amount value={typeof amount.value === 'bigint' ? amount.value : BigInt(amount.value)} /></p>
         </div>
       );
     });

--- a/src/utils/nanoContracts.js
+++ b/src/utils/nanoContracts.js
@@ -7,6 +7,7 @@
 
 import hathorLib from '@hathor/wallet-lib';
 import { SignedDataDisplay } from '../components/Reown/SignedDataDisplay';
+import Amount from '../components/Amount';
 import { get } from 'lodash';
 
 /**
@@ -89,7 +90,7 @@ const nanoContracts = {
     }
 
     if (typeWithoutOptional === 'Amount') {
-      return hathorLib.numberUtils.prettyValue(value, decimalPlaces);
+      return <Amount value={value} />;
     }
 
     if (typeWithoutOptional.startsWith('SignedData')) {

--- a/src/utils/tokens.js
+++ b/src/utils/tokens.js
@@ -11,6 +11,7 @@ import wallet from './wallet';
 import hathorLib from '@hathor/wallet-lib';
 import LOCAL_STORE from '../storage';
 import { getGlobalWallet } from '../modules/wallet';
+import { formatAmount } from './amount';
 
 /**
  * Methods to create and handle tokens
@@ -107,22 +108,24 @@ const tokens = {
   /**
    * Returns the deposit amount in 'pretty' format
    *
+   * The deposit is always paid in HTR, so it is formatted without isNFT.
+   *
    * @param {number} mintAmount Amount of tokens to mint
    * @param {number} depositPercent deposit percentage for creating tokens
    * @param {number} decimalPlaces Number of decimal places
+   * @param {string} [amountFormat] AMOUNT_FORMAT.EXPANDED or COMPRESSED; defaults to expanded
    *
    * @return {string} deposit amount
    *
    * @memberof Tokens
    * @inner
    */
-  getDepositAmount(mintAmount, depositPercent, decimalPlaces) {
+  getDepositAmount(mintAmount, depositPercent, decimalPlaces, amountFormat) {
     if (mintAmount) {
       const deposit = hathorLib.tokensUtils.getDepositAmount(mintAmount, depositPercent);
-      return hathorLib.numberUtils.prettyValue(deposit, decimalPlaces);
-    } else {
-      return '0';
+      return formatAmount(deposit, { decimalPlaces, amountFormat });
     }
+    return '0';
   },
 
   /**


### PR DESCRIPTION
### Acceptance Criteria

- Every remaining direct `numberUtils.prettyValue` call is routed through the shared amount layer from #892, so the Expanded/Compressed preference applies consistently across the whole wallet — Reown, atomic swap, nano contracts, the NFT list, token mint/melt, token import, and the send/create flows
- `numberUtils.prettyValue` now survives only in `InputNumber`, which is always expanded by design
- No behaviour change while the `amount-format-desktop.rollout` flag is off (its default)

Second of 6 PRs. **Stacked on #892** — base branch is `raul-oliveira/feat/amount-format`, not `master`. Review #892 first.

### What changed

18 files, all mechanical conversions onto the three PR1 APIs:

- **JSX sites** render `<Amount>`
- **Function components** needing a string use `useAmountFormat()`
- **Class components** and plain modules use `formatAmount`, and mask the preference with `resolveAmountFormat(...)` in `mapStateToProps` so the feature flag can't be bypassed

Two sites needed more than a substitution:

- `Reown/CreateTokenRequestData.js` defined its formatter at module scope; it moved inside the component to use the hook, and keeps a `null` / `try-catch` guard around the amount because the payload arrives from an **external dApp over Reown** — an unguarded `prettyValue` does `BigInt()`, which throws on a malformed value.
- `utils/tokens.js` `getDepositAmount` gained an optional `amountFormat` parameter (last, so it stays backward-compatible), threaded from its two wrapper callers.

HTR fee and deposit amounts are never given a token's `isNFT` — a fee is always HTR.

### Testing

Suite unchanged from #892: 33/33 pass, same 7 pre-existing suites failing on the Jest/axios ESM issue (see #892 for detail). No new user-facing strings, so `make update_pot` is a no-op.

### Manual QA needed

With the flag temporarily forced on and **Compressed** selected, confirm small values compress everywhere and long values are consistent (Expanded elsewhere when the flag is off):

- [ ] Reown: transaction fees, nano-contract actions, send-transaction and get-utxos modals, and a create-token request
- [ ] Atomic swap: edit-swap table, proposal balance table, the send modal
- [ ] Nano contract detail amounts
- [ ] NFT list balances
- [ ] Token mint / melt success messages and deposit label
- [ ] Token import balance column
- [ ] Send Tokens required-amount message; Create Token deposit label
- [ ] A create-token Reown request with a **missing or malformed amount** does not crash the modal (the guard renders it as empty)

### Security Checklist

- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
