### PR TITLE
fix(amount): wrap read-only amount labels instead of overflowing

### DIFF
--- a/src/components/SendTokensOne.js
+++ b/src/components/SendTokensOne.js
@@ -514,7 +514,7 @@ class SendTokensOne extends React.Component {
       });
 
       return (
-        <span className="ml-3">
+        <span className="ml-3 amount-label">
           (
             {t`Balance available: `}
             { tokenBalance.status === TOKEN_DOWNLOAD_STATUS.LOADING && (
@@ -588,21 +588,21 @@ class SendTokensOne extends React.Component {
                   </div>
                 )}
               </span>
-              <span style={{ fontSize: '12px', color: '#404040' }}>
+              <span className="amount-label" style={{ fontSize: '12px', color: '#404040' }}>
                 {this.renderFeeValue()}
               </span>
             </div>
 
             <div className="d-flex justify-content-between align-items-center mb-2">
               <span style={{ fontWeight: 600, fontSize: '14px' }}>{t`Amount to be sent`}</span>
-              <span style={{ fontSize: '12px', color: '#404040' }}>
+              <span className="amount-label" style={{ fontSize: '12px', color: '#404040' }}>
                 {this.getTotalOutputAmount()} {this.state.selected.symbol}
               </span>
             </div>
 
             {!this.state.isDepositToken && this.state.fee > 0n && (
               <div className="d-flex justify-content-end">
-                <span style={{ fontSize: '12px', color: '#8e8e93' }}>
+                <span className="amount-label" style={{ fontSize: '12px', color: '#8e8e93' }}>
                   <strong>{t`You'll pay:`}</strong>
                   {` ${this.getTotalOutputAmount()} ${this.state.selected.symbol} + ${formatAmount(this.state.fee, { decimalPlaces: this.props.decimalPlaces, amountFormat: this.props.amountFormat })} HTR`}
                 </span>

--- a/src/components/tokens/TokenAction.js
+++ b/src/components/tokens/TokenAction.js
@@ -164,7 +164,7 @@ class TokenAction extends React.Component {
       <div key={this.props.action}>
         <h2>{this.props.title}</h2>
         <p>{this.props.subtitle}</p>
-        <p>{this.props.deposit}</p>
+        <p className={this.props.depositClassName}>{this.props.deposit}</p>
         <form className={`mt-4 mb-3 ${this.state.formValidated ? 'was-validated' : ''}`} ref={this.form} onSubmit={(e) => e.preventDefault()}>
           {this.props.renderForm()}
         </form>

--- a/src/components/tokens/TokenMint.js
+++ b/src/components/tokens/TokenMint.js
@@ -219,6 +219,7 @@ class TokenMint extends React.Component {
        title={t`Mint tokens`}
        subtitle={`A deposit of ${depositPercent * 100}% in ${nativeTokenConfig.symbol} of the mint amount is required`}
        deposit={`Deposit: ${tokens.getDepositAmount(getAmountToCalculateDeposit(), depositPercent, this.props.decimalPlaces, this.props.amountFormat)} ${nativeTokenConfig.symbol} (${formatAmount(this.props.htrBalance, { decimalPlaces: this.props.decimalPlaces, amountFormat: this.props.amountFormat })} ${nativeTokenConfig.symbol} available)`}
+       depositClassName="amount-label"
        buttonName={t`Go`}
        validateForm={this.mint}
        getSuccessMessage={this.getSuccessMessage}

--- a/src/index.module.scss
+++ b/src/index.module.scss
@@ -1458,3 +1458,13 @@ div .nc-token-balance:not(:last-child) {
     }
   }
 }
+
+/* Read-only amount labels beside inputs (deposit, fee, available balance) */
+.amount-label {
+  // The label embeds amounts inside a sentence, so the break can land at a
+  // space normally; `anywhere` is the fallback for a single very long number
+  // that exceeds the container on its own.
+  overflow-wrap: anywhere;
+  white-space: normal;
+  max-width: 100%;
+}

--- a/src/screens/CreateNFT.js
+++ b/src/screens/CreateNFT.js
@@ -350,10 +350,10 @@ function CreateNFT() {
           </div>
         </div>
         <hr className="mb-5 mt-5"/>
-        <p><strong>{nativeTokenConfig.symbol} available:</strong> <Amount value={htrBalance} symbol={nativeTokenConfig.symbol} /></p>
-        <p><strong>Deposit:</strong> <Amount value={depositAmount} symbol={nativeTokenConfig.symbol} /></p>
-        <p><strong>Fee:</strong> {nftFee} {nativeTokenConfig.symbol}</p>
-        <p><strong>Total:</strong> <Amount value={tokensUtils.getNFTFee() + depositAmount} symbol={nativeTokenConfig.symbol} /></p>
+        <p className="amount-label"><strong>{nativeTokenConfig.symbol} available:</strong> <Amount value={htrBalance} symbol={nativeTokenConfig.symbol} /></p>
+        <p className="amount-label"><strong>Deposit:</strong> <Amount value={depositAmount} symbol={nativeTokenConfig.symbol} /></p>
+        <p className="amount-label"><strong>Fee:</strong> {nftFee} {nativeTokenConfig.symbol}</p>
+        <p className="amount-label"><strong>Total:</strong> <Amount value={tokensUtils.getNFTFee() + depositAmount} symbol={nativeTokenConfig.symbol} /></p>
         <button type="button" className="mt-3 btn btn-hathor" onClick={onClickCreate}>Create</button>
       </form>
       <p className="text-danger mt-3">{errorMessage}</p>

--- a/src/screens/CreateToken.js
+++ b/src/screens/CreateToken.js
@@ -334,7 +334,7 @@ function CreateToken() {
     if (isDepositToken) {
       infoLabel = `${t`Deposit:`} ${tokens.getDepositAmount(amount, depositPercent, decimalPlaces, amountFormat)} ${nativeTokenConfig.symbol} (${availableBalanceText})`;
     }
-    return <p className="mb-0">{infoLabel}</p>;
+    return <p className="mb-0 amount-label">{infoLabel}</p>;
   }
 
   const formContainerStyle = {


### PR DESCRIPTION
### Acceptance Criteria

- The read-only amount labels on Create Deposit Token, Create Fee Token, Create NFT and Send Tokens wrap within their card instead of overflowing when the amount is long
- The editable amount input is unchanged
- Short amounts render identically to `master`

Sixth and final PR. **Stacked on #896** — base branch is `raul-oliveira/feat/amount-format-tx-overview`, not `master`. Review #896 first.

### What changed

Layout only. A shared `.amount-label` class (`overflow-wrap: anywhere; white-space: normal; max-width: 100%`) is added to the read-only amount labels:

- Create Token / Create Fee Token: the deposit / fee / available-balance info line.
- Create NFT: the available / deposit / fee / total rows.
- Send Tokens: the available-balance readout, the network-fee value, the "Amount to be sent" total, and the "You'll pay" line.
- Token Mint: the deposit label. It is rendered by the shared `TokenAction` component (also used by Delegate / Destroy), so `TokenAction` gains an opt-in `depositClassName` prop passed only from `TokenMint`; Delegate and Destroy render `className={undefined}` (no attribute) and are unaffected.

`InputNumber` (the editable input) is deliberately untouched — it already accepts unlimited decimals via BigInt accumulation with the caret pinned to the end. Token Melt has no persistent read-only deposit label (only a toast and an error line that already wrap), so it needed no change.

### Testing

Suite unchanged from #896: the same 7 pre-existing suites fail on the Jest/axios ESM issue (see #892), `33 passed`. No new strings.

### Manual QA needed

- [ ] Create Deposit Token: type an amount long enough that the deposit label exceeds the card width — it wraps within the card, does not overflow / clip / widen the card. The input itself scrolls horizontally as before, caret pinned to the end.
- [ ] Create Fee Token: same for the network-fee label.
- [ ] Create NFT: available / deposit / total all wrap.
- [ ] Send Tokens: the fee row, available balance, "Amount to be sent" and "You'll pay" all wrap; the token select stays usable.
- [ ] Token Mint: the deposit label wraps.
- [ ] Narrow the window to ~900px and repeat — nothing clips.
- [ ] Short amounts render identically to `master`.

### Security Checklist

- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
