### PR TITLE
fix(amount): wrap long dashboard amounts instead of clipping

### DIFF
--- a/src/components/WalletBalance.js
+++ b/src/components/WalletBalance.js
@@ -44,9 +44,18 @@ class WalletBalance extends React.Component {
     const renderBalance = () => {
       return (
         <div>
-          <p><strong>{t`Total:`}</strong> <Amount value={balance.available + balance.locked} symbol={symbol} isNFT={isNFT} /></p>
-          <p><strong>{t`Available:`}</strong> <Amount value={balance.available} symbol={symbol} isNFT={isNFT} /></p>
-          <p><strong>{t`Locked:`}</strong> <Amount value={balance.locked} symbol={symbol} isNFT={isNFT} /></p>
+          <div className="wallet-balance-row">
+            <strong className="wallet-balance-label">{t`Total:`}</strong>
+            <Amount value={balance.available + balance.locked} symbol={symbol} isNFT={isNFT} />
+          </div>
+          <div className="wallet-balance-row">
+            <strong className="wallet-balance-label">{t`Available:`}</strong>
+            <Amount value={balance.available} symbol={symbol} isNFT={isNFT} />
+          </div>
+          <div className="wallet-balance-row">
+            <strong className="wallet-balance-label">{t`Locked:`}</strong>
+            <Amount value={balance.locked} symbol={symbol} isNFT={isNFT} />
+          </div>
         </div>
       );
     }

--- a/src/index.module.scss
+++ b/src/index.module.scss
@@ -266,6 +266,11 @@ i.pointer {
 	text-align: right;
 	font-family: monospace;
 	font-size: 1.2rem;
+	// Long amounts wrap onto a second line, right-aligned, and are never
+	// shrunk or ellipsized. min-width stops the column collapsing so far that
+	// the value breaks earlier than it needs to.
+	min-width: 12rem;
+	white-space: normal;
 }
 
 #token-history .voided-element {
@@ -1382,6 +1387,29 @@ div .nc-token-balance:not(:last-child) {
   // space before the fractional digits, so there is no other break opportunity.
   overflow-wrap: anywhere;
   white-space: normal;
+}
+
+/* Dashboard balance rows */
+.wallet-balance {
+  &-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    // Bootstrap's paragraph spacing used to provide this; the rows are divs now.
+    margin-bottom: 1rem;
+
+    // The value is the flex item, so its wrapped continuation lines align under
+    // the value's first character rather than under the label. This is the
+    // hanging indent from the design — it needs no explicit indent.
+    .amount {
+      min-width: 0;
+    }
+  }
+
+  &-label {
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
 }
 
 /* Amount format modal */


### PR DESCRIPTION
### Acceptance Criteria

- Long amounts on the dashboard wrap onto a second line instead of clipping or overflowing — in the balance block (Total / Available / Locked) and the transaction-history `Value` column
- Wrapped balance values hang-indent under the value, not the label
- Wrapped history values stay flush-right; the column never collapses, shrinks, or ellipsizes
- Short values and row spacing are unchanged from `master`

Fourth of 6 PRs. **Stacked on #894** — base branch is `raul-oliveira/feat/amount-format-radio`, not `master`. Review #894 first.

### What changed

Layout only — no formatting logic.

- `WalletBalance.js`: each balance row becomes a flex row (`<div className="wallet-balance-row">` + a nowrap `<strong>` label + the existing `<Amount>`). The value is the flex item, so its continuation lines hang-indent under the value — the design's hanging indent, a free consequence of flex, no explicit indent.
- `index.module.scss`: new `.wallet-balance*` block; the existing `#token-history .value` rule gains `min-width: 12rem; white-space: normal` so the column wraps and never collapses. No fixed `width` — the Figma columns are content-hugged.

Left diverging from the mock on purpose (designer to confirm): history values keep the app's `monospace 1.2rem` and `#28a745`/`#dc3545`, where Figma shows 20px sans and `#41A922`/`#A92224`. The brief for this screen is wrapping only.

Possible follow-up (out of scope, pre-existing): the Token Import modal's balance column (`.token-balance`) uses `white-space: nowrap`, so a long compressed amount could clip there. Not on the dashboard, not touched here.

### Testing

Suite unchanged from #894: the same 7 pre-existing suites fail on the Jest/axios ESM issue (see #892), `33 passed`. No new strings.

### Manual QA needed

- [ ] Dashboard Total / Available / Locked with a very large balance (~`123,456,789,012,345,678.12345678`): the value wraps to a second line that starts under the value, not the label.
- [ ] Narrow the window to ~900px: values still wrap, never clip / ellipsize / shrink.
- [ ] History `Value` column: long values wrap to two lines, both flush right; the column does not collapse.
- [ ] Short values and balance-row spacing are identical to `master`.

### Security Checklist

- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
