### PR TITLE
fix(amount): wrap long amounts in the transaction overview modal

### DIFF
--- a/src/components/ModalTransactionOverview.js
+++ b/src/components/ModalTransactionOverview.js
@@ -217,7 +217,8 @@ function ModalTransactionOverview({
             fontWeight: 500,
             color: '#404040',
             marginLeft: '12px',
-            whiteSpace: 'nowrap',
+            overflowWrap: 'anywhere',
+            minWidth: 0,
             fontSize: '14px',
           }}
         >
@@ -229,6 +230,7 @@ function ModalTransactionOverview({
               color: arrowColor,
               marginLeft: '10px',
               fontSize: '14px',
+              alignSelf: 'flex-end',
             }}
           />
         </span>
@@ -239,7 +241,15 @@ function ModalTransactionOverview({
   const renderNetworkFeeValue = () => {
     if (hasAnyFee) {
       return (
-        <span style={{ fontSize: '14px', fontWeight: 500, color: '#404040' }}>
+        <span
+          style={{
+            fontSize: '14px',
+            fontWeight: 500,
+            color: '#404040',
+            minWidth: 0,
+            overflowWrap: 'anywhere',
+          }}
+        >
           {formatValue(fee)} HTR
         </span>
       );
@@ -283,8 +293,18 @@ function ModalTransactionOverview({
   const renderTotalPayment = () => {
     return (
       <div className="d-flex justify-content-between mb-4">
-        <span style={{ fontSize: '14px', fontWeight: 600 }}>{t`You will pay`}</span>
-        <span style={{ fontSize: '14px', fontWeight: 500, color: '#404040' }}>
+        <span style={{ fontSize: '14px', fontWeight: 600, flexShrink: 0 }}>{t`You will pay`}</span>
+        <span
+          style={{
+            fontSize: '14px',
+            fontWeight: 500,
+            color: '#404040',
+            lineHeight: '20px',
+            textAlign: 'right',
+            overflowWrap: 'anywhere',
+            minWidth: 0,
+          }}
+        >
           {formatTotalPayment()}
         </span>
       </div>
@@ -308,7 +328,7 @@ function ModalTransactionOverview({
 
       {/* Network fee */}
       <div className="d-flex justify-content-between align-items-center mb-2">
-        <span style={{ fontSize: '14px', fontWeight: 600 }}>
+        <span style={{ fontSize: '14px', fontWeight: 600, flexShrink: 0 }}>
           {t`Network fee`}{' '}
           <span style={{ color: '#57606a', fontWeight: 400 }}>({t`paid in HTR`})</span>
         </span>


### PR DESCRIPTION
### Acceptance Criteria

- Long amounts in the transaction-overview modal wrap instead of clipping — the per-output amounts, the "You will pay" total, and the network-fee value
- The direction arrow stays with the final wrapped line
- The modal never widens past its dialog and never shows a horizontal scrollbar for long values
- Short amounts render identically to `master`

Fifth of 6 PRs. **Stacked on #895** — base branch is `raul-oliveira/feat/amount-format-dashboard`, not `master`. Review #895 first.

### What changed

Wrapping only — no formatting change, no font-size change, no headline element, no structural change to the modal. (The brief's "adapt the font size like mobile" targeted a headline amount the desktop modal doesn't have; the settled decision is wrapping-only.)

- Per-output amount span: dropped `whiteSpace:'nowrap'`, added `overflowWrap:'anywhere'` + `minWidth:0`; the direction arrow is pinned to the last line with `alignSelf:'flex-end'`.
- "You will pay" total: the value wraps (`overflowWrap:'anywhere'`, `minWidth:0`, `lineHeight:20px`, right-aligned) and the label gets `flexShrink:0`, so the value is what wraps rather than widening the row.
- Network-fee value: `overflowWrap:'anywhere'` + `minWidth:0`, label `flexShrink:0`. The "No fee" pill is untouched.

### Testing

Suite unchanged from #895: the same 7 pre-existing suites fail on the Jest/axios ESM issue (see #892), `33 passed`. This component has no render test (the Jest env can't mount it); it is covered by the manual QA below.

### Manual QA needed

- [ ] Trigger the modal from Send Tokens with an amount near `123,456,789,012,345,678.12345678`: the per-output amount wraps and the direction arrow stays on the final line.
- [ ] "You will pay" wraps across lines, right-aligned, and does not widen the modal.
- [ ] Multiple tokens plus a fee: the joined total (`"… AAA + … HTR"`) wraps sensibly, and the network-fee value wraps too.
- [ ] The modal does not grow wider than its `modal-dialog`; no horizontal scrollbar appears.
- [ ] Short amounts, the PIN field, Cancel and Confirm are unaffected.

### Security Checklist

- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
